### PR TITLE
fix code block in run-a-distributionsupplied-kernel-with-pvgrub

### DIFF
--- a/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub.md
+++ b/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub.md
@@ -164,7 +164,7 @@ Ubuntu 12.04 (Precise)
 
     {: .file-excerpt }
 	/boot/grub/menu.lst
-	:~~~
+	: ~~~
     	 kopt=root=/dev/xvda console=hvc0 ro quiet
 	~~~
 


### PR DESCRIPTION
Corrects code block indentation in 
item 6 of https://linode.com/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub#ubuntu-1204-precise
