### PR TITLE
change DNS axfr1 IP

### DIFF
--- a/docs/networking/dns/dns-manager-overview.md
+++ b/docs/networking/dns/dns-manager-overview.md
@@ -88,7 +88,7 @@ Here's how to add a new domain zone:
     {: .note}
     > In order for Linode's DNS servers to function as slaves, your DNS master server must notify and allow AXFR requests to and from the follow IP addresses:
     >
-    >     69.93.127.10
+    >     104.237.137.10
     >     65.19.178.10
     >     75.127.96.10
     >     207.192.70.10

--- a/docs/websites/cms/creating-accounts-on-directadmin.md
+++ b/docs/websites/cms/creating-accounts-on-directadmin.md
@@ -61,9 +61,9 @@ Make sure you use a valid email address as the DirectAdminsystem will email your
     You must use these dns servers for your domain. They can be changed through your domain registrar.
 
     NS1:    ns1.linode.com
-    NS1 IP: 69.93.127.10
+    NS1 IP: 162.159.27.72
     NS2:    ns2.linode.com
-    NS2 IP: 65.19.178.10
+    NS2 IP: 162.159.24.39
 
     POP Email Accounts:     100
     Email Forwarders:       0

--- a/docs/websites/cms/set-up-dns-services-on-cpanel.md
+++ b/docs/websites/cms/set-up-dns-services-on-cpanel.md
@@ -63,7 +63,7 @@ The transfer of DNS records from your Master DNS server to the Linode DNS server
 /etc/named.conf
 :   ~~~
     allow-transfer {
-         69.93.127.10;
+         104.237.137.10;
          65.19.178.10;
          75.127.96.10;
          207.192.70.10;
@@ -75,7 +75,7 @@ The transfer of DNS records from your Master DNS server to the Linode DNS server
          2a01:7e00::a;
      };
      also-notify {
-         69.93.127.10;
+         104.237.137.10;
          65.19.178.10;
          75.127.96.10;
          207.192.70.10;


### PR DESCRIPTION
The public IP address for axfr1 (DNS transfer server) is being changed.  The new IP is already functional, so this doc change can be pushed immediately.

While I was searching for docs to change, found one still referencing the axfr addresses as the ns addresses.  Revised to use the current ns addresses (changed when we adopted CloudFlare for DNS DDoS prevention).

-- ccravens