### PR TITLE
Updated SSL cert and key config line entries

### DIFF
--- a/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-7.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-7.md
@@ -241,8 +241,8 @@ This completes the configuration for Postfix.
         log_timestamp = "%Y-%m-%d %H:%M:%S "
         mail_location = maildir:/home/vmail/%d/%n/Maildir
 
-        ssl_cert_file = /etc/pki/dovecot/certs/dovecot.pem
-        ssl_key_file = /etc/pki/dovecot/private/dovecot.pem
+        ssl_cert = </etc/pki/dovecot/certs/dovecot.pem
+        ssl_key = </etc/pki/dovecot/private/dovecot.pem
 
         namespace {
             type = private


### PR DESCRIPTION
The format for the location of the SSL cert and key file entries has changed in Dovecot's config file.  I'm not sure which version the change took place in but I'm running version 2.2.10 on Cent OS 7 and had to use the format specified in my change (or Dovecot would fail to respond to pop3 connections).  This is a great guide, thanks.  This was the only "gotcha" I ran into so I wanted to contribute the update.