### PR TITLE
Update NixOS installation guide for NixOS 17.09

### DIFF
--- a/docs/tools-reference/custom-kernels-distros/install-nixos-on-linode.md
+++ b/docs/tools-reference/custom-kernels-distros/install-nixos-on-linode.md
@@ -66,7 +66,14 @@ In your browser, navigate to the [NixOS download page](https://nixos.org/nixos/d
 
 [Boot your Linode into rescue mode](/docs/troubleshooting/rescue-and-rebuild#booting-into-rescue-mode) with the installer disk mounted as `/dev/sda`. Once in rescue mode, run the following command, replacing the URL with the latest 64-bit minimal installation image copied from the [NixOS download page](https://nixos.org/nixos/download.html). This example installs NixOS 17.03:
 
-    curl https://d3g5gsiof5omrk.cloudfront.net/nixos/17.03/nixos-17.03.1437.a2c7482319/nixos-minimal-17.03.1437.a2c7482319-x86_64-linux.iso | dd of=/dev/sda
+    # Bind the URL you grabbed from the download page to a bash variable
+    iso=<URL for nixos download>
+
+    # Update SSL certificates to allow HTTPS connections
+    update-ca-certificates
+
+    # Download the ISO and write it to the installer disk
+    curl $iso | dd of=/dev/sda
 
 ## Install NixOS
 

--- a/docs/tools-reference/custom-kernels-distros/install-nixos-on-linode.md
+++ b/docs/tools-reference/custom-kernels-distros/install-nixos-on-linode.md
@@ -1,6 +1,5 @@
 ---
-author:
-  name: Andrew Miller
+author: name: Andrew Miller
   email: docs@linode.com
 published: 'Friday, June 16, 2017'
 description: 'Install NixOS, which is known for its declarative approach to configuration management, configuration rollback, reliability, and for being DevOps-friendly.'
@@ -141,8 +140,7 @@ When GRUB detects a partitionless disk, it will warn about the unreliability of 
 
 Set the timeout for GRUB to be lengthy enough to accommodate LISH connection delays. The following hardware configuration example sets a 10 second timeout:
 
-    boot.loader.grub.device = "/dev/sda";
-    boot.loader.grub.forceInstall = true;
+    boot.loader.grub.device = "nodev";
     boot.loader.timeout = 10;
 
 ### Edit NixOS Configuration


### PR DESCRIPTION
NixOS 17.09 nicknamed "Hummingbird" was released so I went through this guide to ensure that it still worked.

Everything in the guide still worked, but running through it again I found that downloading the installer could use a touch up. I also realized there was a better way to configure grub to get only the configuration file.

These are small changes and the guide is still good, but this will make the user experience a little smoother.