### PR TITLE
Adds protocol to author's GitHub URL.

### DIFF
--- a/docs/security/gpg-key-for-ssh-authentication.md
+++ b/docs/security/gpg-key-for-ssh-authentication.md
@@ -8,7 +8,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 title: 'How to use a GPG key for SSH authentication'
 contributor:
   name: Huw Evans
-  link: github.com/huw
+  link: https://github.com/huw
 external_resources:
  - '[Securely set up smartcard](https://gist.github.com/abeluck/3383449)'
  - '[Instructions for GPG 2.1](https://incenp.org/notes/2015/gnupg-for-ssh-authentication.html)'


### PR DESCRIPTION
The "Contributed by" link at the top of the guide is a malformed link. This should fix it.