### PR TITLE
Add iptables rules for IPv6 SLAAC

### DIFF
--- a/docs/security/securing-your-server.md
+++ b/docs/security/securing-your-server.md
@@ -354,6 +354,12 @@ If you would like to supplement your web server's IPv4 rules with IPv6 too, this
     -A INPUT -i lo -j ACCEPT
     -A INPUT ! -i lo -s ::1/128 -j REJECT
 
+    # Below are the rules which are required for your IPv6 address to be properly allocated
+    -A INPUT -p icmpv6 --icmpv6-type router-advertisement -m hl --hl-eq 255 -j ACCEPT
+    -A INPUT -p icmpv6 --icmpv6-type neighbor-solicitation -m hl --hl-eq 255 -j ACCEPT
+    -A INPUT -p icmpv6 --icmpv6-type neighbor-advertisement -m hl --hl-eq 255 -j ACCEPT
+    -A INPUT -p icmpv6 --icmpv6-type redirect -m hl --hl-eq 255 -j ACCEPT
+
     # Allow ICMP
     -A INPUT -p icmpv6 -m state --state NEW -j ACCEPT
 


### PR DESCRIPTION
The rules were lifted verbatim from 'docs/security/firewalls/control-network-traffic-with-iptables'.

I'm no iptables expert but at least for me these rules were necessary to make SLAAC work on Debian 8.
It would be great if someone more knowledgable in this area could chime in whether this makes sense for all systems?