### PR TITLE
Include instructions for PHP extensions like php-xmlrpc

### DIFF
--- a/docs/websites/cms/install-wordpress-on-ubuntu-16-04.md
+++ b/docs/websites/cms/install-wordpress-on-ubuntu-16-04.md
@@ -171,11 +171,10 @@ Nginx needs to be directed to check whether the page each permalink refers to ex
         try_files $uri $uri/ /index.php?$args;
     ~~~
     
-## Install PHP Extensions for XML-RPC and others (Optional)
+## Install PHP Extension for XML-RPC (Optional)
+To use XML-RPC to access Wordpress via the mobile app or to use Jetpack, you'll need php-xmlrpc.  For more information on XML-RPC, visit the [WordPress guide on XML-RPC](https://codex.wordpress.org/XML-RPC_Support).  For more information on Jetpack, visit [Jetpack for Wordpress](https://jetpack.com/).
 
-WordPress and many of its plugins leverage additional PHP extensions.  For example, to use XML-RPC to access Wordpress via the mobile app, you'll need php-xmlrpc.
-
-We can download and install php-xmlrpc and several more of the most popular PHP extensions for use with WordPress with these commands:
+We can download and install php-xmlrpc with these commands:
 
     sudo apt-get update
-    sudo apt-get install php-curl php-gd php-mbstring php-mcrypt php-xml php-xmlrpc
+    sudo apt-get install php-xmlrpc

--- a/docs/websites/cms/install-wordpress-on-ubuntu-16-04.md
+++ b/docs/websites/cms/install-wordpress-on-ubuntu-16-04.md
@@ -170,3 +170,12 @@ Nginx needs to be directed to check whether the page each permalink refers to ex
         index index.php index.html index.htm;
         try_files $uri $uri/ /index.php?$args;
     ~~~
+    
+## Install PHP Extensions for XML-RPC and others (Optional)
+
+WordPress and many of its plugins leverage additional PHP extensions.  For example, to use XML-RPC to access Wordpress via the mobile app, you'll need php-xmlrpc.
+
+We can download and install php-xmlrpc and several more of the most popular PHP extensions for use with WordPress with these commands:
+
+    sudo apt-get update
+    sudo apt-get install php-curl php-gd php-mbstring php-mcrypt php-xml php-xmlrpc


### PR DESCRIPTION
Without these instructions, Jetpack installation and use of the Wordpress mobile app are not possible