### PR TITLE
Update ssl-apache2-debian-ubuntu.md

### DIFF
--- a/docs/security/ssl/ssl-apache2-debian-ubuntu.md
+++ b/docs/security/ssl/ssl-apache2-debian-ubuntu.md
@@ -63,7 +63,7 @@ This updates system hooks and the main ca-certificate.crt file located in `/etc/
             SSLEngine On
             SSLCertificateFile /etc/ssl/localcerts/www.example.com.crt
             SSLCertificateKeyFile /etc/ssl/localcerts/www.example.com.key
-            SSLCACertificateFile /etc/ssl/localcerts/ca-certificates.crt  # If using a self-signed certificate, omit this line
+            SSLCACertificateFile /etc/ssl/certs/ca-certificates.crt  # If using a self-signed certificate, omit this line
 
             ServerAdmin info@example.com
             ServerName www.example.com


### PR DESCRIPTION
SSLCACertificateFile must be set to /etc/ssl/certs/ca-certificates.crt, not localcerts. This is to match the reference on line 53.