### PR TITLE
Spfdkim rotate testkey

### DIFF
--- a/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8.md
+++ b/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8.md
@@ -1,6 +1,6 @@
 ---
 author:
-    name: Linode Community 
+    name: Linode Community
     email: contribute@linode.com
 description: 'Configure SPF and DKIM in Postfix on Debian 8.'
 keywords: 'email,postfix,spf,dkim,debian 8,opendkim,dns'
@@ -63,11 +63,11 @@ The value in an SPF DNS record will look something like the following examples. 
 
         v=spf1 a:mail.example.com -all
 
-- The `v=spf1` tag is required and has to be the first tag. 
+- The `v=spf1` tag is required and has to be the first tag.
 
 - The last tag, `-all`, indicates that mail from your domain should only come from servers identified in the SPF string. Anything coming from any other source is forging your domain. An alternative is `~all`, indicating the same thing but also indicating that mail servers should accept the message and flag it as forged instead of rejecting it outright. `-all` makes it harder for spammers to forge your domain successfully; it is the recommended setting. `~all` reduces the chances of email getting lost because an incorrect mail server was used to send mail. `~all` can be used if you don't want to take chances.
 
-The tags between identify eligible servers from which email to your domain can originate. 
+The tags between identify eligible servers from which email to your domain can originate.
 
 - `mx` is a shorthand for all the hosts listed in MX records for your domain. If you've got a solitary mail server, `mx` is probably the best option. If you've got a backup mail server (a second MX record), using `mx` won't cause any problems. Your backup mail server will be identified as an authorized source for email althought it will probably never send any.
 
@@ -385,9 +385,13 @@ You don't need to set this up, but doing so makes it harder for anyone to forge 
 
 The reason the YYYYMM format is used for the selector is that best practice calls for changing the DKIM signing keys every so often (monthly is recommended, and no longer than every 6 months). To do that without disrupting messages in transit, you generate the new keys using a new selector. The process is:
 
-1.  Generate new keys as in step 6 of "Configuring OpenDKIM". Do this in a scratch directory, not directly in `/etc/opendkim/keys`. Use the current year and month for the YYYYMM selector value, so it's different from the selector currently in use.
+1.  Generate new keys as in step 8 of "Configure OpenDKIM". Do this in a scratch directory, not directly in `/etc/opendkim/keys`. Use the current year and month for the YYYYMM selector value, so it's different from the selector currently in use.
 
-2.  Use the newly-generated `.txt` files to add the new keys to DNS as in the DKIM "Setting Up DNS" section, using the new YYYYMM selector in the host names. Don't remove or alter the existing DKIM TXT records.
+2.  Use the newly-generated `.txt` files to add the new keys to DNS as in the DKIM "Setting Up DNS" section, using the new YYYYMM selector in the host names. Don't remove or alter the existing DKIM TXT records. Once this is done, verify the new key data using the following command (replacing example.com, example and YYYYMM with the appropriate values):
+
+    opendkim-testkey -d example.com -s YYYYMM -k example.private
+
+Add the `-vvv` switch to get debugging output if you need it to diagnose any problems. Correct any problems before proceeding, beginning to use the new private key file and selector when `opendkim-testkey` doesn't indicate a successful verification will cause problems with your email including non-receipt of messages.
 
 3.  Stop Postfix and OpenDKIM by doing a `systemctl stop postfix opendkim` so that they won't be processing mail while you're changing out keys.
 


### PR DESCRIPTION
Expand step 2 of rotating keys to include verifying the new key and DNS data before activating the key in Postfix.

Fix a minor naming/numbering error referring to a previous section and step.