### PR TITLE
Add DNS settings to new network config file

### DIFF
--- a/docs/networking/linux-static-ip-configuration.md
+++ b/docs/networking/linux-static-ip-configuration.md
@@ -214,6 +214,10 @@ You must create the `/etc/sysconfig/network-scripts/ifcfg-static-eth0` file.
   # Adding a private IP address.
   IPADDR2=192.168.133.234
   PREFIX2=17
+  
+  # Specifying DNS
+  DNS1=56.78.9.10
+  DNS2=56.78.10.10
   ~~~
 
 Reload NetworkManager:


### PR DESCRIPTION
CentOS 7 static ip configuration script is missing DNS settings.
