### PR TITLE
fix web.config and use a supported aspx hint in mod_mono guides

### DIFF
--- a/docs/websites/frameworks/build-aspnetmono-applications-with-modmono-and-apache-on-debian-5-lenny.md
+++ b/docs/websites/frameworks/build-aspnetmono-applications-with-modmono-and-apache-on-debian-5-lenny.md
@@ -162,8 +162,8 @@ Creating a Simple ASP.NET Application
 Now that you have created a sample database, you can test your installation with the following test page. This will not only test your Mono installation but it will also will test your MySQL connector configuration. First create a file called `testdb.aspx` in your `DocumentRoot` and paste the text below into it. Be sure to change the `User ID` and `Password` to match what you specified above.
 
 {: .file-excerpt }
-/srv/www/example.com/public\_html/testdb.aspx
-:   ~~~ aspx-cs
+/srv/www/example.com/public_html/testdb.aspx
+:   ~~~ aspx
     <%@ Page Language="C#" %>
     <%@ Import Namespace="System.Data" %>
     <%@ Import Namespace="MySql.Data.MySqlClient" %>
@@ -205,19 +205,19 @@ Now that you have created a sample database, you can test your installation with
 Next you will need to create a `web.config` file. You can copy and paste the the example below. Please note that `Custom Errors` have been turned off in this web.config for debugging purposes. The `customErrors mode` line should be removed in a production environment.
 
 {: .file-excerpt }
-/srv/www/example.com/public\_html/web.config
-
-> \<configuration\>
-> :   \<system.web\>
->     :   \<customErrors mode="Off"/\>
->         :   \<compilation\>
->             :   \<assemblies\> \<add assembly="MySql.Data"/\> \</assemblies\>
->
->             \</compilation\>
->
->     \</system.web\>
->
-> \</configuration\>
+/srv/www/example.com/public_html/web.config
+:   ~~~
+    <configuration>
+      <system.web>
+        <customErrors mode="Off"/>
+        <compilation>
+          <assemblies>
+            <add assembly="MySql.Data"/>
+          </assemblies>
+        </compilation>
+      </system.web>
+    </configuration>
+    ~~~
 
 Visit the `testdb.aspx` file in a web browser. If you see the text "Testing Sample Databases" in your browser with the information that you inserted into the database above, you now have a functioning `mod_mono` installation and can continue with the development and deployment of your own application!
 

--- a/docs/websites/frameworks/build-aspnetmono-applications-with-modmono-and-apache-on-ubuntu-10-04-lucid.md
+++ b/docs/websites/frameworks/build-aspnetmono-applications-with-modmono-and-apache-on-ubuntu-10-04-lucid.md
@@ -204,7 +204,7 @@ Now that you have created a sample database, you can test your installation with
 
 {: .file-excerpt }
 /srv/www/example.org/public\_html/testdb.aspx
-:   ~~~ aspx-cs
+:   ~~~ aspx
     <%@ Page Language="C#" %>
     <%@ Import Namespace="System.Data" %>
     <%@ Import Namespace="MySql.Data.MySqlClient" %>
@@ -247,19 +247,19 @@ Next you will need to create a `web.config` file. You can copy and paste the the
 
 {: .file-excerpt }
 /srv/www/example.org/public\_html/web.config
-
-> \<configuration\>
-> :   \<system.web\>
->     :   \<customErrors mode="Off"/\>
->         :   \<compilation\>
->             :   \<assemblies\> \<add assembly="MySql.Data"/\> \</assemblies\>
->
->             \</compilation\>
->
->     \</system.web\>
->
-> \</configuration\>
-
+:   ~~~
+    <configuration>
+      <system.web>
+        <customErrors mode="Off"/>
+        <compilation>
+          <assemblies>
+            <add assembly="MySql.Data"/>
+          </assemblies>
+        </compilation>
+      </system.web>
+    </configuration>
+    ~~~
+    
 Restart the web server process by issuing the following command:
 
     /etc/init.d/apache2 restart

--- a/docs/websites/frameworks/build-aspnetmono-applications-with-modmono-and-apache-on-ubuntu-9-10-karmic.md
+++ b/docs/websites/frameworks/build-aspnetmono-applications-with-modmono-and-apache-on-ubuntu-9-10-karmic.md
@@ -212,7 +212,7 @@ Now that you have created a sample database, you can test your installation with
 
 {: .file-excerpt }
 /srv/www/example.com/public\_html/testdb.aspx
-:   ~~~ aspx-cs
+:   ~~~ aspx
     <%@ Page Language="C#" %>
     <%@ Import Namespace="System.Data" %>
     <%@ Import Namespace="MySql.Data.MySqlClient" %>
@@ -254,19 +254,19 @@ Now that you have created a sample database, you can test your installation with
 Next you will need to create a `web.config` file. You can copy and paste the the example below. Please note that `Custom Errors` have been turned off in this web.config for debugging purposes. The `customErrors mode` line should be removed in a production environment.
 
 {: .file-excerpt }
-/srv/www/example.com/public\_html/web.config
-
-> \<configuration\>
-> :   \<system.web\>
->     :   \<customErrors mode="Off"/\>
->         :   \<compilation\>
->             :   \<assemblies\> \<add assembly="MySql.Data"/\> \</assemblies\>
->
->             \</compilation\>
->
->     \</system.web\>
->
-> \</configuration\>
+/srv/www/example.org/public\_html/web.config
+:   ~~~
+    <configuration>
+      <system.web>
+        <customErrors mode="Off"/>
+        <compilation>
+          <assemblies>
+            <add assembly="MySql.Data"/>
+          </assemblies>
+        </compilation>
+      </system.web>
+    </configuration>
+    ~~~
 
 Point your browser to the `testdb.aspx` page. If you see the text "Testing Sample Databases" in your browser with the information that you inserted into the database above, you now have a functioning `mod_mono` installation and can continue with the development and deployment of your own application!
 


### PR DESCRIPTION
aspx-cs is invalid to the syntax highlighter. aspx works.

the web.config excerpt blocks were over escaped and improperly formatted in other ways.
