### PR TITLE
Corrected typo in CENTOS 7 static networking config example

### DIFF
--- a/docs/networking/linux-static-ip-configuration.md
+++ b/docs/networking/linux-static-ip-configuration.md
@@ -96,7 +96,7 @@ Edit the interface's config file:
     PREFIX0="24"
 
     # To add a second public IP address:
-    IPADDR=198.51.100.10
+    IPADDR1=198.51.100.10
     PREFIX1="24"
 
     # To add a private IP address:


### PR DESCRIPTION
Small typo, but makes a big difference. Without the correct suffix here, network no-workie.