### PR TITLE
update pgAdmin links

### DIFF
--- a/docs/databases/postgresql/securely-manage-remote-postgresql-servers-with-pgadmin-on-macos-x.md
+++ b/docs/databases/postgresql/securely-manage-remote-postgresql-servers-with-pgadmin-on-macos-x.md
@@ -20,7 +20,7 @@ pgAdmin is a free, open-source PostgreSQL database administration GUI for Micros
 
 ## Install pgAdmin
 
-1.  Visit the [pgAdmin download page](http://www.pgadmin.org/download/macosx.php) to obtain the most recent version of the program. Save the installer to your desktop and launch it. Read the license agreement and click the "Agree" button to continue.
+1.  Visit the [pgAdmin download page](https://www.pgadmin.org/download/macos4.php) to obtain the most recent version of the program. Save the installer to your desktop and launch it. Read the license agreement and click the "Agree" button to continue.
 
     [![pgAdmin on Mac OS X installer license agreement dialog](/docs/assets/pg-admin-macosx-license.png)](/docs/assets/pg-admin-macosx-license.png)
 

--- a/docs/databases/postgresql/securely-manage-remote-postgresql-servers-with-pgadmin-on-windows.md
+++ b/docs/databases/postgresql/securely-manage-remote-postgresql-servers-with-pgadmin-on-windows.md
@@ -20,7 +20,7 @@ pgAdmin is a free, open source PostgreSQL database administration GUI for Micros
 
 ## Install pgAdmin
 
-Visit the [pgAdmin download page](http://www.pgadmin.org/download/windows.php) to obtain the most recent version of the program. Save the installer to your desktop and launch it. You'll be greeted with the following screen; click "Next" to continue.
+Visit the [pgAdmin download page](https://www.pgadmin.org/download/windows4.php) to obtain the most recent version of the program. Save the installer to your desktop and launch it. You'll be greeted with the following screen; click "Next" to continue.
 
 [![pgAdmin on Windows installer welcome dialog](/docs/assets/364-pgadmin-windows-install-1.png)](/docs/assets/364-pgadmin-windows-install-1.png)
 


### PR DESCRIPTION
pgAdmin 3 is no longer supported. Both guides have been updated to use their respective links to download pgAdmin 4.

I also would consider linking to the root pgAdmin `/download/` page, so the reader can decide for themselves, but that is up to all of you.  Most Windows users will probably be fine on pgAdmin 4 (minimum requirement of Windows 7), but pgAdmin 4 for macOS requires 10.10, and some may not be up to date.

I avoided updating the wording to use 4 throughout until someone else weighs in, but would be happy to update this pull request.