### PR TITLE
update service command to systemctl for CentOS 7

### DIFF
--- a/docs/security/securing-your-server.md
+++ b/docs/security/securing-your-server.md
@@ -347,7 +347,7 @@ Here's how to install and configure Fail2Ban:
 3.  Set the `bantime` variable to specify how long (in seconds) bans should last.
 4.  Set the `maxretry` variable to specify the default number of tries a connection may be attempted before an attacker's IP address is banned.
 5.  Press `Control-x` and then press `y` to save the changes to the Fail2Ban configuration file.
-6.  Restart Fail2Ban by using `sudo service fail2ban restart`.
+6.  Restart Fail2Ban by using `sudo /bin/systemctl restart  fail2ban.service`.
 
 Fail2Ban is now installed and running on your Linode. It will monitor your log files for failed login attempts. After an IP address has exceeded the maximum number of authentication attempts, it will be blocked at the network level and the event will be logged in `/var/log/fail2ban.log`.
 


### PR DESCRIPTION
It seems like this guideline all up to date with CentOS 7. only the fail2bin restart command.