### PR TITLE
Make adjustments to our Arch Linux networking documentation in accord…

### DIFF
--- a/docs/networking/linux-static-ip-configuration.md
+++ b/docs/networking/linux-static-ip-configuration.md
@@ -90,7 +90,24 @@ A default gateway should not be specified for private IP addresses. Additionally
 
 ### Arch
 
-There are multiple ways to configure static IP addresses in Arch. See the [Static IP Address](https://wiki.archlinux.org/index.php/Network_Configuration#Static_IP_address) section of Arch's Network Configuration Wiki page.
+Edit the interface's config file:
+
+{: .file-excerpt }
+/etc/systemd/network/05-eth0.network
+:   ~~~ conf
+    . . .
+
+    [Match]
+    Name=eth0
+
+    [Network]
+    Gateway=45.79.131.1
+    Address=45.79.131.10/24
+    Address=192.168.133.234/17
+
+    ~~~
+
+There are multiple ways to configure static IP addresses in Arch. See the [Static IP Address](https://wiki.archlinux.org/index.php/Network_Configuration#Static_IP_address) section of Arch's Network Configuration Wiki page for other options such as using Netctl.
 
 ### CentOS 7 / Fedora 22+
 

--- a/docs/networking/native-ipv6-networking.md
+++ b/docs/networking/native-ipv6-networking.md
@@ -153,6 +153,33 @@ If you are using CentOS 7, you will need to reload your configuration using `nmc
     nmcli con down "System eth0"
     nmcli con up "System eth0"
 
+### Arch Linux/Fedora 21 (systemd-networkd)
+
+If you are using `systemd-networkd` on Arch Linux or Fedora 21, you can statically configure IPv6 pools by editing `/etc/systemd/network/50-static.network`.
+
+1.  Set up [Static IP Networking](/docs/networking/linux-static-ip-configuration/#arch-linux--fedora-21) for your IPv4 address.
+
+2.  Edit your current static IP networking configuration to allow for your IPv6 addresses. You will need to include your default IPv6 address as well.
+
+    {: .file }
+    /etc/systemd/network/50-static.network
+    :   ~~~
+        [Match]
+        Name=eth0
+
+        [Network]
+        Address=198.51.100.2/24
+        Address=192.168.133.234/17
+        Gateway=198.51.100.1
+        Address=2001:DB8:2000:aff0::/32
+        Address=2001:DB8:2000:aff0::1/32
+        Address=2001:DB8:2000:aff0::2/32
+        ~~~
+
+3.  Restart `systemd-networkd`
+
+        systemctl restart systemd-networkd
+
 ### Arch Linux (netctl)
 
 If you are still using `netctl` in Arch Linux, you can statically configure your IPv6 pools by editing the `/etc/netctl/examples/ethernet-static` file and copying it to `/etc/netctl`.
@@ -198,33 +225,6 @@ If you are still using `netctl` in Arch Linux, you can statically configure your
 5.  Enable your new network profile:
 
         netctl enable ethernet-static
-
-### Arch Linux/Fedora 21 (systemd-networkd)
-
-If you are using `systemd-networkd` on Arch Linux or Fedora 21, you can statically configure IPv6 pools by editing `/etc/systemd/network/50-static.network`.
-
-1.  Set up [Static IP Networking](/docs/networking/linux-static-ip-configuration/#arch-linux--fedora-21) for your IPv4 address.
-
-2.  Edit your current static IP networking configuration to allow for your IPv6 addresses. You will need to include your default IPv6 address as well.
-
-    {: .file }
-    /etc/systemd/network/50-static.network
-    :   ~~~
-        [Match]
-        Name=eth0
-
-        [Network]
-        Address=198.51.100.2/24
-        Address=192.168.133.234/17
-        Gateway=198.51.100.1
-        Address=2001:DB8:2000:aff0::/32
-        Address=2001:DB8:2000:aff0::1/32
-        Address=2001:DB8:2000:aff0::2/32
-        ~~~
-
-3.  Restart `systemd-networkd`
-
-        systemctl restart systemd-networkd
 
 ### Gentoo
 


### PR DESCRIPTION
…ance to our current image.

I've added a configuration snippet for Arch Linux IP configuration which does not rely on delegation to Arch's docs. Please note that it uses systemd-networkd instead of netctl as that is what network helper edits.

And I've switched netctl and systemd-networkd, for the Native IPv6 guide, in order to encourage systemd-networkd to be tried first.

This should help avoid any confusion or mistakes, as Network Helper automatically generates good examples to be worked from which will end up being more simple and headache free.