### PR TITLE
default IPv6 address not assigned by SLAAC when /64 pool requested

### DIFF
--- a/docs/networking/native-ipv6-networking.md
+++ b/docs/networking/native-ipv6-networking.md
@@ -106,6 +106,9 @@ While default IPv6 addresses are configured automatically, you will need to stat
         address 2001:DB8:2000:aff0::2/64
       ~~~
 
+{: .note}
+>On Debian Jessie, your default IPv6 address provided by SLAAC will no longer be automatically assigned after you request /64 pool. You will need to manually add it as a static address or IPv6 routing will not work.
+
 2.  Restart networking. As this will break an SSH connection, this command should be performed in [LISH](/docs/networking/using-the-linode-shell-lish)
 
         ifdown -a && ifup -a


### PR DESCRIPTION
I verified that after requesting /64 pool, the default address is no longer assigned by SLAAC in Debian Jessie. The administrator will need to statically define that address in /etc/network/interface, failing to do that will break IPv6 routing.