### PR TITLE
Update lamp-server-on-centos-7.md

### DIFF
--- a/docs/websites/lamp/lamp-server-on-centos-7.md
+++ b/docs/websites/lamp/lamp-server-on-centos-7.md
@@ -210,7 +210,6 @@ PHP makes it possible to produce dynamic and interactive pages using your own sc
         error_log = /var/log/php/error.log
         max_execution_time = 30
         memory_limit = 128M
-        register_globals = Off
         max_input_time = 30
         ~~~
 


### PR DESCRIPTION
The "register_globals" keyword is deprecated as of v5.4.0, see http://php.net/manual/en/ini.core.php#ini.register-globals