### PR TITLE
Use GiB like Linode Manager does

### DIFF
--- a/docs/platform/how-to-use-block-storage-with-your-linode.md
+++ b/docs/platform/how-to-use-block-storage-with-your-linode.md
@@ -12,7 +12,7 @@ published: 'Friday, June 16, 2017'
 title: How to Use Block Storage with Your Linode
 ---
 
-Linode's block storage service allows you to attach additional storage volumes to your Linode. A single volume can range from 1 to 1024 gigabytes in size and costs $0.10 per GB. They can be partitioned however you like and can accommodate any filesystem type you choose. Up to eight volumes can be attached to a single linode, be it new or currently-existing, so you do not need to recreate your server to add a block storage volume.
+Linode's block storage service allows you to attach additional storage volumes to your Linode. A single volume can range from 1 to 1024 gigabytes in size and costs $0.10 per GiB. They can be partitioned however you like and can accommodate any filesystem type you choose. Up to eight volumes can be attached to a single linode, be it new or currently-existing, so you do not need to recreate your server to add a block storage volume.
 
 
 {: .caution}
@@ -34,7 +34,7 @@ This guide assumes a Linode with the root disk mounted as `/dev/sda` and swap sp
 
     [![Linode Manager create a volume](/docs/assets/bs-manager-create-new-volume-small.png)](/docs/assets/bs-manager-create-new-volume.png)
 
-2.  Assign the block storage volume a label and size. The label can be up to 32 characters long and consist only of ASCII characters `a-z; 0-9.-_`. The maximum volume size is 1024 GB (1 terabyte). When finished, click *Add this Volume!*:
+2.  Assign the block storage volume a label and size. The label can be up to 32 characters long and consist only of ASCII characters `a-z; 0-9.-_`. The maximum volume size is 1024 GiB (1 terabyte). When finished, click *Add this Volume!*:
 
     [![Linode Manager add a volume](/docs/assets/bs-add-a-volume.png)](/docs/assets/bs-add-a-volume.png)
 
@@ -118,7 +118,7 @@ This guide assumes a Linode with the root disk mounted as `/dev/sda` and swap sp
 
 2.  Click the **Edit** option for the volume you want to resize.
 
-3.  Enter the new volume size. The minimum size is 1 GB and maximum is 1024 GB. Then click **Save Changes**.
+3.  Enter the new volume size. The minimum size is 1 GiB and maximum is 1024 GiB. Then click **Save Changes**.
 
       [![Linode Manager edit volume](/docs/assets/bs-resize-volume-small.png)](/docs/assets/bs-resize-volume.png)
 


### PR DESCRIPTION
In the screenshots included in the guide we write GiB but the docs say GB. This inconsistency is confusing (and inaccurate).