### PR TITLE
Added step to install PHP GD library for image processing

### DIFF
--- a/docs/websites/cms/install-wordpress-on-ubuntu-16-04.md
+++ b/docs/websites/cms/install-wordpress-on-ubuntu-16-04.md
@@ -60,6 +60,10 @@ In this guide, you'll learn to how to install WordPress on a Linode running Ubun
 
             quit
 
+-   Install the PHP GD package. This will be necessary for modifying images you upload to your site:
+
+        sudo apt-get install php7.0-gd
+
 ## Install WordPress
 
 1.  Create a directory called `src` under your website's directory to store fresh copies of WordPress's source files. In this guide, the home directory `/var/www/html/example.com/` is used as an example. Navigate to that new directory:


### PR DESCRIPTION
I discovered this incidentally while working on a personal site. Without the PHP GD library, users can't modify uploaded images (i.e., cropping to create a favicon, etc.). It's likely this change applies to other docs, but I made my initial commit based on the environment I found it in.