### PR TITLE
Removed aliases for Debian and CentOS as per iproute2

### DIFF
--- a/docs/networking/linux-static-ip-configuration.md
+++ b/docs/networking/linux-static-ip-configuration.md
@@ -8,11 +8,7 @@ license: '[CC BY-ND 3.0](http://creativecommons.org/licenses/by-nd/3.0/us/)'
 alias: ['networking/configuring-static-ip-interfaces/']
 modified: Saturday, December 27th, 2014
 modified_by:
-<<<<<<< HEAD
-  name: Dave Russell Jr
-=======
   name: Dave Russell
->>>>>>> d4f444241a661b318e873ff9d48698fedbe0158e
 published: 'Thursday, July 20th, 2014'
 title: Linux Static IP Configuration
 ---
@@ -154,11 +150,7 @@ In the example below, change the IP addresses to reflect the values shown under 
     iface lo inet loopback
 
     # Configuration for eth0
-<<<<<<< HEAD
     # We no longer need to use aliases (eg. eth0:0 eth0:1 eth0:2)
-=======
-    # We no longer need to use aliases (eg. eth0:0 eth0:1 eth0:2) 
->>>>>>> d4f444241a661b318e873ff9d48698fedbe0158e
     # This line ensures that the interface will be brought up during boot
     auto eth0
 
@@ -176,10 +168,6 @@ In the example below, change the IP addresses to reflect the values shown under 
     # This is a private IP address. Private IPs do not have a gateway (they are not publicly routable).
     # All you need to specify is the address and the block. The netmask is taken from the block.
     # Example: /17 is considered to be a private IP address: netmask 255.255.128.0
-<<<<<<< HEAD
-=======
-
->>>>>>> d4f444241a661b318e873ff9d48698fedbe0158e
     iface eth0 inet static
     address 192.168.133.234/17
     ~~~
@@ -212,19 +200,19 @@ You must create the `/etc/sysconfig/network-scripts/ifcfg-eth0` file.
 
   # Adding a public IP address.
   # The netmask is taken from the PREFIX (where 24 is Public IP, 17 is Private IP)
-  IPADDR=12.34.56.78
-  PREFIX=24
+  IPADDR0=12.34.56.78
+  PREFIX0=24
 
   # Specifying the gateway
-  GATEWAY=12.34.56.1
+  GATEWAY0=12.34.56.1
 
   # Adding a second public IP address.
-  IPADDR=34.56.78.90
-  PREFIX=24
+  IPADDR1=34.56.78.90
+  PREFIX1=24
 
   # Adding a private IP address.
-  IPADDR=192.168.133.234
-  PREFIX=17
+  IPADDR2=192.168.133.234
+  PREFIX2=17
   ~~~
 
 Reload NetworkManager:
@@ -237,11 +225,7 @@ Put the DHCP network configuration offline:
 
 Bring the static network configuration we just created online:
 
-<<<<<<< HEAD
     nmcli con up "System eth0"
-=======
-    nmcli con up "System eth0" 
->>>>>>> d4f444241a661b318e873ff9d48698fedbe0158e
 
 Any changes you make to the configuration will require you to reload and down/up the interface.
 

--- a/docs/networking/linux-static-ip-configuration.md
+++ b/docs/networking/linux-static-ip-configuration.md
@@ -6,9 +6,9 @@ description: 'Setting up networking for multiple IP addresses.'
 keywords: 'static ip,linux networking,ifconfig,configure network,linux network,multiple ip'
 license: '[CC BY-ND 3.0](http://creativecommons.org/licenses/by-nd/3.0/us/)'
 alias: ['networking/configuring-static-ip-interfaces/']
-modified: Friday, December 26, 2014
+modified: Saturday, December 27th, 2014
 modified_by:
-  name: Linode
+  name: Dave Russell Jr
 published: 'Thursday, July 20th, 2014'
 title: Linux Static IP Configuration
 ---
@@ -150,9 +150,9 @@ In the example below, change the IP addresses to reflect the values shown under 
     iface lo inet loopback
 
     # Configuration for eth0
-	
+    # We no longer need to use aliases (eg. eth0:0 eth0:1 eth0:2)
     # This line ensures that the interface will be brought up during boot
-    auto eth0 eth0:0 eth0:1
+    auto eth0
 
     # The address and gateway are necessary.
     # The netmask is taken automatically from the block.
@@ -162,13 +162,13 @@ In the example below, change the IP addresses to reflect the values shown under 
         gateway 12.34.56.1
 
     # This is a second public IP address
-    iface eth0:0 inet static
+    iface eth0 inet static
         address 34.56.78.90/24
 
     # This is a private IP address. Private IPs do not have a gateway (they are not publicly routable).
     # All you need to specify is the address and the block. The netmask is taken from the block.
     # Example: /17 is considered to be a private IP address: netmask 255.255.128.0
-    iface eth0:1 inet static
+    iface eth0 inet static
     address 192.168.133.234/17
     ~~~
 
@@ -200,19 +200,19 @@ You must create the `/etc/sysconfig/network-scripts/ifcfg-eth0` file.
 
   # Adding a public IP address.
   # The netmask is taken from the PREFIX (where 24 is Public IP, 17 is Private IP)
-  IPADDR0=12.34.56.78
-  PREFIX0=24
+  IPADDR=12.34.56.78
+  PREFIX=24
 
   # Specifying the gateway
-  GATEWAY0=12.34.56.1
+  GATEWAY=12.34.56.1
 
   # Adding a second public IP address.
-  IPADDR1=34.56.78.90
-  PREFIX1=24
+  IPADDR=34.56.78.90
+  PREFIX=24
 
   # Adding a private IP address.
-  IPADDR2=192.168.133.234
-  PREFIX2=17
+  IPADDR=192.168.133.234
+  PREFIX=17
   ~~~
 
 Reload NetworkManager:


### PR DESCRIPTION
We should not be using aliases anymore. After ifconfig was deprecated and iproute2 took precedence, aliases became a thing of the past. 

As per Debian: "The newer ip utility does not use the same concept of aliases or virtual interfaces." 

Using aliases doesn't break the configuration, but it's probably not the best practice. It's best not to use them. 