### PR TITLE
Docker seems to use OverlayFS(overlay2) by default now when available.

### DIFF
--- a/docs/applications/containers/how-to-install-docker-and-deploy-a-lamp-stack.md
+++ b/docs/applications/containers/how-to-install-docker-and-deploy-a-lamp-stack.md
@@ -45,7 +45,7 @@ Use the Docker-maintained install script for Debian or Ubuntu. For other operati
           linux-image-virtual kernel and linux-image-extra-virtual for AUFS support.
           + sleep 10
     >
-    >This message can be safely ignored, as the script will continue the installation using DeviceMapper.  If you require AUFS support, you will need to configure a [distribution supplied](https://www.linode.com/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub) or [custom compiled](/docs/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu) kernel.
+    >This message can be safely ignored, as the script will continue the installation using DeviceMapper or OverlayFS.  If you require AUFS support, you will need to configure a [distribution supplied](https://www.linode.com/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub) or [custom compiled](/docs/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu) kernel.
 
 2.  If necessary, add the non-root user to the "docker" group:
 

--- a/docs/applications/containers/node-js-web-server-deployed-within-docker.md
+++ b/docs/applications/containers/node-js-web-server-deployed-within-docker.md
@@ -32,7 +32,7 @@ Use the Docker-maintained install script for Debian or Ubuntu. For other operati
           linux-image-virtual kernel and linux-image-extra-virtual for AUFS support.
           + sleep 10
     >
-    >This message can be safely ignored, as the script will continue the installation using DeviceMapper.  If you require AUFS support, you will need to configure a [distribution supplied](https://www.linode.com/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub) or [custom compiled](/docs/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu) kernel.
+    >This message can be safely ignored, as the script will continue the installation using DeviceMapper or OverlayFS.  If you require AUFS support, you will need to configure a [distribution supplied](https://www.linode.com/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub) or [custom compiled](/docs/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu) kernel.
 
 2.  If necessary, add the non-root user to the "docker" group:
 


### PR DESCRIPTION
On a recent installation it was noted that while it still gives the warning regarding aufs missing it now uses OverlayFS (overlay2) as the storage driver instead of DeviceMapper.