### PR TITLE
Update running-a-mail-server.md

### DIFF
--- a/docs/email/running-a-mail-server.md
+++ b/docs/email/running-a-mail-server.md
@@ -51,7 +51,6 @@ If the prospect of managing your own mail server is too daunting, you should con
 
 -   [Fastmail](https://www.fastmail.fm) has good uptime and fast IMAP. It's paid and has capped storage.
 -   [Google Apps](http://www.google.com/intl/en/enterprise/apps/business/) uses the top-notch Gmail interface and has great uptime. It's paid and the IMAP implementation is unusual. We have a [guide](/docs/email/google-mail) on how to use Google Apps with your Linode.
--   [Outlook.com](http://www.microsoft.com/en-us/outlook-com/) is probably the best free mail host. The interface is nice and easy to use. Also, Outlook has been updated to use the IMAP protocol. Here's a [review](http://lifehacker.com/5928102/outlook-is-a-completely-new-feature+filled-webmail-service-from-microsoft).
 
 If you decide to use an outside mail service, you will still need to set up [DNS](/docs/networking/dns/adding-dns-records) for your mail, using the settings provided by the third-party mail service.
 


### PR DESCRIPTION
Remove Outlook.com as an External Mail Service, it is no longer supported. Microsoft has migrated the service over to Office 365, but it is a paid service. I have not updated the article to mention Office 365 because I'm not familiar with it. Just wanted to correct inaccuracy because it lead me astray.