### PR TITLE
Escape characters displaying on site. Possible fix?

### DIFF
--- a/docs/networking/squid/squid-http-proxy-ubuntu-12-04.md
+++ b/docs/networking/squid/squid-http-proxy-ubuntu-12-04.md
@@ -45,7 +45,8 @@ This section covers the easiest way to use Squid as an HTTP proxy, using only th
 	{: .file-excerpt }
 	/etc/squid3/squid.conf
 	: ~~~
-		acl client src 12.34.56.78 \# Home IP http\_access allow client
+		acl client src 12.34.56.78 # Home IP 
+		http_access allow client
 	~~~
 	
 	Be sure to replace **client** with a name identifying the connecting computer, and **12.34.56.78** with your local IP address. The comment `# Home IP` isn't required, but comments can be used to help identify clients.


### PR DESCRIPTION
This is what it looks like before the change: http://imgur.com/ck4oPRz

Ideally, this change will make it appear like this: http://imgur.com/lFSfMyH
