### PR TITLE
Update configure-spf-and-dkim-in-postfix-on-debian-8.md

### DIFF
--- a/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8.md
+++ b/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8.md
@@ -46,9 +46,9 @@ The DNS instructions for setting up SPF, DKIM and DMARC are generic. The instruc
 
 ## Install DKIM, SPF and Postfix
 
-1.  Install the three required packages:
+1.  Install the four required packages:
 
-        apt-get install opendkim opendkim-tools postfix-policyd-spf-python
+        apt-get install opendkim opendkim-tools postfix-policyd-spf-python postfix-pcre
 
 2.  Add user `postfix` to the `opendkim` group so that Postfix can access OpenDKIM's socket when it needs to:
 


### PR DESCRIPTION
The installation instructions as is will cause any mail server using postfix to be unable to receive emails. The reason is because postfix does not come standard with support for pcre, and any received emails will be rejected. Here is the specific error that will be generated located in /var/log/mail.log: "postfix/cleanup[6782]: warning: pcre:/etc/postfix/header_checks is unavailable. unsupported dictionary type: pcre". This should be updated as soon as possible, because related errors are also generated, further complicating the troubleshooting. Here is the full printout of related errors:

May 24 06:40:50 darkstar postfix/pickup[6381]: warning: maildrop/0D19C222C7: error writing C374722351: queue file write error
May 24 06:40:51 darkstar postfix/pickup[6381]: C5B4822351: uid=999 from=<sogo>
May 24 06:40:51 darkstar postfix/cleanup[6782]: warning: pcre:/etc/postfix/header_checks is unavailable. unsupported dictionary type: pcre
May 24 06:40:51 darkstar postfix/cleanup[6782]: warning: pcre:/etc/postfix/header_checks lookup error for "Received: by darkstar.vps.com (Postfix, from userid 999)??id C5B4822351; Wed, 24 May 2017 06:14:02 -"
May 24 06:40:51 darkstar postfix/cleanup[6782]: warning: C5B4822351: header_checks map lookup problem -- message not accepted, try again later

Feel free to email me with any questions. 

-Andrew Lescher