### PR TITLE
Correct php5-fpm listening socket

### DIFF
--- a/docs/websites/lemp/lemp-server-on-ubuntu-12-04-precise-pangolin.md
+++ b/docs/websites/lemp/lemp-server-on-ubuntu-12-04-precise-pangolin.md
@@ -227,7 +227,7 @@ Additionally, it's a good idea to secure any upload directories your application
 location ~ \.php$ {
     include /etc/nginx/fastcgi_params;
     if ($uri !~ "^/images/") {
-    fastcgi_pass 127.0.0.1:9000;
+    fastcgi_pass unix:/var/run/php5-fpm.sock;
     }
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME /srv/www/example.com/public_html$fastcgi_script_name;


### PR DESCRIPTION
The suggested nginx.conf should point to the unix socket that php5-fpm is already configured to be listening on.