### PR TITLE
Fixing an error and providing explanatory text

### DIFF
--- a/docs/security/ssl/how-to-make-a-selfsigned-ssl-certificate.md
+++ b/docs/security/ssl/how-to-make-a-selfsigned-ssl-certificate.md
@@ -38,7 +38,9 @@ CentOS/Fedora users:
 As an example, we'll create a certificate that might be used to secure a personal website that's hosted with Apache. Issue the following commands:
 
     openssl req -new -x509 -sha256 -days 365 -nodes -out /etc/ssl/localcerts/example.com.crt -keyout /etc/ssl/localcerts/example.com.key
-    chmod 600 /etc/ssl/localcerts/apache*
+    chmod 600 /etc/ssl/localcerts/example.com*
+
+Change example.com in the above commands to correspond to the domain you are generating the certificate for
 
 You will be asked for several configuration values. Enter values appropriate for your organization and server, as shown here. This example will create a certificate valid for 365 days; you may wish to increase this value. We've specified the FQDN (fully qualified domain name) of the VPS for the "Common Name" entry, as this certificate will be used for generic SSL service. The `-nodes` flag instructs OpenSSL to create a certificate that does not require a passphrase. If this option is omitted, you will be required to enter a passphrase on the console to unlock the certificate each time the server application using it is restarted (most frequently, this will happen when you reboot your Linode).
 


### PR DESCRIPTION
As it currently stands the instructions tell you to create certificates and then chmod some unrelated files that probably don't exist.  I changed the chmod command to relate to the files generates, and added some text to explain that example.com should be replaced with the domain in question in both commands.