### PR TITLE
Update installing-mail-filtering-for-ubuntu-12-04.md

### DIFF
--- a/docs/email/installing-mail-filtering-for-ubuntu-12-04.md
+++ b/docs/email/installing-mail-filtering-for-ubuntu-12-04.md
@@ -113,7 +113,7 @@ Here we'll set various options and settings for SpamAssassin.
 
         cp /etc/spamassassin/local.cf /etc/spamassassin/local.cf.orig
 
-3.  SpamAssassin scores incoming messages and assigns a score between 0 and 5. A score of 0 is considered safe, and a score of 5 is usually spam. You need to adjust its configuration file to determine what score threshold will be allowed through the filter. We're going to use 3.5, but this can be adjusted later. Locate and uncomment the line `# required_score 5.0` by removing the **\#** symbol, and adjust the value to 3.5:
+3.  SpamAssassin scores incoming messages and assigns a score based on its spam characteristics. A score of 0 is considered safe, and a score of 10 or higher is usually spam. You need to adjust its configuration file to determine what score threshold will be allowed through the filter. We're going to use 8, but this can be adjusted later. Locate and uncomment the line `# required_score 5.0` by removing the **\#** symbol, and adjust the value to 8:
 
     {: .file }
     /etc/spamassassin/local.cf

--- a/docs/email/installing-mail-filtering-for-ubuntu-12-04.md
+++ b/docs/email/installing-mail-filtering-for-ubuntu-12-04.md
@@ -120,7 +120,7 @@ Here we'll set various options and settings for SpamAssassin.
     :   ~~~
         #   Set the threshold at which a message is considered spam (default: 5.0)
         #
-        required_score 3.5
+        required_score 8
         ~~~
 
 4.  Once finished, save and exit the file. If you're using Nano the command is Control + x


### PR DESCRIPTION
SpamAssassin docs (https://spamassassin.apache.org/full/3.1.x/doc/Mail_SpamAssassin_Conf.html) indicate that the default of 5 is already fairly aggressive and to start with something like 8 or 10.  The currently tutorial text recommends 3.5 which is EXTREMELY aggressive and likely to result in unwanted mail filtering.