### PR TITLE
Added Note In Creating Folder public_html and logs

### DIFF
--- a/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04.md
+++ b/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04.md
@@ -136,6 +136,9 @@ You can set up virtual hosts several ways; however, below is the recommended met
 
         sudo mkdir -p /var/www/html/example.com/{public_html,logs}
 
+    {: .note }
+    > Make sure that you do not put space after comma between `public_html` and `logs` because it will create a folder named `{public_html,` and will cause an error when you will reload Apache.
+
 4.  Link your virtual host file from the `sites-available` directory to the `sites-enabled` directory:
 
         sudo a2ensite example.com.conf


### PR DESCRIPTION
I've added a note not to put space after comma in the command of making the folders public_html and logs. Beginners like me may accidentally put space after the comma, which will cause an error in reloading Apache. With the note, reader are made aware before they bump into an error that would discourage them from continuing the configuration.