### PR TITLE
Update macOs cache flush command

### DIFF
--- a/docs/networking/dns/previewing-websites-without-dns.md
+++ b/docs/networking/dns/previewing-websites-without-dns.md
@@ -87,7 +87,9 @@ Please note that on some systems pressing tab will align to the previous lines, 
 
 On OS X systems, you will need to flush the DNS cache if you've already visited or looked up the domain before. The [command to do so varies according to your version of Mac OS X](https://support.apple.com/en-us/HT202516). In Terminal from a shell prompt:
 
-    # Yosemite (10.10)
+    # Yosemite, El Capitan, Sierra (10.10.4 and later)
+    killall -HUP mDNSResponder
+    # Yosemite (up to 10.10.3)
     discoveryutil mdnsflushcache
     # Mavericks, Mountain Lion, and Lion (10.7 - 10.9)
     killall -HUP mDNSResponder


### PR DESCRIPTION
The command to flush the macOS DNS cache was not updated beyond Yosemite,
and in fact changed back to the old one in 10.10.4.