### PR TITLE
email should be unique per domain in "virtual_users" table

### DIFF
--- a/docs/email/postfix/email-with-postfix-dovecot-and-mysql.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mysql.md
@@ -208,7 +208,7 @@ Here's how to create the necessary database and tables in MySQL:
           `password` varchar(106) NOT NULL,
           `email` varchar(100) NOT NULL,
           PRIMARY KEY (`id`),
-          UNIQUE KEY `email` (`email`),
+          UNIQUE KEY `domain_email` (`domain_id`, `email`),
           FOREIGN KEY (domain_id) REFERENCES virtual_domains(id) ON DELETE CASCADE
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
Changing unique key in table *'virtual_users'* to be combination of *'domain_id'* and *'email'* to allow for email duplication across different domains **but** not in the same domain.

more details can be found in the issue i opened here, https://github.com/linode/docs/issues/136