### PR TITLE
Update PHP error log location in "LAMP on Debian 7" guide

### DIFF
--- a/docs/websites/lamp/lamp-server-on-debian-7-wheezy.md
+++ b/docs/websites/lamp/lamp-server-on-debian-7-wheezy.md
@@ -190,7 +190,7 @@ Make sure that the following values are set, and relevant lines are uncommented 
     error_reporting = E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR
     display_errors = Off 
     log_errors = On 
-    error_log = /var/log/php.log  
+    error_log = /var/log/php/error.log  
     register_globals = Off
     max_input_time = 30
     ~~~


### PR DESCRIPTION
Previously this guide informed the user to set their php error log as `php.log` in `/var/log/`:
`error_log = /var/log/php.log`

After which it tells the user to create `/var/log/php` and set the permissions on that directory:
`mkdir /var/log/php`
`chown www-data /var/log/php`

The fix is either to set the error_log to a file in `/var/log/php/` and then create and chown that directory, or to place the error log in `/var/log`. I chose the former. 
