### PR TITLE
Change backticks to single quotes in timedatectl command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -284,7 +284,7 @@ Use the `Up`, `Down`, `Page Up` and `Page Down` keys to navigate. Find the time 
 
 To set the time zone:
 
-    timedatectl set-timezone `America/New_York`
+    timedatectl set-timezone 'America/New_York'
 
 ### All Other Distributions
 


### PR DESCRIPTION
Using backticks in the name of the zone file is a syntax error