### PR TITLE
Fix syntax error in 'create user' command

### DIFF
--- a/docs/databases/mysql/how-to-install-mysql-on-ubuntu-14-04.md
+++ b/docs/databases/mysql/how-to-install-mysql-on-ubuntu-14-04.md
@@ -123,7 +123,7 @@ The standard tool for interacting with MySQL is the `mysql` client which install
 1.  In the example below, `testdb` is the name of the database, `testuser` is the user, and `password` is the user's password.
 
         create database testdb;
-        create user 'testuser'@localhost identified by x'password';
+        create user 'testuser'@'localhost' identified by 'password';
         grant all on testdb.* to 'testuser';
 
     You can shorten this process by creating the user *while* assigning database permissions:


### PR DESCRIPTION
Fixed the error: "You have an error in your SQL syntax;" in the example create user command.