### PR TITLE
Update obtain-a-commercially-signed-ssl-certificate-on-debian-and-ubu…

### DIFF
--- a/docs/security/ssl/obtain-a-commercially-signed-ssl-certificate-on-debian-and-ubuntu.md
+++ b/docs/security/ssl/obtain-a-commercially-signed-ssl-certificate-on-debian-and-ubuntu.md
@@ -27,7 +27,7 @@ If hosting multiple websites with commercial SSL certificates on the same IP add
 
 - Complete our [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/securing-your-server) guides.
 
-- Ensure that your packages are up to date by running `apt-get update && apt-get upgrade`.
+- Ensure that your packages are up to date by running `apt-get update`, and then `apt-get upgrade`.
 
 {: .note}
 >


### PR DESCRIPTION
…ntu.md

A bonehead like me could try `sudo apt-get update && apt-get upgrade`, and then spend some time wondering why this gave a 13: Permission denied error on my Ubuntu 16.04 LTS Linode.  I think the problem is that I needed to put another sudo after the &&.  It worked later like that.  But running the commands separately is probably a better idea for the caliber of people who use these guides :)