### PR TITLE
Fixed typo "preform" vs "prefork"

### DIFF
--- a/docs/websites/lamp/lamp-server-on-ubuntu-14-04.md
+++ b/docs/websites/lamp/lamp-server-on-ubuntu-14-04.md
@@ -39,7 +39,7 @@ Before beginning this guide, we suggest you first read through [Getting Started]
 
         apt-get install apache2
 
-3.  Edit the main Apache configuration file to adjust the KeepAlive setting, and add the `<IfModule mpm_preform_module>` section. The settings shown below are a good starting point for a **Linode 1GB**:
+3.  Edit the main Apache configuration file to adjust the KeepAlive setting, and add the `<IfModule mpm_prefork_module>` section. The settings shown below are a good starting point for a **Linode 1GB**:
 
     {: .file }
     /etc/apache2/apache2.conf


### PR DESCRIPTION
LAMP Server Ubuntu 14.04 incorrectly referred to mpm_prefork_module as
mpm_preform_module. This fixes that.
