### PR TITLE
Update email-with-postfix-dovecot-and-mysql.md

### DIFF
--- a/docs/email/postfix/email-with-postfix-dovecot-and-mysql.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mysql.md
@@ -287,7 +287,7 @@ Next, set up Postfix so the server can accept incoming messages for the domains.
       query = SELECT 1 FROM virtual_domains WHERE name='%s'
       ~~~
 
-4.  Create the `/etc/postfix/mysql-virtual-domains.cf` file, and enter the following values. Make sure you use the `mailuser`'s password and make any other changes as needed.
+4.  Create the `/etc/postfix/mysql-virtual-mailbox-maps.cf` file, and enter the following values. Make sure you use the `mailuser`'s password and make any other changes as needed.
 
     {: .file }
     /etc/postfix/mysql-virtual-mailbox-maps.cf

--- a/docs/email/postfix/email-with-postfix-dovecot-and-mysql.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mysql.md
@@ -921,6 +921,13 @@ You have successfully added the new email address to the Postfix and Dovecot set
     >
     > Ensure that the correct number is entered for the `domain_id` value. Use the `id` of the domain for this email address. For an explanation of `id` us, see the email users section above.
 
+You can also add a "catch-all" alias which will forward all emails sent to a domain which do not have matching aliases or users by specifying `@newdomain.com` as the source of the alias.
+
+        INSERT INTO `mailserver`.`virtual_aliases`
+          (`domain_id`, `source`, `destination`)
+        VALUES
+          ('5', '@newdomain.com', 'myemail@gmail.com');
+
 2.  Verify that the new alias has been added. The new alias will be displayed in the output.
 
         SELECT * FROM mailserver.virtual_aliases;


### PR DESCRIPTION
Added an email2email mapping for alias lookups. This allows catch-all email aliases (e.g. @example.com -> email1@example.com) to operate properly. Without this change, a catch-all alias will redirect all email sent to that domain, including email sent to other valid users, because the alias matches before the user lookup. This adds a user lookup to the alias search to email sent to valid users will be delivered to them first.