### PR TITLE
Update limiting-access-with-sftp-jails-on-debian-and-ubuntu.md

### DIFF
--- a/docs/tools-reference/tools/limiting-access-with-sftp-jails-on-debian-and-ubuntu.md
+++ b/docs/tools-reference/tools/limiting-access-with-sftp-jails-on-debian-and-ubuntu.md
@@ -42,7 +42,7 @@ First, you need to configure OpenSSH.
        {: .file-excerpt }
        /etc/ssh/sshd\_config
        :    ~~~
-            Match group filetransfer
+            Match Group filetransfer
                 ChrootDirectory %h
                 X11Forwarding no
                 AllowTcpForwarding no


### PR DESCRIPTION
There's a mis-capitialisation in the /etc/ssh/sshd_config file that could potentially lock a user out of their node