### PR TITLE
Removed circular alias references

### DIFF
--- a/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions.md
+++ b/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions.md
@@ -5,7 +5,7 @@ author:
 description: Using GNU Screen to Manage Persistent Terminal Sessions
 keywords: 'screen,gnu screen,terminal,console,linux'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-alias: ['linux-tools/utilities/screen/', 'tools-reference/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/']
+alias: ['linux-tools/utilities/screen/']
 modified: Monday, January 13th, 2014
 modified_by:
   name: Linode

--- a/docs/web-servers/apache/apache-2-web-server-on-ubuntu-8-04-lts-hardy.md
+++ b/docs/web-servers/apache/apache-2-web-server-on-ubuntu-8-04-lts-hardy.md
@@ -6,7 +6,7 @@ author:
 description: 'Instructions for getting started with the Apache web server on Ubuntu 8.04 LTS (Hardy).'
 keywords: 'apache,apache ubuntu 8.04,apache ubuntu hardy,web server,apache on ubuntu,apache hardy'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-alias: ['web-servers/apache/installation/ubuntu-8-04-hardy/','web-servers/apache/apache-2-web-server-on-ubuntu-8-04-lts-hardy/','websites/apache/apache-2-web-server-on-ubuntu-8-04-lts-hardy/']
+alias: ['web-servers/apache/installation/ubuntu-8-04-hardy/','websites/apache/apache-2-web-server-on-ubuntu-8-04-lts-hardy/']
 modified: Tuesday, May 17th, 2011
 modified_by:
   name: Linode


### PR DESCRIPTION
These were never found via curl or scrapy because it still returned 200. Moreover, a symlink with the same path as an alias would still work because symlinks seem to take precedence with redirection. Removals might not be exhaustive...