### PR TITLE
change '-' to '.' in CentOS6 kernel install cmd

### DIFF
--- a/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub.md
+++ b/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub.md
@@ -508,7 +508,7 @@ Before you get started, make sure you follow the steps outlined in our [Getting 
 
     **64-bit CentOS:** :
 
-        yum install kernel-x86_64
+        yum install kernel.x86_64
 
 6.  Create a file named `/boot/grub/menu.lst` with the following contents. Adjust the `title`, `kernel`, and `initrd` lines to reflect the actual file names found in the `/boot/` directory.
 


### PR DESCRIPTION
Line 511: When I used  'yum install kernel-x86_64'   the debug version of the kernel was installed.  I changed the hyphen to a dot and the correct non-debug version was installed.  Assuming same for other entries.