### PR TITLE
Update self-signed certificate command to use SHA256 signature

### DIFF
--- a/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-debian-5-lenny.md
+++ b/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-debian-5-lenny.md
@@ -79,7 +79,7 @@ SSL or TLS provides a method of encrypting the communication between your remote
 Issue the following sequence of commands to install the prerequisites and [generate a self-signed SSL certificate](/docs/security/ssl-certificates/self-signed):
 
     apt-get install openssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/ssl/postfix.pem -keyout /etc/ssl/postfix.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/ssl/postfix.pem -keyout /etc/ssl/postfix.key
 
 Be sure to generate a certificate with a "Common Name" that corresponds to the host name that your users will connect your mail server (e.g. `mail.ducklington.org`).
 

--- a/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-debian-6-squeeze.md
+++ b/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-debian-6-squeeze.md
@@ -75,7 +75,7 @@ SSL or TLS provides a method of encrypting the communication between your remote
 
 Issue the following command to install the prerequisites and [generate a self-signed SSL certificate](/docs/security/ssl-certificates/self-signed):
 
-    openssl req -new -x509 -days 365 -nodes -out /etc/ssl/certs/postfix.pem -keyout /etc/ssl/private/postfix.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/ssl/certs/postfix.pem -keyout /etc/ssl/private/postfix.key
 
 Be sure to generate a certificate with a "Common Name" that corresponds to the host name that your users will connect your mail server (e.g. `mail.ducklington.org`).
 

--- a/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-04-lucid.md
+++ b/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-04-lucid.md
@@ -79,7 +79,7 @@ SSL or TLS provides a method of encrypting the communication between your remote
 Issue the following sequence of commands to install the prerequisites and [generate a self-signed SSL certificate](/docs/security/ssl-certificates/self-signed):
 
     apt-get install openssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/ssl/certs/ssl-mail.pem -keyout /etc/ssl/private/ssl-mail.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/ssl/certs/ssl-mail.pem -keyout /etc/ssl/private/ssl-mail.key
 
 Be sure to generate a certificate with a "Common Name" that corresponds to the host name that your users will connect your mail server (e.g. `mail.ducklington.org`).
 

--- a/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-10-maverick.md
+++ b/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-10-maverick.md
@@ -76,7 +76,7 @@ SSL or TLS provides a method of encrypting the communication between your remote
 Issue the following sequence of commands to install the prerequisites and [generate a self-signed SSL certificate](/docs/security/ssl-certificates/self-signed):
 
     apt-get install openssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/ssl/postfix.pem -keyout /etc/ssl/postfix.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/ssl/postfix.pem -keyout /etc/ssl/postfix.key
 
 Be sure to generate a certificate with a "Common Name" that corresponds to the host name that your users will connect your mail server (e.g. `mail.ducklington.org`).
 

--- a/docs/security/ssl/how-to-make-a-selfsigned-ssl-certificate.md
+++ b/docs/security/ssl/how-to-make-a-selfsigned-ssl-certificate.md
@@ -37,7 +37,7 @@ Creating a Self-Signed Certificate
 
 As an example, we'll create a certificate that might be used to secure a personal website that's hosted with Apache. Issue the following commands:
 
-    openssl req -new -x509 -days 365 -nodes -out /etc/ssl/localcerts/apache.pem -keyout /etc/ssl/localcerts/apache.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/ssl/localcerts/apache.pem -keyout /etc/ssl/localcerts/apache.key
     chmod 600 /etc/ssl/localcerts/apache*
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service. The `-nodes` flag instructs OpenSSL to create a certificate that does not require a passphrase. If this option is omitted, you will be required to enter a passphrase on the console to unlock the certificate each time the server application using it is restarted (most frequently, this will happen when you reboot your Linode).

--- a/docs/security/ssl/multiple-ssl-sites-using-subjectaltname.md
+++ b/docs/security/ssl/multiple-ssl-sites-using-subjectaltname.md
@@ -60,7 +60,7 @@ Substitute your own domain names for "firstsite.org" and "secondsite.org", addin
 
 Issue the following command to generate the certificate itself. Note that this command should be issued on a single line, without the backslash (e.g. `\`):
 
-    openssl req -new -x509 -days 365 -nodes -out /etc/ssl/localcerts/apache.pem\
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/ssl/localcerts/apache.pem\
          -keyout /etc/ssl/localcerts/apache.key
 
 OpenSSL will ask you for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.

--- a/docs/security/ssl/ssl-certificates-with-apache-2-on-centos-5-6.md
+++ b/docs/security/ssl/ssl-certificates-with-apache-2-on-centos-5-6.md
@@ -26,7 +26,7 @@ At the shell prompt, issue the following commands to install SSL for Apache and 
 
     yum install mod_ssl
     mkdir /etc/httpd/ssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/httpd/ssl/httpd.pem -keyout /etc/httpd/ssl/httpd.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/httpd/ssl/httpd.pem -keyout /etc/httpd/ssl/httpd.key
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.
 

--- a/docs/security/ssl/ssl-certificates-with-apache-2-on-debian-5-lenny.md
+++ b/docs/security/ssl/ssl-certificates-with-apache-2-on-debian-5-lenny.md
@@ -27,7 +27,7 @@ At the shell prompt, issue the following commands to enable SSL for Apache and g
 
     a2enmod ssl
     mkdir /etc/apache2/ssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.
 

--- a/docs/security/ssl/ssl-certificates-with-apache-2-on-fedora-12.md
+++ b/docs/security/ssl/ssl-certificates-with-apache-2-on-fedora-12.md
@@ -29,7 +29,7 @@ At the shell prompt, issue the following commands to install SSL for Apache and 
 
     yum install mod_ssl
     mkdir /etc/httpd/ssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/httpd/ssl/httpd.pem -keyout /etc/httpd/ssl/httpd.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/httpd/ssl/httpd.pem -keyout /etc/httpd/ssl/httpd.key
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.
 

--- a/docs/security/ssl/ssl-certificates-with-apache-2-on-fedora-14.md
+++ b/docs/security/ssl/ssl-certificates-with-apache-2-on-fedora-14.md
@@ -29,7 +29,7 @@ At the shell prompt, issue the following commands to install SSL for Apache and 
 
     yum install mod_ssl
     mkdir /etc/httpd/ssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/httpd/ssl/httpd.pem -keyout /etc/httpd/ssl/httpd.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/httpd/ssl/httpd.pem -keyout /etc/httpd/ssl/httpd.key
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.
 

--- a/docs/security/ssl/ssl-certificates-with-apache-2-on-ubuntu-10-04-lucid.md
+++ b/docs/security/ssl/ssl-certificates-with-apache-2-on-ubuntu-10-04-lucid.md
@@ -29,7 +29,7 @@ At the shell prompt, issue the following commands to enable SSL for Apache and g
 
     a2enmod ssl
     mkdir /etc/apache2/ssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.
 

--- a/docs/security/ssl/ssl-certificates-with-apache-2-on-ubuntu-10-10-maverick.md
+++ b/docs/security/ssl/ssl-certificates-with-apache-2-on-ubuntu-10-10-maverick.md
@@ -29,7 +29,7 @@ At the shell prompt, issue the following commands to enable SSL for Apache and g
 
     a2enmod ssl
     mkdir /etc/apache2/ssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.
 

--- a/docs/security/ssl/ssl-certificates-with-apache-2-on-ubuntu-12-04-precise-pangolin.md
+++ b/docs/security/ssl/ssl-certificates-with-apache-2-on-ubuntu-12-04-precise-pangolin.md
@@ -29,7 +29,7 @@ At the shell prompt, issue the following commands to enable SSL for Apache and g
 
     a2enmod ssl
     mkdir /etc/apache2/ssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.
 

--- a/docs/security/ssl/ssl-certificates-with-apache-2-on-ubuntu-9-10-karmic.md
+++ b/docs/security/ssl/ssl-certificates-with-apache-2-on-ubuntu-9-10-karmic.md
@@ -29,7 +29,7 @@ At the shell prompt, issue the following commands to enable SSL for Apache and g
 
     a2enmod ssl
     mkdir /etc/apache2/ssl
-    openssl req -new -x509 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/apache2/ssl/apache.pem -keyout /etc/apache2/ssl/apache.key
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service.
 

--- a/docs/security/ssl/ssl-certificates-with-nginx.md
+++ b/docs/security/ssl/ssl-certificates-with-nginx.md
@@ -42,7 +42,7 @@ The following procedure generates a single self-signed SSL certificate. These ce
 
     mkdir /srv/ssl/
     cd /srv/ssl/
-    openssl req -new -x509 -days 365 -nodes -out /srv/ssl/nginx.pem -keyout /srv/ssl/nginx.key
+    openssl req -new -x509 -sha256 -days 365 -nodes -out /srv/ssl/nginx.pem -keyout /srv/ssl/nginx.key
 
 If you wish to use a 2048-bit certificate, add the following option to the above command:
 


### PR DESCRIPTION
https://shaaaaaaaaaaaaa.com/

Commercial certificates from some providers may require additional efforts to support SHA256 signatures in signing requests, but self-signed certificates are a simple and quick improvement.
