### PR TITLE
need to replace mpm_event_module with mpm_prefork_module

### DIFF
--- a/docs/websites/lamp/lamp-server-on-arch-linux.md
+++ b/docs/websites/lamp/lamp-server-on-arch-linux.md
@@ -274,7 +274,7 @@ PHP makes it possible to produce dynamic and interactive pages using your own sc
         AddType application/x-httpd-php .php
         AddType application/x-httpd-php-source .phps
         ~~~
-5. While in that file, need to replace mpm_event_module with mpm_prefork_module, comment out the line `LoadModule mpm_event_module modules/mod_mpm_event.so` by adding a `#` in front, and add `LoadModule mpm_prefork_module modules/mod_mpm_prefork.so` after that line
+5. While in that file, comment out the line `LoadModule mpm_event_module modules/mod_mpm_event.so` by adding a `#` in front, and add `LoadModule mpm_prefork_module modules/mod_mpm_prefork.so` after that line
 
     {: .file-excerpt }
     /etc/httpd/conf/httpd.conf

--- a/docs/websites/lamp/lamp-server-on-arch-linux.md
+++ b/docs/websites/lamp/lamp-server-on-arch-linux.md
@@ -274,12 +274,13 @@ PHP makes it possible to produce dynamic and interactive pages using your own sc
         AddType application/x-httpd-php .php
         AddType application/x-httpd-php-source .phps
         ~~~
-5. While in that file, comment out the line `LoadModule mpm_event_module modules/mod_mpm_event.so` by adding a `#` in front:
+5. While in that file, need to replace mpm_event_module with mpm_prefork_module, comment out the line `LoadModule mpm_event_module modules/mod_mpm_event.so` by adding a `#` in front, and add `LoadModule mpm_prefork_module modules/mod_mpm_prefork.so` after that line
 
     {: .file-excerpt }
     /etc/httpd/conf/httpd.conf
     :   ~~~ apache
         #LoadModule mpm_event_module modules/mod_mpm_event.so
+        LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
         ~~~
 
 6. With this completed, restart the httpd service:


### PR DESCRIPTION
only comment out pm_event_module will fail to start httpd.service, and give `httpd: Configuration error: No MPM Loaded.`, need replace with mpm_prefork_module