### PR TITLE
Fix broken link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Linode Guides and Tutorials
 
 This repository contains all the tutorials featured at [linode.com/docs](https://linode.com/docs). Please feel free to contribute by suggesting document improvements, identifying corrections, or submitting updates.
 
-If you'd like to write for us, please apply via our [contributing page](https://linode.com/docs/contribute). Then, see the [Linode Writer's Formatting Guide](/docs/linode-writers-formatting-guide) for more information regarding content and formatting.
+If you'd like to write for us, please apply via our [contributing page](https://linode.com/docs/contribute). Then, see the [Linode Writer's Formatting Guide](https://www.linode.com/docs/linode-writers-formatting-guide) for more information regarding content and formatting.


### PR DESCRIPTION
Based on the relative path, I assume you wanted this to point to the formatted version on the site, not the version on GitHub. As of now, it doesn't go anywhere.