### PR TITLE
Change old links

### DIFF
--- a/docs/networking/ssh/setting-up-an-ssh-tunnel-with-your-linode-for-safe-browsing.md
+++ b/docs/networking/ssh/setting-up-an-ssh-tunnel-with-your-linode-for-safe-browsing.md
@@ -123,10 +123,10 @@ Keep these considerations in mind when you use SSH tunneling.
     6.  Leave the `about:config window` by typing any URL in the location bar or closing Firefox.
 
 -   If the access to SSH is blocked in the public network you are using, it will not be possible to establish the tunnel. A workaround for this is to run your SSH server on a different port, more likely to be open; for example port 80 (HTTP).
--   If you are already in a public network that blocks your access to SSH, to edit the server settings you can use the Linode Shell from the web (More info: <https://library.linode.com/using-lish-the-linode-shell#sph_using-a-web-browser>).
+-   If you are already in a public network that blocks your access to SSH, to edit the server settings you can use the Linode Shell from the web (More info: <https://www.linode.com/docs/networking/using-the-linode-shell-lish/#using-a-web-browser>).
 -   Sometimes, the traffic through the tunnel could be a bit slower than browsing the web without it; but remember, it's a small price to pay when your privacy is at risk.
 -   This is a simple and quick way to establish a secure connection for web browsing, a kind of “poor man's VPN” solution.
--   If you often access the web using untrusted public networks or if you need to secure other applications and not just the browser, then this method will fall short and you will need to set up a VPN on your server. Take a look at one of the Linode Library's [OpenVPN](https://library.linode.com/networking/openvpn/) guides for instructions about that topic.
+-   If you often access the web using untrusted public networks or if you need to secure other applications and not just the browser, then this method will fall short and you will need to set up a VPN on your server. Take a look at one of the Linode Library's [OpenVPN](/docs/networking/vpn/) guides for instructions about that topic.
 
 More Information
 ----------------

--- a/docs/platform/accounts-and-passwords.md
+++ b/docs/platform/accounts-and-passwords.md
@@ -168,7 +168,7 @@ If you can't remember the password for the `root` user on a Linode, use the Lino
 7.  Click **Reset Root Password**. The Linode's dashboard appears.
 8.  Click **Boot** to turn on your Linode.
 
-Now you can use the new `root` user password to log in to your Linode. See [Connecting to Your Linode](getting-started#sph_connecting-to-your-linode) for more information about connecting.
+Now you can use the new `root` user password to log in to your Linode. See [Connecting to Your Linode](/docs/getting-started#connecting-to-your-linode) for more information about connecting.
 
 Next Steps
 ----------

--- a/docs/platform/accounts-and-passwords.md
+++ b/docs/platform/accounts-and-passwords.md
@@ -173,7 +173,7 @@ Now you can use the new `root` user password to log in to your Linode. See [Conn
 Next Steps
 ----------
 
-You can take additional steps to secure your Linode Manager account by enabling the two-factor authentication and IP address whitelisting features. You can also configure security event notifications and disable API access. For instructions, see the [Security](/docs/linode-manager-security) guide.
+You can take additional steps to secure your Linode Manager account by enabling the two-factor authentication and IP address whitelisting features. You can also configure security event notifications and disable API access. For instructions, see the [Security](/docs/security/linode-manager-security-controls/) guide.
 
 
 


### PR DESCRIPTION
Some links in these [two](https://www.linode.com/docs/networking/ssh/setting-up-an-ssh-tunnel-with-your-linode-for-safe-browsing) [articles](https://www.linode.com/docs/platform/accounts-and-passwords) redirect to their new pages and the link to the **Getting Started** page is broken.