### PR TITLE
Remove ApacheBuddy, which doesn't work

### DIFF
--- a/docs/websites/apache-tips-and-tricks/tuning-your-apache-server.md
+++ b/docs/websites/apache-tips-and-tricks/tuning-your-apache-server.md
@@ -29,7 +29,7 @@ There are a variety of tools that can assist in determining if you need to alter
 	echo [PID]  [MEM]  [PATH] &&  ps aux | awk '{print $2, $4, $11}' | sort -k2rn | head -n 20
 	ps -eo pcpu,pid,user,args | sort -k 1 -r | head -20
 
-More specific resources for resource tuning Apache includes Apache `mod_status` and ApacheBuddy.
+You can get more specific insight for tuning Apache with the included `mod_status`.
 
 ###Apache mod_status
 
@@ -87,12 +87,6 @@ Apache `mod_status` diplays information related to incoming server connections b
 6.  Open the file:
 
 		lynx http://localhost/server-status
-
-###ApacheBuddy
-
-The ApacheBuddy script, similar to MySQLTuner, reviews your Apache setup, and makes suggestions based on your Apache process memory and overall RAM. Although it is a fairly basic program, focusing on the `MaxClients` directive, ApacheBuddy is useful, and can be run through a single command:
-
-	curl -L http://apachebuddy.pl/ | perl
 
 ##Multi Processing Modules
 


### PR DESCRIPTION
[root@linode2 conf.modules.d]# perl ~pepper/apachebuddy.pl 
########################################################################
# Apache Buddy v 0.3 ###################################################
########################################################################
Gathering information...
We are checking the service running on port 80
The process listening on port 80 is /usr/sbin/httpd
The process running on port 80 is not Apache. 
 Falling back to process list...
Could not find Apache process. Exiting...