### PR TITLE
Minor bug fix update for  configure-spf-and-dkim-in-postfix-on-debian-8.md

### DIFF
--- a/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8.md
+++ b/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8.md
@@ -257,7 +257,7 @@ DKIM involves setting up the OpenDKIM package, hooking it into Postfix, and addi
 
 8.  Generate keys for each domain:
 
-        opendkim-genkey -b 2048 -h rsa-sha256 -r -s YYYYMM -d example.com -v
+        opendkim-genkey -b 2048 -h sha256 -r -s YYYYMM -d example.com -v
 
     Replace `YYYYMM` with the current year and month as in the key table. This will give you two files, `YYYYMM.private` containing the key and `YYYYMM.txt` containing the TXT record you'll need to set up DNS. Rename the files so they have names matching the third section of the second field of the key table for the domain:
 


### PR DESCRIPTION
Section 8 of 'Configure OpenDKIM' contains (what I believe is) an error; the -h parameter should be sha256, not rsa-sha256. Using the latter causes signed mails to fail validation using the tests at check-auth@verifier.port25.com and appmaildev.com.

I tracked this down thanks to a clue in http://arstechnica.com/civis/viewtopic.php?t=1238575&start=120 (2nd post) which also says this error is present in much of the documentation around the internet.