### PR TITLE
Securing your server: save modified firewall rules

### DIFF
--- a/docs/security/securing-your-server.md
+++ b/docs/security/securing-your-server.md
@@ -537,7 +537,7 @@ UFW is the iptables controller included with Ubuntu but is also available in Deb
 
         sudo apt-get install iptables-persistent
 
-4. You'll be asked if you want to save the current IPv4 and IPv6 rules. Answer `yes` to each prompt.
+4. You'll be asked if you want to save the current IPv4 and IPv6 rules. Answer `yes` to each prompt.  If in future, you edit the rules and need to save them again, use: `sudo dpkg-reconfigure iptables-persistent`
 
 5.  Remove the temporary rule files:
 


### PR DESCRIPTION
Debian/Ubuntu - explain how to save modified iptables rules.

The instructions later (for adding, editing, deleting rules) state: 
"To accomplish this, revisit the area above for your distro to 
save your iptables edits so they’re loaded on reboots."

It may not be immediately apparent how to do this in Debian.
