### PR TITLE
Drupal scrub

### DIFF
--- a/docs/websites/cms/drush-drupal.md
+++ b/docs/websites/cms/drush-drupal.md
@@ -34,7 +34,7 @@ Before installing Drush and Drupal, ensure that the following prerequisites have
 
 ##Install Git & Composer
 
-The developers of Drush recommend installation through Composer, a PHP dependency manager. The Drush project is hosted on Github and controlled with Git, another necessary app to install.
+The developers of Drush recommend installation through Composer, a PHP dependency manager. The Drush project is hosted on GitHub and controlled with Git, another necessary app to install.
 
 
 1. Install Git:
@@ -57,7 +57,7 @@ Composer is designed to install PHP dependencies on a per project basis, but the
 
        sudo ln -s /usr/local/bin/composer /usr/bin/composer
 
-2. Use Git to download, or clone, the Github Drush project into a new directory:
+2. Use Git to download, or clone, the GitHub Drush project into a new directory:
 
        sudo git clone https://github.com/drush-ops/drush.git /usr/local/src/drush
 

--- a/docs/websites/cms/managing-web-content-with-drupal-7.md
+++ b/docs/websites/cms/managing-web-content-with-drupal-7.md
@@ -32,7 +32,7 @@ With these dependencies installed and running, we're ready to begin installing t
 >
 >The steps required in this guide require root privileges. Be sure to run the steps below as ``root`` or with the **sudo** prefix. For more information on privileges see our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
 
-##Download and Install Drupal
+##Download and Install Drupal 7
 
 The Drupal software is frequently updated as bugs are patched and security vulnerabilities are found and removed. Visit the [Drupal download page](http://drupal.org/project/drupal) to find the latest version of the Drupal 7 Release, and download that file rather than the file mentioned in the example below. A sample release chart is pictured below.
 

--- a/docs/websites/cms/managing-web-content-with-drupal-7.md
+++ b/docs/websites/cms/managing-web-content-with-drupal-7.md
@@ -10,7 +10,7 @@ modified: Thursday, November 6th, 2014
 modified_by:
   name: Joseph Dooley
 published: 'Tuesday, September 29th, 2009'
-title: Managing Web Content with Drupal 7
+title: Installing Drupal 7
 ---
 
 Drupal is an advanced and powerful content management framework, built on the PHP scripting language, and supported by a [database](/docs/databases/) engine like [MySQL](/docs/databases/mysql/). Drupal provides a flexible system that can be used to manage websites of all different sorts and profiles. Drupal is capable of providing the tools necessary to create rich, interactive "community" websites with forums, user blogs, and private messaging. Drupal can also provide support for multifaceted personal publishing projects and can power podcasts, blogs, and knowledge bases systems all within a single unified system.

--- a/docs/websites/cms/managing-web-content-with-drupal-8-beta.md
+++ b/docs/websites/cms/managing-web-content-with-drupal-8-beta.md
@@ -10,7 +10,7 @@ modified: Friday, October 24th, 2014
 modified_by:
     name: Joseph Dooley
 published: 'Friday, October 31, 2014'
-title: Managing Web Content with Drupal 8 Beta
+title: Installing Drupal 8 (beta)
 ---
 
 [Drupal 8](https://www.drupal.org/drupal-8.0) is the lastest version of the extremely popular [Drupal](https://www.drupal.org/) content management system. The Drupal 8 beta-2 version was released on October 15th, and since it's so new, there isn't much documentation on the web. This how-to demonstrates all of the necessary steps to install Drupal 8 on your Linode.


### PR DESCRIPTION
Very minor changes:

- changed Github to GitHub
- specified Drupal version in a subtile of the Drupal 7 doc
- changed the titles of both "Managing Web Content with Drupal *" guides to "Installing Drupal *"
- changed the formatting of the word beta