### PR TITLE
Added cmake to required packages.

### DIFF
--- a/docs/applications/development/gitlab-on-ubuntu-14-04.md
+++ b/docs/applications/development/gitlab-on-ubuntu-14-04.md
@@ -54,7 +54,7 @@ In this section you will install the development tools and the required packages
 
 1. Install the required packages to compile Ruby and native extensions to Ruby gems:
 
-        sudo apt-get install build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate
+        sudo apt-get install build-essential cmake zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate
 
 2. Install Git:
     


### PR DESCRIPTION
The "bundle install" step for installing the ruby gems used by gitlab complained about the missing cmake command. Installing the cmake package via apt-get fixes the problem.
