### PR TITLE
Normalize naming coventions for RHEL

### DIFF
--- a/docs/networking/linux-static-ip-configuration.md
+++ b/docs/networking/linux-static-ip-configuration.md
@@ -6,7 +6,7 @@ description: 'Setting up networking for multiple IP addresses.'
 keywords: 'static ip,linux networking,ifconfig,configure network,linux network,multiple ip'
 license: '[CC BY-ND 3.0](http://creativecommons.org/licenses/by-nd/3.0/us/)'
 alias: ['networking/configuring-static-ip-interfaces/']
-modified: Tuesday, August 12, 2014
+modified: Friday, December 26, 2014
 modified_by:
   name: Linode
 published: 'Thursday, July 20th, 2014'
@@ -188,10 +188,10 @@ Note: CentOS 7/Fedora 20 no longer uses the `network` service. Instead, use the 
 
 In the example below, change the IP addresses to reflect the values shown under the "Remote Access" tab of the Linode Manager.
 
-You must create the `/etc/sysconfig/network-scripts/ifcfg-static-eth0` file.
+You must create the `/etc/sysconfig/network-scripts/ifcfg-eth0` file.
 
 {: .file }
-/etc/sysconfig/network-scripts/ifcfg-static-eth0
+/etc/sysconfig/network-scripts/ifcfg-eth0
 : ~~~
   # Configuration for eth0
   DEVICE=eth0
@@ -225,7 +225,7 @@ Put the DHCP network configuration offline:
 
 Bring the static network configuration we just created online:
 
-    nmcli con up "System static-eth0" 
+    nmcli con up "System eth0"
 
 Any changes you make to the configuration will require you to reload and down/up the interface.
 


### PR DESCRIPTION
These conventions follow the current standard for REHL based distributions, which is to use `ifcfg-eth0`.

Directly addresses: https://github.com/linode/docs/issues/140
