### PR TITLE
Add "nameserver" options to config file

### DIFF
--- a/docs/networking/create-a-socks5-proxy-server-with-shadowsocks-on-ubuntu-and-centos7.md
+++ b/docs/networking/create-a-socks5-proxy-server-with-shadowsocks-on-ubuntu-and-centos7.md
@@ -97,6 +97,7 @@ Since there is currently no Shadowsocks package available for Ubuntu or CentOS, 
  | timeout | Connection timeout in seconds. The default value should be sufficient here. | User determined |
  | method | Encryption method. Using AEAD algorithms is recommended. | See [Stream Ciphers](https://shadowsocks.org/en/spec/Stream-Ciphers.html) and [AEAD Ciphers](https://shadowsocks.org/en/spec/AEAD-Ciphers.html) |
  | fast_open | Reduces latency when turned on. Can only be used with kernel versions 3.7.1 or higher. Check your kernel version with `umame -r`. | true, false |
+ | nameserver | Name servers for internal DNS resolver. | User determined |
 
 {: .file}
 **/etc/shadowsocks/shadowsocks.json**
@@ -109,7 +110,8 @@ Since there is currently no Shadowsocks package available for Ubuntu or CentOS, 
       "password":"mypassword",
       "timeout":300,
       "method":"aes-256-gcm",
-      "fast_open": true
+      "fast_open": true,
+      "nameserver":"8.8.8.8"
   }
   ~~~
 


### PR DESCRIPTION
The "nameserver" option is used inside the ss-server(shadowsocks server) to resolve hostname requested from client,
skipping it may result very slow response from the server.

For example, I got a big improve after set this option: from 3xxxms to 5xxms.