### PR TITLE
apt-get upgrade vs apt-get install

### DIFF
--- a/docs/security/security-patches/patching-bash-for-the-shellshock-vulnerability.md
+++ b/docs/security/security-patches/patching-bash-for-the-shellshock-vulnerability.md
@@ -102,7 +102,7 @@ Below is the relevant information for upgrading Bash and ensuring that your Lino
 To upgrade Bash on Ubuntu and Debian, run these commands to update and upgrade the Bash package. If you are not running as the root user, prepend `sudo` to each command:
 
 	apt-get update
-	apt-get upgrade bash
+	apt-get install bash
 
 Re-run the commands in the "Checking the Vulnerability" section of this documentation to ensure it has been upgraded.
 


### PR DESCRIPTION
`apt-get upgrade bash` is simply `apt-get upgrade` and installs all packages to be upgraded--the `bash` argument is ignored. Instead use `apt-get install bash` which installs only the latest bash.
