### PR TITLE
Updated URL to Apache2Buddy script

### DIFF
--- a/docs/web-servers/apache-tips-and-tricks/tuning-your-apache-server.md
+++ b/docs/web-servers/apache-tips-and-tricks/tuning-your-apache-server.md
@@ -95,7 +95,7 @@ Apache `mod_status` diplays information related to incoming server connections b
 
 The Apache2Buddy script, similar to MySQLTuner, reviews your Apache setup, and makes suggestions based on your Apache process memory and overall RAM. Although it is a fairly basic program, focusing on the `MaxClients` directive, Apache2Buddy is useful, and can be run through a single command:
 
-	curl -L http://apache2buddy.pl/ | perl
+	curl -sL https://raw.githubusercontent.com/richardforth/apache2buddy/master/apache2buddy.pl | perl
 
 ##Multi Processing Modules
 


### PR DESCRIPTION
As mentioned in the readme, for security reasons this new URL should be used.