### PR TITLE
Adds directory indices to vhost snippet.

### DIFF
--- a/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04.md
+++ b/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04.md
@@ -120,6 +120,8 @@ You can set up virtual hosts several ways; however, below is the recommended met
                 ServerAlias www.example.com
                 ServerAdmin webmaster@localhost
                 DocumentRoot /var/www/html/example.com/public_html
+		
+		DirectoryIndex index.html index.php
 
                 ErrorLog /var/www/html/example.com/logs/error.log
                 CustomLog /var/www/html/example.com/logs/access.log combined


### PR DESCRIPTION
I've followed this guide a few times, and always end up with errors because Apache shows me a directory listing instead of index.php or index.html. I thought I'd contribute this upstream instead of keeping it in my Linode setup notes.