### PR TITLE
Installing Odoo 9 Guide update

### DIFF
--- a/docs/websites/cms/install-odoo-9-erp-on-ubuntu-16-04.md
+++ b/docs/websites/cms/install-odoo-9-erp-on-ubuntu-16-04.md
@@ -1,0 +1,22 @@
+---
+author:
+  name: Linode Community
+  email: docs@linode.com
+description: 'Odoo is an open-source suite of over 4,500 business applications. Odoo allows administrators to install, configure and customize any application to satisfy their needs. This guide covers how to install and configure Odoo using Git source so it will be easy to upgrade and maintain.'
+keywords: 'Odoo,Odoo ERP,CMS,Ubuntu,CRM,OpenERP'
+license: '[CC BY-ND 3.0](http://creativecommons.org/licenses/by-nd/3.0/us/)'
+published: ' '
+modified: ' '
+modified_by:
+  name: Linode
+title: 'Install Odoo 9 ERP on Ubuntu 16.04'
+contributor:
+  name: Damaso Sanoja
+external_resources:
+ - '[Odoo User Documentation](https://doc.odoo.com/book/)'
+---
+
+*This is a Linode Community guide. Write for us and earn $250 per published guide.*
+<hr>
+
+***Content placeholder***


### PR DESCRIPTION
Hi all,
Ubuntu 16.04 LTS will be released in few days, this will be the first LTS to use  systemd by default instead of upstart.

I wonder which would be the best way to update the guide: "Installing Odoo 9 ERP on Ubuntu.", because is more an editorial decision than a technical one.

**Changes to run Odoo 9 on Ubuntu 16.04 server are:**

**Dependencies changes summary:**
1. Update global dependencies (new packages versions allows this).
2. Update postgresql version over 14.04 LTS
3. New workaround for installing lessc

**Technical _optional_ changes (see comments bellow):**
1. Change from using odoo-server init script in favor of odoo.service unit (systemd)
2. Necessary changes to use centralized journald for log recording.

About point 1, Odoo 9 actually runs perfectly with current script. Many sysadmins (myself included) would say "If it ain't broke, don't fix it"... but on the other hand, controversy aside, Ubuntu adopted systemd a year ago, so formally speaking new guides "should" include the new scripts or at least mention how to implement a mix of both. The same argument is valid for log entries, current logfile works fine, but from an academic point of view that _should_ be managed through journals.

So then, which solution would be best according Linode guidelines:
- An updated article including 14.04 and 16.04 different approaches (init vs systemd units)?
- An updated article with a mix of both approaches trying to make the fewer changes possible?
- A new guide for 16.04 with emphasis on systemd changes (clean systemd no custom init scripts)?
- Suggestions about another approach?

Best regards, waiting your comments.
