### PR TITLE
Link to "Using the Linode Shell (LISH)" fixed

### DIFF
--- a/docs/networking/linux-static-ip-configuration.md
+++ b/docs/networking/linux-static-ip-configuration.md
@@ -16,7 +16,7 @@ title: Linux Static IP Configuration
 By default, Linodes use DHCP to acquire their IP address, routing and DNS information. However, DHCP will only assign one IP to your Linode, so if you have multiple IPs, you'll need to use a static configuration. Even if you only have one IP, you can still do a static assignment, but it's not required in most cases.
 
 {:.note}
-> As errors in network configurations may cause SSH connections to be disconnected, it is advised that you use the Linode Shell (LISH) when making network configuration changes. See [Using the Linode Shell (LISH)] (//www.linode.com/docs/networking/using-the-linode-shell-lish) for more information. 
+> As errors in network configurations may cause SSH connections to be disconnected, it is advised that you use the Linode Shell (LISH) when making network configuration changes. See [Using the Linode Shell (LISH)] (/docs/networking/using-the-linode-shell-lish) for more information. 
 
 
 Some distributions will determine the netmask based on the block of the IP address. The blocks of each type of IP address are:


### PR DESCRIPTION
The link to "Using the Linode Shell (LISH)" did not work in [the docs page](https://www.linode.com/docs/networking/linux-static-ip-configuration), so I have changed it to an absolute URL rather than a relative URL.
