### PR TITLE
Update hosting-a-website.md

### DIFF
--- a/docs/websites/hosting-a-website.md
+++ b/docs/websites/hosting-a-website.md
@@ -68,7 +68,7 @@ Installing Apache is easy, but if you leave it running with the default settings
 	StartServers 2
 	MinSpareServers 6
 	MaxSpareServers 12
-	MaxClients 80
+	MaxClients 8
 	MaxRequestsPerChild 3000
 	</IfModule>
 	~~~


### PR DESCRIPTION
Reduced MaxClients for a 1GB node, 80 is way too high for the most common use of mpm_prefork which is a LAMP stack. 8 will mean that if each process uses 64MB RAM (not uncommon for PHP and can be quite low) that it'll use 512MB leaving the other 512MB for the OS/MySQL.