### PR TITLE
bugfixes for fail2ban config files

### DIFF
--- a/docs/security/using-fail2ban-for-security.md
+++ b/docs/security/using-fail2ban-for-security.md
@@ -125,7 +125,7 @@ Fail2ban reads its configuration files so that all `.conf` files are read first 
 
 2.  The file `fail2ban.conf` contains the default configuration variables for Fail2ban logging, the socket used to communicate with the daemon, and the location of the PID file. Changes should be made in a separate file, `fail2ban.local`, definitions in which override `fail2ban.conf`. If you want, you can copy `fail2ban.conf` to `fail2ban.local`, commenting out all variables, and then uncomment only the options you want to modify:
 
-        sed 's/\(^[[:alpha:]]\)/# \1/' fail2ban.conf | sudo tee fail2ban.local 1&> /dev/null
+        sed 's/\(^[[:alpha:]]\)/# \1/' fail2ban.conf | sudo tee fail2ban.local &> /dev/null
 
     Otherwise, create a blank `fail2ban.local` file, and manually add the options (with corresponding section titles) you wish to modify.
 
@@ -140,7 +140,7 @@ Fail2ban reads its configuration files so that all `.conf` files are read first 
 
 1.  Return to `/etc/fail2ban` directory and copy the `jail.conf` file to `jail.local`:
 
-        sed 's/\(^[[:alpha:]]\)/# \1/' jail.conf | sudo tee jail.local 1&> /dev/null
+        sed 's/\(^[a-z tab]\)/# \1/' jail.conf | sudo tee jail.local &> /dev/null
 
     This will create a copy of `jail.conf` with all the directives commented out. To overwrite a setting, uncomment and modify it in `jail.local`.
 


### PR DESCRIPTION
* do not create a junk file named ``1``
* make ``jail.local`` syntactically valid so that fail2ban will start