### PR TITLE
for fixing fail2ban start up failure

### DIFF
--- a/docs/security/using-fail2ban-for-security.md
+++ b/docs/security/using-fail2ban-for-security.md
@@ -56,7 +56,7 @@ Follow the [Getting Started](/docs/getting-started) guide to configure your basi
         systemctl enable fail2ban
         systemctl start sendmail
         systemctl enable sendmail
-
+Note:  create directory '/var/run/fail2ban' if you start Fail2ban failed.
 ### Debian
 
 1.  Ensure your system is up to date:


### PR DESCRIPTION
ERROR  There is no directory /var/run/fail2ban to contain the socket file /var/run/fail2ban/fail2ban.sock.