### PR TITLE
Disables Export Ciphers

### DIFF
--- a/docs/websites/nginx/startssl-wth-latest-nginx-debian-7.md
+++ b/docs/websites/nginx/startssl-wth-latest-nginx-debian-7.md
@@ -6,9 +6,9 @@ author:
 description: 'Using StartSSL with the latest Nginx on Debian 7'
 keywords: 'startssl,nginx'
 license: '[CC BY-ND 3.0](http://creativecommons.org/licenses/by-nd/3.0/us/)'
-modified: Monday, October 20, 2014
+modified: Monday, July 13, 2015
 modified_by:
-  name: Alex Fornuto
+  name: Ryan Laverdiere
 published: Monday, October 20, 2014
 title: 'Using StartSSL with the latest Nginx on Debian 7'
 contributor:
@@ -218,7 +218,7 @@ You should now be logged into your StartSSL account.
             ssl_session_cache shared:SSL:10m;
             ssl_session_timeout  5m;
 
-            ssl_ciphers  "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
+            ssl_ciphers  "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !EXPORT !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
             ssl_prefer_server_ciphers   on;
             
             ssl_protocols TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
Disables export ciphers to protect against a [Logjam attack](https://weakdh.org/).