### PR TITLE
Removed Longview iptables rules

### DIFF
--- a/docs/security/securing-your-server.md
+++ b/docs/security/securing-your-server.md
@@ -233,19 +233,6 @@ Here's how to create a firewall on your Linode:
     >
     > Be sure to revise these rules if you add new services later.
 
-6. <div id="step_6">**Optional:**  If you plan on using the Linode Longview service, add these additional lines above the `#  Drop all other inbound` section:
-
-    {: .file-excerpt}
-    /etc/iptables.firewall.rules
-    :   ~~~
-        #  Allow incoming Longview connections 
-        -A INPUT -s longview.linode.com -j ACCEPT
-
-        # Allow metrics to be provided Longview
-        -A OUTPUT -d longview.linode.com -j ACCEPT
-        ~~~
-    </div>
-
 7.  Save the changes to the firewall rules file by pressing Control-X, and then Y.
 
 8.  Activate the firewall rules by entering the following command:


### PR DESCRIPTION
Iptables cannot resolve addresses and as such adding iptables rules with domain names won't work. For example part of starting up the network is starting iptables which would require you do a DNS query to find out what longview.linode.com resolves to but because the network isn't up that resolution fails and because the resolution fails loading the iptables rules fails which ultimately causes the networking daemon to fail and leave you with no network connection. All Longview requires is that the Linode accepts related, established traffic in and port 443 out so declaring longview.linode.com is redundant.