### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -253,7 +253,7 @@ Enter the following command to access the timezone utility:
 
     dpkg-reconfigure tzdata
 
-### Arch Linux
+### Arch Linux and CentOS 7
 
 Enter the following command to view a list of available time zones:
 


### PR DESCRIPTION
/usr/share/zoneinfo/ has older names for some timezones. Creating the link did not work for me since the name of my timezone has changed from Asia/Calcutta to Asia/Kolkata. timedatectl works perfectly well on CentOS7 and seems like a better way of setting the timezone.
