### PR TITLE
Add line to fix the appearance of Grub in Lish

### DIFF
--- a/docs/tools-reference/custom-kernels-distros/run-a-distribution-supplied-kernel-with-kvm.md
+++ b/docs/tools-reference/custom-kernels-distros/run-a-distribution-supplied-kernel-with-kvm.md
@@ -77,6 +77,7 @@ Before you get started, make sure you follow the steps outlined in our [Getting 
       GRUB_CMDLINE_LINUX="console=ttyS0,19200n8"
       GRUB_DISABLE_LINUX_UUID=true
       GRUB_SERIAL_COMMAND="serial --speed=19200 --unit=0 --word=8 --parity=no --stop=1"
+      GRUB_TERMINAL=serial
 	  ~~~
 
 2.  Run the following command to update the bootloader.


### PR DESCRIPTION
Grub doesn't look very good on Lish without the GRUB_TERMINAL=serial line as Lish acts as a serial terminal. Line 133 is just a newline trimmed at the end of the file.