### PR TITLE
Fix Missing Package List Line in OwnCloud Guide for Debian 7

### DIFF
--- a/docs/applications/cloud-storage/owncloud-debian-7.md
+++ b/docs/applications/cloud-storage/owncloud-debian-7.md
@@ -32,6 +32,8 @@ Installing ownCloud
 
 2.  Enter the following path into the file:
 
+        deb http://download.opensuse.org/repositories/isv:/ownCloud:/community/Debian_7.0/ /
+    
 3.  Download the key associated with ownCloud:
 
         wget http://download.opensuse.org/repositories/isv:ownCloud:community/Debian_7.0/Release.key


### PR DESCRIPTION
The line that needs to be added to /etc/apt/sources.list.d/owncloud.list was missing.
