### PR TITLE
Fix Systemd Config Highlighting And Spacing

### DIFF
--- a/docs/applications/development/install-gogs-on-debian-8-jessie.md
+++ b/docs/applications/development/install-gogs-on-debian-8-jessie.md
@@ -206,7 +206,7 @@ In this section we will setup Gogs to run automatically on boot by creating a sy
 1.  Using `sudo`, create `/etc/systemd/system/gogs.service`:
 
     {: .file}
-    /etc/nginx/sites-available/gogs
+    /etc/systemd/system/gogs.service
     :   ~~~ ini
         [Unit]
         Description=Gogs (Go Git Service)

--- a/docs/networking/native-ipv6-networking.md
+++ b/docs/networking/native-ipv6-networking.md
@@ -209,7 +209,7 @@ If you are using `systemd-networkd` on Arch Linux or Fedora 21, you can statical
 
     {: .file }
     /etc/systemd/network/50-static.network
-    :   ~~~
+    :   ~~~ ini
         [Match]
         Name=eth0
 

--- a/docs/uptime/monitoring/install-nagios-4-on-ubuntu-debian-8.md
+++ b/docs/uptime/monitoring/install-nagios-4-on-ubuntu-debian-8.md
@@ -150,7 +150,7 @@ As of this guide's publication, the Nagios build process does not create a syste
 
  {: .file}
  /etc/systemd/system/nagios.service
- :    ~~~
+ :    ~~~ ini
       [Unit]
       Description=Nagios
       BindTo=network.target

--- a/docs/websites/lemp/lemp-server-on-centos-7-with-fastcgi.md
+++ b/docs/websites/lemp/lemp-server-on-centos-7-with-fastcgi.md
@@ -131,9 +131,9 @@ When PHP-FastCGI is installed it does not automatically get set up as a service 
 
 {: .file }
 /etc/systemd/system/php-fastcgi.service
-:   ~~~ systemd
+:   ~~~ ini
     [Unit]
-    Description= php-fastcgi systemd service script
+    Description=php-fastcgi systemd service script
 
     [Service]
     Type=forking

--- a/docs/websites/nginx/nginx-web-server-debian-8.md
+++ b/docs/websites/nginx/nginx-web-server-debian-8.md
@@ -108,7 +108,7 @@ The Debian project does not track the latest development of Nginx server. If you
 
     {: .file}
     /lib/systemd/system/nginx.service
-    :   ~~~ shell
+    :   ~~~ ini
         [Unit]
         Description=A high performance web server and a reverse proxy server
         After=network.target


### PR DESCRIPTION
Make all systemd configs consistant
Set highlighting to ini since it is the closest language
that has highlighting
Remove spaces between = sign and description