### PR TITLE
[UPDATE] Removed blank provide-encrypted-resource-access-using-ssl-certificates-on-nginx.md

### DIFF
--- a/docs/websites/ssl/provide-encrypted-resource-access-using-ssl-certificates-on-nginx.md
+++ b/docs/websites/ssl/provide-encrypted-resource-access-using-ssl-certificates-on-nginx.md
@@ -1,1 +1,0 @@
-../../security/ssl/provide-encrypted-resource-access-using-ssl-certificates-on-nginx.md


### PR DESCRIPTION
This is a blank markdown file under `websites/ssl/provide-encrypted-resource-access-using-ssl-certificates-on-nginx.md`. File has been renamed recently. However, the alias direct the previous name under `/security/ssl/provide-encrypted-resource-access-using-ssl-certificates-on-nginx/`

Reference:
https://raw.githubusercontent.com/linode/docs/master/docs/security/ssl/Enable-SSL-for-HTTPS-Configuration-on-Nginx.md