### PR TITLE
Clarified the correct format of the "action" setting.

### DIFF
--- a/docs/security/using-fail2ban-for-security.md
+++ b/docs/security/using-fail2ban-for-security.md
@@ -208,7 +208,7 @@ If you wish to receive email when Fail2ban is triggered, adjust the email settin
 >
 >If unsure of what to put under `sender`, run the command `sendmail -t user@email.com`, replacing `user@email.com` with your email address. Check your email (including spam folders, if needed) and review the sender email. This address can be used for the above configuration.
 
-You will also need to adjudst the `action` setting, which defines what actions occur when the threshold for ban is met. The default, `%(action_)s`, only bans the user. `action_mw` will ban and send an email with a WhoIs report; while `action_mwl` will ban and send an email with the WhoIs report and all relevant lines in the log file. This can also be changed on a jail-specific basis.
+You will also need to adjudst the `action` setting, which defines what actions occur when the threshold for ban is met. The default, `%(action_)s`, only bans the user. `%(action_mw)s` will ban and send an email with a WhoIs report; while `%(action_mwl)s` will ban and send an email with the WhoIs report and all relevant lines in the log file. This can also be changed on a jail-specific basis.
 
 ### Jail Configuration
 


### PR DESCRIPTION
This may be stating the obvious, but I believe that the "action" setting
value must be enclosed in brackets, and wrapped in %s. For example:

`%(action_mw)s`

The current instructions don't make this clear, in my opinion.
