### PR TITLE
Fix apparent mistake in IPv6 firewall rules

### DIFF
--- a/docs/security/securing-your-server.md
+++ b/docs/security/securing-your-server.md
@@ -355,7 +355,7 @@ If you would like to supplement your web server's IPv4 rules with IPv6 too, this
     -A INPUT ! -i lo -s ::1/128 -j REJECT
 
     # Allow ICMP
-    -A INPUT -p icmpv6 -m state --state NEW -j ACCEPT
+    -A INPUT -p icmpv6 -j ACCEPT
 
     # Allow HTTP and HTTPS connections from anywhere
     # (the normal ports for web servers).


### PR DESCRIPTION
It appears only accepting ICMP traffic matching `-m state --state NEW` stops all incoming connections – I could not even ping the machine with `ping6`. My knowledge of this area is quite weak, but the suggestion on IRC was that Conntrack does not track state, so --state NEW would not match.

This was using Debian 8.2 with the newest Kernel (4.4.0-x86_64-linode63)