### PR TITLE
Update the part of menu.lst to fix errors

### DIFF
--- a/docs/tools-reference/custom-kernels-distros/run-a-custom-compiled-kernel-with-pvgrub.md
+++ b/docs/tools-reference/custom-kernels-distros/run-a-custom-compiled-kernel-with-pvgrub.md
@@ -100,7 +100,9 @@ Create a `menu.lst` file with the following contents. Adjust the "title" and "ke
 : ~~~
 	timeout 5
 	
-	title Custom Compiled, kernel 2.6.32.16-custom root (hd0) kernel /boot/vmlinuz-2.6.32.16-custom root=/dev/xvda ro quiet
+	title Custom Compiled, kernel 2.6.32.16-custom 
+	root (hd0) 
+	kernel /boot/vmlinuz-2.6.32.16-custom root=/dev/xvda ro quiet
 ~~~
 
 Note that there is no `initrd` line. With some distributions, the `initrd` image prepared during the kernel installation process will not work correctly with your Linode, and it isn't needed anyhow.


### PR DESCRIPTION
I have tried this instruction and failed. Then I figured it out that the problem is the `menu.lst`. This should be three lines not two.  
title Custom Compiled, kernel 2.6.32.16-custom 
    root (hd0) 
    kernel /boot/vmlinuz-2.6.32.16-custom root=/dev/xvda ro quiet
Should be separate line, or when it boot, it cannot load the kernel.
