### PR TITLE
Added expiryDate to truncated documents.

### DIFF
--- a/docs/databases/hadoop/install-configure-run-spark-on-top-of-hadoop-yarn-cluster.md
+++ b/docs/databases/hadoop/install-configure-run-spark-on-top-of-hadoop-yarn-cluster.md
@@ -41,12 +41,12 @@ Spark can run as a standalone cluster manager, or by taking advantage of dedicat
 
 4. Run `jps` on each of the nodes to confirm that HDFS and YARN are running. If they are not, start the services with:
 
-       start-dfs.sh
-       start-yarn.sh
+        start-dfs.sh
+        start-yarn.sh
 
-{: .note}
->
-> This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, see the [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+{{< note >}}
+ This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, see the [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+{{< / note >}}
 
 ## Download and Install Spark Binaries
 
@@ -71,7 +71,7 @@ PATH=/home/hadoop/spark/bin:$PATH
 
     **For RedHat/Fedora/CentOS systems:**
 
-{{< file-excerpt "/home/hadoop/.profile" shell >}}
+    {{< file-excerpt "/home/hadoop/.profile" shell >}}
 pathmunge /home/hadoop/spark/bin
 {{< /file-excerpt >}}
 
@@ -91,7 +91,7 @@ export LD_LIBRARY_PATH=/home/hadoop/hadoop/lib/native:$LD_LIBRARY_PATH
 
 3. Rename the spark default template config file:
 
-       mv $SPARK_HOME/conf/spark-defaults.conf.template $SPARK_HOME/conf/spark-defaults.conf
+        mv $SPARK_HOME/conf/spark-defaults.conf.template $SPARK_HOME/conf/spark-defaults.conf
 
 4. Edit `$SPARK_HOME/conf/spark-defaults.conf` and set `spark.master` to `yarn`:
 
@@ -119,8 +119,10 @@ Allocation of Spark containers to run in YARN containers may fail if memory allo
 
 Be sure to understand how Hadoop YARN manages memory allocation before editing Spark memory settings so that your changes are compatible with your YARN cluster's limits.
 
-{:.note}
-> See the memory allocation section of the [Install and Configure a 3-Node Hadoop Cluster](docs/databases/hadoop/install-and-configure-hadoop-cluster) guide for more details on managing your YARN cluster's memory.
+{{< note >}}
+See the memory allocation section of the [Install and Configure a 3-Node Hadoop Cluster](docs/databases/hadoop/install-and-configure-hadoop-cluster) guide for more details on managing your YARN cluster's memory.
+{{< / note >}}
+
 
 ### Give Your YARN Containers Maximum Allowed Memory
 
@@ -148,8 +150,9 @@ spark.driver.memory    512m
 
   - Use the `--driver-memory` parameter to specify the amount of memory requested by `spark-submit`. See the following section about application submission for examples.
 
-    {:.note}
-    > Values given from the command line will override whatever has been set in `spark-defaults.conf`.
+    {{< note >}}
+Values given from the command line will override whatever has been set in `spark-defaults.conf`.
+{{< /note >}}
 
 ### Configure the Spark Application Master Memory Allocation in Client Mode
 
@@ -157,7 +160,7 @@ In client mode, the Spark driver will not run on the cluster, so the above confi
 
 Set the amount of memory allocated to Application Master in client mode with `spark.yarn.am.memory` (default to `512M`)
 
-    {{< file-excerpt "$SPARK_HOME/conf/spark-defaults.conf" conf >}}
+{{< file-excerpt "$SPARK_HOME/conf/spark-defaults.conf" conf >}}
 spark.yarn.am.memory    512m
 {{< /file-excerpt >}}
 
@@ -170,14 +173,15 @@ The Spark Executors' memory allocation is calculated based on two parameters ins
   - `spark.executor.memory`: sets the base memory used in calculation
   - `spark.yarn.executor.memoryOverhead`: is added to the base memory. It defaults to 7% of base memory, with a minimum of `384MB`
 
-{:.note}
-> Make sure that Executor requested memory, **including** overhead memory, is below the YARN container maximum size, otherwise the Spark application won't initialize.
+{{< note >}}
+Make sure that Executor requested memory, **including** overhead memory, is below the YARN container maximum size, otherwise the Spark application won't initialize.
+{{< /note >}}
 
 Example: for `spark.executor.memory` of 1Gb , the required memory is 1024+384=1408MB. For 512MB, the required memory will be 512+384=896MB
 
 To set executor memory to `512MB`, edit `$SPARK_HOME/conf/spark-defaults.conf` and add the following line:
 
-    {{< file-excerpt "$SPARK_HOME/conf/spark-defaults.conf" conf >}}
+{{< file-excerpt "$SPARK_HOME/conf/spark-defaults.conf" conf >}}
 spark.executor.memory          512m
 {{< /file-excerpt >}}
 
@@ -210,7 +214,7 @@ spark.eventLog.dir hdfs://node-master:9000/spark-logs
 
 2. Create the log directory in HDFS:
 
-       hdfs dfs -mkdir /spark-logs
+        hdfs dfs -mkdir /spark-logs
 
 3. Configure History Server related properties in `$SPARK_HOME/conf/spark-defaults.conf`:
 
@@ -225,13 +229,13 @@ spark.history.ui.port             18080
 
 4. Run the History Server:
 
-       $SPARK_HOME/sbin/start-history-server.sh
+        $SPARK_HOME/sbin/start-history-server.sh
 
 5. Repeat steps from previous section to start a job with `spark-submit` that will generate some logs in the HDFS:
 
 6.  Access the History Server by navigating to http://node-master:18080 in a web browser:
 
-    ![Screenshot of Spark History Server](/docs/assets/spark/spark-history-server-wide.png "Screenshot of Spark History Server")
+    ![Screenshot of Spark History Server](/docs/assets/spark/spark-history-server-wide.png)
 
 ## Run the Spark Shell
 

--- a/docs/databases/mysql/standalone-mysql-server.md
+++ b/docs/databases/mysql/standalone-mysql-server.md
@@ -4,20 +4,22 @@ author:
   name: Stan Schwertly
   email: docs@linode.com
 description: 'Deploying a standalone MySQL database server on a separate Linode for increased application performance.'
-keywords: ["mysql", "standalone myql", "separate mysql", "wordpress"]
+keywords: 'mysql,standalone myql,separate mysql,wordpress'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2011-04-29
+modified: Friday, April 29th, 2011
 modified_by:
   name: Linode
-published: 2009-09-30
+published: 'Wednesday, September 30th, 2009'
+expiryDate: 2013-04-29
 title: Standalone MySQL Server
 ---
 
 In some kinds of deployments, particularly where rich dynamic applications rely on a large database, separating the database server from the application server can permit your application to scale and accommodate a much larger user base. Designating a separate server to be used solely by MySQL will allow the application's web server to serve content more efficiently, while the database server will be able to respond more quickly.
 
-As a result, these database servers can more effectively support deployments with high traffic loads. This may help you achieve higher performance for a range of applications, from popular packages such as [WordPress](/docs/web-applications/cms-guides/wordpress/) and [Drupal](/docs/web-applications/cms-guides/drupal/) to custom applications written in [Ruby on Rails](/docs/frameworks/) and [Django](/content/frameworks/).
+As a result, these database servers can more effectively support deployments with high traffic loads. This may help you achieve higher performance for a range of applications, from popular packages such as [WordPress](/docs/web-applications/cms-guides/wordpress/) and [Drupal](/docs/web-applications/cms-guides/drupal/) to custom applications written in [Ruby on Rails](/docs/frameworks/) and [Django](/docs/frameworks/).
 
-# Prerequisites
+Prerequisites
+-------------
 
 In this guide we will be using two Linodes. Note that this is different than simply deploying a second configuration profile on your existing Linode account, as both servers will need to be running at the same time. We're assuming you have followed the [getting started](/docs/getting-started/) guide for both Linodes.
 
@@ -26,21 +28,37 @@ In this guide we will be using two Linodes. Note that this is different than sim
 
 Also, you will want to configure aliases for the private IP address of each Linode. You can follow the [Linux Static IP Configuration](/docs/networking/configuring-static-ip-interfaces) guide for assistance with this. **It is important to note that both Linodes should be in the same data center** for private networking to work. This enables the servers to communicate without having the traffic count against your monthly bandwidth quota. It is necessary to reboot both Linodes after configuring the private IP addresses.
 
-# Edit /etc/hosts
+Edit /etc/hosts
+---------------
 
 You will want to create hostnames for each machine so you can keep track of them later. This also saves work, should you find yourself in a situation where you need to change the IP address of the server. Edit the `/etc/hosts` file to include the **private** IP addresses of each Linode. Use the following excerpt from an example `/etc/hosts` file as an example:
 
-{{< file "/etc/hosts" ini >}}
-bind-address = mysql
+{: .file }
+/etc/hosts
 
-{{< /file >}}
+> 127.0.0.1 localhost 192.168.192.168 mysql.example.com mysql 192.168.192.169 app.example.com app
 
+Remember to replace `192.168.192.168` and `192.168.192.169` with the actual private IP addresses.
+
+While this step is optional, configuring `hosts` entries will allow you to avoid hard coding application configurations to specific IP addresses. You will be able to quickly migrate your application and database servers to alternate servers if you ever have to change your IP addresses.
+
+Configuring the MySQL Server
+----------------------------
+
+The next step is to modify the `/etc/mysql/my.cnf` file on your MySQL server to listen on your private IP address. Using your favorite editor, open the `/etc/mysql/my.cnf` file and insert the hostname of the MySQL database. For this example, the MySQL database hostname is `mysql`. Locate the `bind-address` line:
+
+{: .file-excerpt }
+/etc/mysql/my.cnf
+:   ~~~ ini
+    bind-address = mysql
+    ~~~
 
 You can alternatively use the private IP address. Save the file, and run the following command to restart the MySQL daemon:
 
     /etc/init.d/mysql restart
 
-# Granting Database Access
+Granting Database Access
+------------------------
 
 On the dedicated database server, you will need to create a database username and password with access rights. This is possible through the MySQL prompt. Issue the following command:
 
@@ -54,7 +72,8 @@ This will provide a MySQL command line. Issue the following commands, substituti
 
 At this stage your application can successfully access the remote database, and you're ready to begin using the database server.
 
-# Using the Database Server
+Using the Database Server
+-------------------------
 
 From this point on, everything is configured and your database server is ready to accept a connection from your web server. You should now be able to point your application at the MySQL server without incident. It is important to remember that when setting up web applications to work with a remote MySQL server you must create a user with rights to the remote system (as shown above).
 
@@ -62,18 +81,19 @@ Using MySQL on a separate database server is very similar to running a local dat
 
 For example, in [WordPress](/docs/web-applications/cms-guides/wordpress/) database settings are contained in the `wp-config.php` file, and the hostname is specified in the following format:
 
-{{< file-excerpt "wp-config.php" php >}}
-/** MySQL hostname */
-define('DB_HOST', 'mysql');
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+wp-config.php
+:   ~~~ php
+    /** MySQL hostname */
+    define('DB_HOST', 'mysql');
+    ~~~
 
 Note that the method for setting the hostname varies from application to application. Furthermore, you can substitute the specific IP address of the database server, rather than using the hostname as configured in `/etc/hosts` above.
 
 Also consider referencing the external [MySQL](http://www.mysql.com/) website for MySQL specific queries and related help.
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/databases/postgresql/fedora-14.md
+++ b/docs/databases/postgresql/fedora-14.md
@@ -4,34 +4,137 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Using the PostgreSQL relational database server with Fedora 14.'
-keywords: ["postgresql fedora 14", "postgresql database", "relational database"]
+keywords: 'postgresql fedora 14,postgresql database,relational database'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2011-04-29
+modified: Friday, April 29th, 2011
 modified_by:
   name: Linode
-published: 2010-12-08
+published: 'Wednesday, December 8th, 2010'
+expiryDate: 2013-04-29
 title: Use PostgreSQL Relational Databases on Fedora 14
 ---
 
 The [PostgreSQL](http://www.postgresql.org/) relational database system is a fast, scalable, and standards-compliant open source database platform. This guide will help you install and configure PostgreSQL on Fedora 14. We assume you've followed the steps detailed in our [getting started guide](/docs/getting-started/), and that you're logged into your Linode as root via SSH.
 
-# System Configuration
+System Configuration
+--------------------
 
 Make sure your `/etc/hosts` file has proper entries, similar to the ones shown below. Replace "12.34.56.78" with your Linode's public address, "servername" with your short hostname, and "mydomain.com" with your system's domain name.
 
-{{< file "/etc/hosts" >}}
-local all all ident
+{: .file }
+/etc/hosts
 
-{{< /file >}}
+> 127.0.0.1 localhost.localdomain localhost 12.34.56.78 servername.mydomain.com servername
 
+Set your system's hostname by issuing the following commands. Replace "servername" with your system's short hostname.
+
+    echo "HOSTNAME=servername" >> /etc/sysconfig/network
+    hostname "servername"
+
+Install PostgreSQL
+------------------
+
+Make sure your system is up to date by issuing the following command:
+
+    yum update
+
+Issue the following command to install PostgreSQL and required dependencies:
+
+    yum install postgresql postgresql-server
+
+The current version of the database server will be installed, along with several supporting packages. Start the database server with the following commands:
+
+    chkconfig postgresql on
+    /etc/init.d/postgresql initdb
+    service postgresql start
+
+Configure PostgreSQL
+--------------------
+
+### Set the Postgresql Password
+
+Set a password for the "postgres" user by issuing the following command (be sure to substitute your postgres password for "CHANGME" below):
+
+    passwd postgres
+    su - postgres
+    psql -d template1 -c "ALTER USER postgres WITH PASSWORD 'CHANGEME';"
+
+You should pick a password consisting of numbers, letters, and non-alphanumeric characters. As with other account passwords, it should be a minimum of eight characters in length.
+
+### Create a Database
+
+Create a database and connect to it with `psql` by issuing the following commands:
+
+    createdb mytestdb
+    psql mytestdb
+
+You should see output similar to the following:
+
+    -bash-4.1$ psql mytestdb
+    psql (8.4.5)
+    Type "help" for help.
+
+    mytestdb=#
+
+This is the PostgreSQL client shell; you may use it to issue SQL statements. To see a list of available commands, use the following command in the shell:
+
+    \h
+
+To get help on a specific command enter it after `\h`, as shown below for the "SELECT" command:
+
+    \h SELECT
+
+### Create a Database Table
+
+To create a table in your test database called "employees", issue the following command:
+
+    CREATE TABLE employees (employee_id int, first_name varchar, last_name varchar);
+
+To insert a record into the table, you would issue a statement like this:
+
+    INSERT INTO employees VALUES (1, 'Jack', 'Sprat');
+
+To see the contents of the "employees" table, you would issue a SELECT statement similar to the following:
+
+    SELECT * FROM employees;
+
+This would produce output similar to the following:
+
+    mytestdb=# SELECT * FROM employees;
+     employee_id | first_name | last_name
+    -------------+------------+-----------
+               1 | Jack       | Sprat
+    (1 row)
+
+To exit the `psql` shell, issue this command:
+
+    \q
+
+### Create PostgreSQL Users (Roles)
+
+PostgreSQL refers to users as "roles", which may have different privileges on your databases. If a user is classified as a "superuser" it will have administrative access to the database system. To add a new user to PostgreSQL, issue the following command as the "postgres" user:
+
+    createuser alison --pwprompt
+
+You will be asked to specify several values for the new user. To delete this user, issue the following command:
+
+    dropuser alison
+
+By default, PostgreSQL uses `ident` authentication. This means database connections will be granted to local system users that own or have privileges on the database being connected to. Such authentication is useful in cases where a particular system user will be running a program (local scripts, CGI/FastCGI processes owned by separate users, etc). However, you may wish to change this behavior to require passwords. To do so, edit the file `/var/lib/pgsql/data/pg_hba.conf` as root or the postgres user. Find the following line:
+
+{: .file-excerpt }
+/var/lib/pgsql/data/pg\_hba.conf
+:   ~~~
+    local all all ident
+    ~~~
 
 Change it to the following to use password authentication:
 
-{{< file-excerpt "/var/lib/pgsql/data/pg\\_hba.conf" >}}
-local all all md5
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+/var/lib/pgsql/data/pg\_hba.conf
+:   ~~~
+    local all all md5
+    ~~~
 
 As root, restart the Postgresql service:
 
@@ -53,14 +156,16 @@ To use the database "mytestdb" as "alison", issue the following command:
 
 You will be prompted to enter the password for the "alison" user and given `psql` shell access to the database.
 
-# Secure Remote Database Access
+Secure Remote Database Access
+-----------------------------
 
 PostgreSQL listens for connections on localhost, and it is not advised to reconfigure it to listen on public IP addresses. If you would like to access your databases remotely using a graphical tool, please follow one of these guides:
 
 -   [Securely Manage Remote PostgreSQL Servers with pgAdmin on Windows](/docs/databases/postgresql/pgadmin-windows)
 -   [Securely Manage Remote PostgreSQL Servers with pgAdmin on Mac OS X](/docs/databases/postgresql/pgadmin-macos-x)
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/development/frameworks/symfony-on-centos-5.md
+++ b/docs/development/frameworks/symfony-on-centos-5.md
@@ -3,22 +3,24 @@ author:
   name: Ozan Yerli
   email: oyerli@gmail.com
 description: 'Installing and configuring Symfony for developing PHP applications on your CentOS 5 Linode.'
-keywords: ["cakephp", "cakephp debian", "php framework", "debian", "develop php"]
+keywords: 'cakephp,cakephp debian,php framework,debian,develop php'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['frameworks/symfony/','websites/frameworks/symfony-on-centos-5/']
-modified: 2013-09-27
+alias: ['frameworks/symfony/','websites/frameworks/symfony-on-centos-5/']
+modified: Friday, September 27th, 2013
 modified_by:
   name: Linode
-published: 2010-06-08
+published: 'Tuesday, June 8th, 2010'
+expiryDate: 2015-09-27
 title: Symfony on CentOS 5
 deprecated: true
 ---
 
 Symfony is a PHP web application framework, providing the classes and tools required to build and enhance both simple and complex applications. Featuring easy AJAX integration, an admin interface generator, and more, Symfony has become a very popular choice for web application development.
 
-Before installing Symfony, it is assumed that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/content/using-linux/administration-basics).
+Before installing Symfony, it is assumed that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/docs/using-linux/administration-basics).
 
-# Basic System Configuration
+Basic System Configuration
+--------------------------
 
 First, update all of the base packages:
 
@@ -34,19 +36,64 @@ Since CentOS does not include the latest version of PHP 5.2 (which is required f
 
 Edit the file `/etc/yum.repos.d/webtatic.repo`. Under `[webtatic]` add the following line:
 
-{{< file-excerpt "/etc/yum.repos.d/webtatic.repo" ini >}}
-short_open_tag = On
+{: .file-excerpt }
+/etc/yum.repos.d/webtatic.repo
 
-{{< /file-excerpt >}}
+> exclude=php\*5.3\*
 
+This will ensure that no PHP 5.3 packages will be installed, as Symfony does not use any features of PHP 5.3.
+
+Install Required Packages
+-------------------------
+
+Install the Apache web server with devel package:
+
+    yum --enablerepo=webtatic install httpd httpd-devel
+
+Install the MySQL database server:
+
+    yum --enablerepo=webtatic install mysql mysql-server
+
+Install PHP 5.2 with the packages required for the Symfony:
+
+    yum --enablerepo=webtatic install php php-mysql php-pear php-devel php-xml php-posix php-mbstring
+
+Install the compiler packages, as we will need them for the installation of the APC accelerator:
+
+    yum install gcc
+
+Install the APC accelerator using PECL:
+
+    pecl install apc
+
+Answer "yes" to all questions. After the installation complete, execute the following command to add the APC module to the web server:
+
+    echo extension=apc.so > /etc/php.d/apc.ini
+
+Set the MySQL server to start on boot and start it:
+
+    /sbin/chkconfig --levels 235 mysqld on
+    service mysqld start
+
+Set the root password for the MySQL server and apply the security necessities:
+
+    mysql_secure_installation
+
+Edit /etc/php.ini and find the following line:
+
+{: .file-excerpt }
+/etc/php.ini
+:   ~~~ ini
+    short_open_tag = On
+    ~~~
 
 Replace it with this line:
 
-{{< file-excerpt "/etc/php.ini" ini >}}
-short_open_tag = Off
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+/etc/php.ini
+:   ~~~ ini
+    short_open_tag = Off
+    ~~~
 
 Set the web server to start on boot and start it:
 
@@ -60,7 +107,8 @@ Download the Symfony system configuration check file and run it:
 
 You should get "OK" for all the tests.
 
-# Create Your First Symfony Project
+Create Your First Symfony Project
+---------------------------------
 
 Create a project folder under `/home`. We will use sfproject as our project name:
 
@@ -103,25 +151,25 @@ Now, we need to configure the web server to serve our new project.
 
 Edit `/etc/httpd/conf/httpd.conf` and add at the end:
 
-{{< file-excerpt "/etc/httpd/conf/httpd.conf" apache >}}
-NameVirtualHost *:80
-<VirtualHost *:80>
-  DocumentRoot "/home/sfproject/web"
-  DirectoryIndex index.php
-  <Directory "/home/sfproject/web">
-    AllowOverride All
-    Allow from All
-  </Directory>
+{: .file-excerpt }
+/etc/httpd/conf/httpd.conf
+:   ~~~ apache
+    NameVirtualHost *:80
+    <VirtualHost *:80>
+      DocumentRoot "/home/sfproject/web"
+      DirectoryIndex index.php
+      <Directory "/home/sfproject/web">
+        AllowOverride All
+        Allow from All
+      </Directory>
 
-  Alias /sf /home/sfproject/lib/vendor/symfony/data/web/sf
-  <Directory "/home/sfproject/lib/vendor/symfony/data/web/sf">
-    AllowOverride All
-    Allow from All
-  </Directory>
-</VirtualHost>
-
-{{< /file-excerpt >}}
-
+      Alias /sf /home/sfproject/lib/vendor/symfony/data/web/sf
+      <Directory "/home/sfproject/lib/vendor/symfony/data/web/sf">
+        AllowOverride All
+        Allow from All
+      </Directory>
+    </VirtualHost>
+    ~~~
 
 Restart the web server:
 
@@ -129,7 +177,8 @@ Restart the web server:
 
 Using your browser, browse to your Linode's IP address. You should now see the Symfony Project Created page. From now on, you can easily follow the [official Symfony tutorial](http://www.symfony-project.org/jobeet/1_4/Doctrine/en/).
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-debian-6-squeeze.md
+++ b/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-debian-6-squeeze.md
@@ -3,20 +3,22 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Use system user accounts, postfix, and dovecot to provide'
-keywords: ["postfix", "dovecot", "system users", "email"]
+keywords: 'postfix,dovecot,system users,email'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['email/postfix/dovecot-system-users-debian-6-squeeze/']
-modified: 2013-09-25
+alias: ['email/postfix/dovecot-system-users-debian-6-squeeze/']
+modified: Wednesday, September 25th, 2013
 modified_by:
   name: Linode
-published: 2011-02-17
+published: 'Thursday, February 17th, 2011'
+expiryDate: 2013-09-25
 title: 'Postfix, Dovecot, and System User Accounts on Debian 6 (Squeeze)'
 deprecated: true
 ---
 
 Postfix is a popular mail transfer agent or "MTA". This document will allow you to create a mail system using Postfix as the core component and aims to provide a simple email solution that uses system user accounts for authentication and mail delivery and Dovecot for remote mailbox access. If you do not need to authenticate to Postfix for SMTP service or use POP or IMAP to download email, you may consider using the [Basic Email Gateway with Postfix](/docs/email/postfix/gateway-debian-6-squeeze) document to install a more minimal email system. If you plan to host a larger number of domains and email aliases, you may want to consider a more sophisticated hosting solution like the [Email Server with Postfix, MySQL and Dovecot](/docs/email/postfix/).
 
-# Set the Hostname
+Set the Hostname
+----------------
 
 Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
@@ -25,7 +27,8 @@ Before you begin installing and configuring the components described in this gui
 
 The first command should show your short hostname, and the second should show your fully qualified domain name (FQDN).
 
-# Install Software
+Install Software
+----------------
 
 Issue the following commands to install any outstanding package updates:
 
@@ -44,25 +47,30 @@ The next prompt will ask for the system mail name. This should correspond to the
 
 [![Selecting the Postfix system mail name.](/docs/assets/86-postfix-courier-mysql-02-mail-server-type-3.png)](/docs/assets/86-postfix-courier-mysql-02-mail-server-type-3.png)
 
-# SASL Authentication
+SASL Authentication
+-------------------
 
 Edit the `/etc/default/saslauthd` file to allow the SASL authentication daemon to start. Uncommon or add the following line:
 
-{{< file-excerpt "/etc/default/saslauthd" ini >}}
-START=yes
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/default/saslauthd
+:   ~~~ ini
+    START=yes
+    ~~~
 
 Create the `/etc/postfix/sasl/smtpd.conf` file, and insert the following line:
 
-{{< file-excerpt "/etc/postfix/sasl/smtpd.conf" >}}
-pwcheck\_method: saslauthd
-{{< /file-excerpt >}}
+{: .file }
+/etc/postfix/sasl/smtpd.conf
+
+> pwcheck\_method: saslauthd
 
 Issue the following command to start the SASL daemon for the first time:
 
     /etc/init.d/saslauthd start
 
-# Configure SSL
+Configure SSL
+-------------
 
 SSL or TLS provides a method of encrypting the communication between your remote users and your mail servers. While this does not encrypt your email messages from end to end, it does ensure that your login credentials are transmitted securely and that communications are secure between your client machine and the email server.
 
@@ -76,37 +84,36 @@ Mail clients may have an issue with certificates generated in this manner becaus
 
 You can use any SSL certificate with Postfix. If you already have a commercial certificate or another SSL certificate for your web server, you can use these `.pem` and `.key` files.
 
-# Postfix
+Postfix
+-------
+
 ### Configure Outbound Mail Service
 
-smtp_use_tls = yes
-smtpd_use_tls = yes
-smtp_tls_note_starttls_offer = yes
-smtpd_tls_loglevel = 1
-smtpd_tls_received_header = yes
+Edit the `/etc/postfix/main.cf` file to edit or add the following lines:
 
-{{< file "/etc/postfix/main.cf" >}}
-smtpd_tls_cert_file=/etc/ssl/certs/postfix.pem
-smtpd_tls_key_file=/etc/ssl/private/postfix.key
+{: .file-excerpt }
+/etc/postfix/main.cf
+:   ~~~ ini
+    smtpd_tls_cert_file=/etc/ssl/certs/postfix.pem
+    smtpd_tls_key_file=/etc/ssl/private/postfix.key
 
-smtp_use_tls = yes
-smtpd_use_tls = yes
-smtp_tls_note_starttls_offer = yes
-smtpd_tls_loglevel = 1
-smtpd_tls_received_header = yes
+    smtp_use_tls = yes
+    smtpd_use_tls = yes
+    smtp_tls_note_starttls_offer = yes
+    smtpd_tls_loglevel = 1
+    smtpd_tls_received_header = yes
 
-smtpd_sasl_type = dovecot
-smtpd_sasl_path = private/auth
-smtpd_sasl_auth_enable = yes
+    smtpd_sasl_type = dovecot
+    smtpd_sasl_path = private/auth
+    smtpd_sasl_auth_enable = yes
 
-smtpd_sasl_security_options = noanonymous
-smtpd_sasl_local_domain = $myhostname
-smtpd_sasl_application_name = smtpd
-broken_sasl_auth_clients = yes
+    smtpd_sasl_security_options = noanonymous
+    smtpd_sasl_local_domain = $myhostname
+    smtpd_sasl_application_name = smtpd
+    broken_sasl_auth_clients = yes
 
-smtpd_recipient_restrictions = reject_unknown_sender_domain, reject_unknown_recipient_domain, reject_unauth_pipelining, permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination
-{{< /file >}}
-
+    smtpd_recipient_restrictions = reject_unknown_sender_domain, reject_unknown_recipient_domain, reject_unauth_pipelining, permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination
+    ~~~
 
 These settings make it possible for the SASL authentication process to interact with Postfix, and for Postfix to use the SSL certificate generated above. If you're using an SSL certificate with a different name, modify the first two lines of this configuration section.
 
@@ -122,13 +129,13 @@ Consider the [basic email gateway guide](/docs/email/postfix/gateway-debian-6-sq
 
 The above Postfix configuration makes it possible to *send* mail using postfix. If your server receives email, Postfix requires additional configuration to deliver mail locally. Edit the `main.cf` file to insert or modify the following configuration directives:
 
-{{< file-excerpt "/etc/postfix/main.cf" ini >}}
-myhostname = lollipop.example.com
-virtual_alias_maps = hash:/etc/postfix/virtual
-home_mailbox = mail/
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+/etc/postfix/main.cf
+:   ~~~ ini
+    myhostname = lollipop.example.com
+    virtual_alias_maps = hash:/etc/postfix/virtual
+    home_mailbox = mail/
+    ~~~
 
 Issue the following command to ensure that new user accounts have a `~/mail` directory:
 
@@ -140,48 +147,86 @@ Every existing user that receives email will also need to make their own `Maildi
 
 Create a `/etc/postfix/virtual` file to map incoming email addresses to their destinations. Consider the following example:
 
-{{< file "/etc/postfix/virtual" INI >}}
-protocols = imap imaps pop3 pop3s
-log_timestamp = "%Y-%m-%d %H:%M:%S "
-mail_privileged_group = mail
-ssl_cert_file = /etc/ssl/certs/postfix.pem
-ssl_key_file = /etc/ssl/private/postfix.key
-mail_location = maildir:~/mail:LAYOUT=fs:INBOX=~/mail/
+{: .file }
+/etc/postfix/virtual
 
-protocol imap {
-}
+> <username@example.com> username <username@example.net> username <username@example.com> username
+>
+> <fore@example.com> <foreman@example.com> <fore@example.net> <foreman@example.com> <fore@example.com> <foreman@example.com>
+>
+> <team@example.com> username, <foreman@example.com> <team@example.net> username, <foreman@example.com> <team@example.com> username, <foreman@example.com>
 
-protocol pop3 {
-    pop3_uidl_format = %08Xu%08Xv
-}
+Here, all mail sent to the three addresses beginning with the characters `username@` are delivered to the local user "username" and deposited to a Maildir in the `/home/username/mail/` directory. The three addresses that begin with the characters `fore@` are delivered to the email address `foreman@example.com`. The final set of three email addresses beginning with `team@` are both delivered locally and sent to the `foreman@example.com` email address.
 
-protocol managesieve {
-}
+You can add additional lines in the same format as the above to control how all incoming email is delivered to local or external destinations. Remember that incoming email has no firm relationship to the name of the user account.
 
-auth default {
-      mechanisms = plain login
-      passdb pam {
-      }
-      userdb passwd {
-      }
-      socket listen {
-        client {
-          path = /var/spool/postfix/private/auth
-          mode = 0660
-          user = postfix
-          group = postfix
-        }
-      }
+Edit the `/etc/alias` file to add the following line. This will to reroute all local mail delivered to the root user to another user account. In the following example, all mail delivered to `root` will be delivered to the `username` user's mail box.
+
+{: .file-excerpt }
+/etc/aliases
+
+> root: username
+
+When you have configured mail delivery issue the following command to recreate the aliases database, rebuild the virtual alias database, and restart the mail server:
+
+    postalias /etc/alias
+
+> postmap /etc/postfix/virtual /etc/init.d/postfix restart
+
+Dovecot
+-------
+
+Dovecot is a contemporary POP3/IMAP server that makes it possible to access and download mail from your mail server remotely onto your local system.
+
+### Configure Remote Mail Access
+
+Issue the following command to create a back up of the default `/etc/dovecot/dovecot.conf` file and remove the original. Then recreate it using the following template:
+
+    cp /etc/dovecot/dovecot.conf /etc/dovecot/dovecot.conf-backup
+    rm /etc/dovecot/dovecot.conf
+
+{: .file }
+/etc/dovecot/dovecot.conf
+:   ~~~ INI
+    protocols = imap imaps pop3 pop3s
+    log_timestamp = "%Y-%m-%d %H:%M:%S "
+    mail_privileged_group = mail
+    ssl_cert_file = /etc/ssl/certs/postfix.pem
+    ssl_key_file = /etc/ssl/private/postfix.key
+    mail_location = maildir:~/mail:LAYOUT=fs:INBOX=~/mail/
+
+    protocol imap {
     }
 
-dict {
-}
+    protocol pop3 {
+        pop3_uidl_format = %08Xu%08Xv
+    }
 
-plugin {
-}
+    protocol managesieve {
+    }
 
-{{< /file >}}
+    auth default {
+          mechanisms = plain login
+          passdb pam {
+          }
+          userdb passwd {
+          }
+          socket listen {
+            client {
+              path = /var/spool/postfix/private/auth
+              mode = 0660
+              user = postfix
+              group = postfix
+            }
+          }
+        }
 
+    dict {
+    }
+
+    plugin {
+    }
+    ~~~
 
 Modify the `ssl` configuration directives if you're using ssl certificates located at alternate paths. Once configured, issue the following command to restart the Dovecot instance:
 
@@ -189,7 +234,8 @@ Modify the `ssl` configuration directives if you're using ssl certificates locat
 
 You may now access email by configuring a local email client to contact the server you have set up. Authentication credentials are the same as the system user accounts. These accounts can be configured outside of this document at any time.
 
-# Organize Mail Services
+Organize Mail Services
+----------------------
 
 This document describes a complete email system configuration. How you use and manage your system from this point forward is beyond the scope of this document. At the same time, we do encourage you to give some thought to the organization of your user accounts and email delivery. Keeping a well organized and easy to manage system is crucial for sustainable use of this system.
 
@@ -197,7 +243,8 @@ Organizational structure is crucial in this kind of deployment because delivery 
 
 Remember that system user accounts may provide access to other services on the system. Unless this access is specifically prohibited, all system user accounts will have SSH access to the server using the same credentials that are used for logging into the email services.
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-04-lucid.md
+++ b/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-04-lucid.md
@@ -4,21 +4,24 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Use system user accounts, postfix, and dovecot to provide'
-keywords: ["postfix", "dovecot", "system users", "email"]
+keywords: 'postfix,dovecot,system users,email'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['email/postfix/dovecot-system-users-ubuntu-10-04-lucid/']
-modified: 2013-09-25
+alias: ['email/postfix/dovecot-system-users-ubuntu-10-04-lucid/']
+modified: Wednesday, September 25th, 2013
 modified_by:
   name: Linode
-published: 2010-11-09
+published: 'Tuesday, November 9th, 2010'
+expiryDate: 2015-09-25
 title: 'Postfix, Dovecot, and System User Accounts on Ubuntu 10.04 (Lucid)'
+deprecated: true
 ---
 
 
 
 Postfix is a popular mail transfer agent or "MTA". This document will allow you to create a mail system using Postfix as the core component and aims to provide a simple email solution that uses system user accounts for authentication and mail delivery and Dovecot for remote mailbox access. If you do not need to authenticate to Postfix for SMTP service or use POP or IMAP to download email, you may consider using the [Basic Email Gateway with Postfix](/docs/email/postfix/gateway-ubuntu-10-04-lucid) document to install a more minimal email system. If you plan to host a larger number of domains and email aliases, you may want to consider a more sophisticated hosting solution like the [Email Server with Postfix, MySQL and Dovecot](/docs/email/postfix/dovecot-mysql-ubuntu-10-04-lucid/).
 
-# Set the Hostname
+Set the Hostname
+----------------
 
 Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
@@ -27,7 +30,8 @@ Before you begin installing and configuring the components described in this gui
 
 The first command should show your short hostname, and the second should show your fully qualified domain name (FQDN).
 
-# Install Software
+Install Software
+----------------
 
 Issue the following commands to install any outstanding package updates:
 
@@ -47,25 +51,30 @@ The next prompt will ask for the system mail name. This should correspond to the
 
 [![Selecting the Postfix system mail name on a Ubuntu 10.04 (Lucid) system.](/docs/assets/90-postfix-courier-mysql-02-mail-server-type-3.png)](/docs/assets/90-postfix-courier-mysql-02-mail-server-type-3.png)
 
-# SASL Authentication
+SASL Authentication
+-------------------
 
 Edit the `/etc/default/saslauthd` file to allow the SASL authentication daemon to start. Uncommon or add the following line:
 
-{{< file-excerpt "/etc/default/saslauthd" ini >}}
-START=yes
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/default/saslauthd
+:   ~~~ ini
+    START=yes
+    ~~~
 
 Create the `/etc/postfix/sasl/smtpd.conf` file, and insert the following line:
 
-{{< file-excerpt "" >}}
-pwcheck\_method: saslauthd
-{{< /file-excerpt >}}
+{: .file }
+/etc/postfix/sasl/smtpd.conf
+
+> pwcheck\_method: saslauthd
 
 Issue the following command to start the SASL daemon for the first time:
 
     /etc/init.d/saslauthd start
 
-# Configure SSL
+Configure SSL
+-------------
 
 SSL or TLS provides a method of encrypting the communication between your remote users and your mail servers. While this does not encrypt your email messages from end to end, it does ensure that your login credentials are transmitted securely and that communications are secure between your client machine and the email server.
 
@@ -80,26 +89,24 @@ Mail clients may have an issue with certificates generated in this manner becaus
 
 You can use any SSL certificate with Postfix. If you already have a commercial certificate or another SSL certificate for your web server, you can use these `.pem` and `.key` files.
 
-# Postfix
+Postfix
+-------
 
 At this point you should be able to send email using your Postfix instance by authenticating with SMTP. Authentication credentials are your [system user accounts](/docs/tools-reference/linux-users-and-groups/).
 
 Consider the [basic email gateway guide](/docs/email/postfix/gateway-ubuntu-10-04-lucid) for more information regarding Postfix virtual hosting configuration. If you need to deliver mail locally, continue for documentation of mail routing and the Dovecot POP3/IMAP server.
 
-{{< file "/etc/postfix/sasl/smtpd.conf" ini >}}
-myhostname = lollipop.example.com
-virtual_alias_maps = hash:/etc/postfix/virtual
-home_mailbox = mail/
+### Configure Mail Delivery
 
-{{< /file >}}
+The above Postfix configuration makes it possible to *send* mail using postfix. If your server receives email, Postfix requires additional configuration to deliver mail locally. Edit the `main.cf` file to insert or modify the following configuration directives:
 
-{{< file "/etc/postfix/main.cf" >}}
-myhostname = lollipop.example.com
-virtual_alias_maps = hash:/etc/postfix/virtual
-home_mailbox = mail/
-
-{{< /file >}}
-
+{: .file-excerpt }
+/etc/postfix/main.cf
+:   ~~~ ini
+    myhostname = lollipop.example.com
+    virtual_alias_maps = hash:/etc/postfix/virtual
+    home_mailbox = mail/
+    ~~~
 
 Issue the following command to ensure that new user accounts have a `~/mail` directory:
 
@@ -111,21 +118,56 @@ Every existing user that receives email will also need to make their own `Maildi
 
 Create a `/etc/postfix/virtual` file to map incoming email addresses to their destinations. Consider the following example:
 
-{{< file "/etc/postfix/virtual" ini >}}
-protocols = imap imaps pop3 pop3s
+{: .file }
+/etc/postfix/virtual
 
-{{< /file >}}
+> <username@example.com> username <username@example.net> username <username@example.com> username
+>
+> <fore@example.com> <foreman@example.com> <fore@example.net> <foreman@example.com> <fore@example.com> <foreman@example.com>
+>
+> <team@example.com> username, <foreman@example.com> <team@example.net> username, <foreman@example.com> <team@example.com> username, <foreman@example.com>
 
+Here, all mail sent to the three addresses beginning with the characters `username@` are delivered to the local user "username" and deposited to a Maildir in the `/home/username/mail/` directory. The three addresses that begin with the characters `fore@` are delivered to the email address `foreman@example.com`. The final set of three email addresses beginning with `team@` are both delivered locally and sent to the `foreman@example.com` email address.
+
+You can add additional lines in the same format as the above to control how all incoming email is delivered to local or external destinations. Remember that incoming email has no firm relationship to the name of the user account.
+
+Edit the `/etc/alias` file to add the following line. This will to reroute all local mail delivered to the root user to another user account. In the following example, all mail delivered to `root` will be delivered to the `username` user's mail box.
+
+{: .file-excerpt }
+/etc/aliases
+
+> root: username
+
+When you have configured mail delivery issue the following command to recreate the aliases database, rebuild the virtual alias database, and restart the mail server:
+
+    postalias /etc/alias
+
+> postmap /etc/postfix/virtual /etc/init.d/postfix restart
+
+Dovecot
+-------
+
+Dovecot is a contemporary POP3/IMAP server that makes it possible to access and download mail from your mail server remotely onto your local system.
+
+### Configure Remote Mail Access
+
+Edit the following configuration directive in the `/etc/dovecot/conf.d/01-dovecot-postfix.conf` file to select the services that Dovecot will provide.
+
+{: .file-excerpt }
+/etc/dovecot/conf.d/01-dovecot-postfix.conf
+:   ~~~ ini
+    protocols = imap imaps pop3 pop3s
+    ~~~
 
 The `protocols` directive enables `imap` and `pop3` services within Dovecot along with their SSL-encrypted alternatives. You may remove any of these services if you do not want Dovecot to provide `imap`, `pop3` or ssl services.
 
 Edit the following directives in `/etc/dovecot/conf.d/01-dovecot-postfix.conf` to ensure that Dovecot can find your user's Maildirs:
 
-{{< file-excerpt "/etc/dovecot/conf.d/01-dovecot-postfix.conf" ini >}}
-mail_location = maildir:~/mail:LAYOUT=fs
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+/etc/dovecot/conf.d/01-dovecot-postfix.conf
+:   ~~~ ini
+    mail_location = maildir:~/mail:LAYOUT=fs
+    ~~~
 
 Once configured, issue the following command to restart the Dovecot instance:
 
@@ -133,7 +175,8 @@ Once configured, issue the following command to restart the Dovecot instance:
 
 You may now access email by configuring a local email client to contact the server you have set up. Authentication credentials are the same as the system user accounts. These accounts can be configured outside of this document at any time.
 
-# Organize Mail Services
+Organize Mail Services
+----------------------
 
 This document describes a complete email system configuration. How you use and manage your system from this point forward is beyond the scope of this document. At the same time, we do encourage you to give some thought to the organization of your user accounts and email delivery. Keeping a well organized and easy to manage system is crucial for sustainable use of this system.
 
@@ -141,7 +184,8 @@ Organizational structure is crucial in this kind of deployment because delivery 
 
 Remember that system user accounts may provide access to other services on the system. Unless this access is specifically prohibited, all system user accounts will have SSH access to the server using the same credentials that are used for logging into the email services.
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-10-maverick.md
+++ b/docs/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-10-maverick.md
@@ -3,20 +3,22 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Use system user accounts, postfix, and dovecot to provide'
-keywords: ["postfix", "dovecot", "system users", "email"]
+keywords: 'postfix,dovecot,system users,email'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['email/postfix/dovecot-system-users-ubuntu-10-10-maverick/']
-modified: 2012-10-08
+alias: ['email/postfix/dovecot-system-users-ubuntu-10-10-maverick/']
+modified: Monday, October 8th, 2012
 modified_by:
   name: Linode
-published: 2010-12-07
+published: 'Tuesday, December 7th, 2010'
+expiryDate: 2014-10-08
 title: 'Postfix, Dovecot, and System User Accounts on Ubuntu 10.10 (Maverick)'
 deprecated: true
 ---
 
 Postfix is a popular mail transfer agent or "MTA". This document will allow you to create a mail system using Postfix as the core component and aims to provide a simple email solution that uses system user accounts for authentication and mail delivery and Dovecot for remote mailbox access. If you do not need to authenticate to Postfix for SMTP service or use POP or IMAP to download email, you may consider using the [basic email gateway with Postfix](/docs/email/postfix/gateway-ubuntu-10-10-maverick) document to install a more minimal email system. If you plan to host a larger number of domains and email aliases, you may want to consider a more sophisticated hosting solution like the [email server with Postfix, MySQL and Dovecot](/docs/email/postfix/dovecot-mysql-ubuntu-10-10-maverick/).
 
-# Set the Hostname
+Set the Hostname
+----------------
 
 Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
@@ -25,7 +27,8 @@ Before you begin installing and configuring the components described in this gui
 
 The first command should show your short hostname, and the second should show your fully qualified domain name (FQDN).
 
-# Install Software
+Install Software
+----------------
 
 Issue the following commands to install any outstanding package updates:
 
@@ -44,25 +47,31 @@ The next prompt will ask for the system mail name. This should correspond to the
 
 [![Selecting the Postfix system mail name on a Ubuntu 10.10 (Maverick) system.](/docs/assets/92-postfix-courier-mysql-02-mail-server-type-3.png)](/docs/assets/92-postfix-courier-mysql-02-mail-server-type-3.png)
 
-# SASL Authentication
+SASL Authentication
+-------------------
 
 Edit the `/etc/default/saslauthd` file to allow the SASL authentication daemon to start. Uncomment or add the following line:
 
-{{< file-excerpt "/etc/default/saslauthd" >}}
-START=yes
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/default/saslauthd
+:   ~~~ ini
+    START=yes
+    ~~~
 
 Create the `/etc/postfix/sasl/smtpd.conf` file, and insert the following line:
 
-{{< file-excerpt "/etc/postfix/sasl/smtpd.conf" >}}
-pwcheck\_method: saslauthd
-{{< /file-excerpt >}}
+{: .file }
+/etc/postfix/sasl/smtpd.conf
+
+> pwcheck\_method: saslauthd
 
 Issue the following command to start the SASL daemon for the first time:
 
     /etc/init.d/saslauthd start
 
-# Configure SSL
+Configure SSL
+-------------
+
 SSL or TLS provides a method of encrypting the communication between your remote users and your mail servers. While this does not encrypt your email messages from end to end, it does ensure that your login credentials are transmitted securely and that communications are secure between your client machine and the email server.
 
 Issue the following sequence of commands to install the prerequisites and [generate a self-signed SSL certificate](/docs/security/ssl/how-to-make-a-selfsigned-ssl-certificate):
@@ -76,22 +85,27 @@ Mail clients may have an issue with certificates generated in this manner becaus
 
 You can use any SSL certificate with Postfix. If you already have a commercial certificate or another SSL certificate for your web server, you can use these `.pem` and `.key` files.
 
-# Postfix
+Postfix
+-------
+
 ### Configure Outbound Mail Service
 
 Edit the `/etc/postfix/main.cf` file to edit or add the following lines:
-{{< file-excerpt "/etc/postfix/main.cf" >}}
-smtpd_tls_cert_file=/etc/ssl/postfix.pem
-smtpd_tls_key_file=/etc/ssl/postfix.key
 
-smtpd_sasl_application_name = smtpd
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/postfix/main.cf
+:   ~~~ ini
+    smtpd_tls_cert_file=/etc/ssl/postfix.pem
+    smtpd_tls_key_file=/etc/ssl/postfix.key
+
+    smtpd_sasl_application_name = smtpd
+    ~~~
 
 These settings make it possible for the SASL authentication process to interact with Postfix, and for Postfix to use the SSL certificate generated above. If you're using an SSL certificate with a different name, modify the first two lines of this configuration section.
 
 When all modifications to the Postfix configuration are complete, issue the following command to restart Postfix to allow these configuration changes to take effect.
 
-    /etc/init.d/postfix restart
+> /etc/init.d/postfix restart
 
 At this point you should be able to send email using your Postfix instance by authenticating with SMTP. Authentication credentials are your [system user accounts](/docs/tools-reference/linux-users-and-groups/).
 
@@ -101,13 +115,13 @@ Consider the [basic email gateway guide](/docs/email/postfix/gateway-ubuntu-10-1
 
 The above Postfix configuration makes it possible to *send* mail using Postfix. If your server receives email, Postfix requires additional configuration to deliver mail locally. Edit the `main.cf` file to insert or modify the following configuration directives:
 
-{{< file-excerpt "/etc/postfix/main.cf" ini >}}
-myhostname = lollipop.example.com
-virtual_alias_maps = hash:/etc/postfix/virtual
-home_mailbox = mail/
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+/etc/postfix/main.cf
+:   ~~~ ini
+    myhostname = lollipop.example.com
+    virtual_alias_maps = hash:/etc/postfix/virtual
+    home_mailbox = mail/
+    ~~~
 
 Issue the following command to ensure that new user accounts have a `~/mail` directory:
 
@@ -119,30 +133,65 @@ Every existing user that receives email will also need to make their own `Maildi
 
 Create a `/etc/postfix/virtual` file to map incoming email addresses to their destinations. Consider the following example:
 
-{{< file "/etc/postfix/virtual" ini >}}
-protocols = imap imaps pop3 pop3s mangesieve
+{: .file }
+/etc/postfix/virtual
 
-{{< /file >}}
+> <username@example.com> username <username@example.net> username <username@example.com> username
+>
+> <fore@example.com> <foreman@example.com> <fore@example.net> <foreman@example.com> <fore@example.com> <foreman@example.com>
+>
+> <team@example.com> username, <foreman@example.com> <team@example.net> username, <foreman@example.com> <team@example.com> username, <foreman@example.com>
 
+Here, all mail sent to the three addresses beginning with the characters `username@` are delivered to the local user "username" and deposited to a Maildir in the `/home/username/mail/` directory. The three addresses that begin with the characters `fore@` are delivered to the email address `foreman@example.com`. The final set of three email addresses beginning with `team@` are both delivered locally and sent to the `foreman@example.com` email address.
+
+You can add additional lines in the same format as the above to control how all incoming email is delivered to local or external destinations. Remember that incoming email has no firm relationship to the name of the user account.
+
+Edit the `/etc/alias` file to add the following line. This will to reroute all local mail delivered to the root user to another user account. In the following example, all mail delivered to `root` will be delivered to the `username` user's mail box.
+
+{: .file-excerpt }
+/etc/aliases
+
+> root: username
+
+When you have configured mail delivery issue the following command to recreate the aliases database, rebuild the virtual alias database, and restart the mail server:
+
+    postalias /etc/alias
+
+> postmap /etc/postfix/virtual /etc/init.d/postfix restart
+
+Dovecot
+-------
+
+Dovecot is a contemporary POP3/IMAP server that makes it possible to access and download mail from your mail server remotely onto your local system.
+
+### Configure Remote Mail Access
+
+Edit the following configuration directive in the `/etc/dovecot/dovecot.conf` file to select the services that Dovecot will provide.
+
+{: .file-excerpt }
+/etc/dovecot/conf.d/01-mail-stack-delivery.conf
+:   ~~~ ini
+    protocols = imap imaps pop3 pop3s mangesieve
+    ~~~
 
 The `protocols` directive enables `imap` and `pop3` services within Dovecot along with their SSL-encrypted alternatives. You may remove any of these services if you do not want Dovecot to provide `imap`, `pop3`, or SSL services.
 
 Edit and modify the following lines in the `/etc/dovecot/conf.d/01-dovecot-postfix.conf` file to configure Dovecot to use the SSL certificates you generated earlier:
 
-{{< file-excerpt "/etc/dovecot/conf.d/01-dovecot-postfix.conf" ini >}}
-ssl_cert_file = /etc/ssl/postfix.pem
-ssl_key_file = /etc/ssl/postfix.key
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+/etc/dovecot/conf.d/01-dovecot-postfix.conf
+:   ~~~ ini
+    ssl_cert_file = /etc/ssl/postfix.pem
+    ssl_key_file = /etc/ssl/postfix.key
+    ~~~
 
 You may replace the files specified with another `.pem` and `.key` file generated for another service, if needed. Modify the `mail_location` directive as follows so that Dovecot can interact properly with your Maildirs:
 
-{{< file-excerpt "dovecot.conf" ini >}}
-mail_location = maildir:~/mail:LAYOUT=fs
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+dovecot.conf
+:   ~~~ ini
+    mail_location = maildir:~/mail:LAYOUT=fs
+    ~~~
 
 Once configured, issue the following command to restart the Dovecot instance:
 
@@ -150,7 +199,8 @@ Once configured, issue the following command to restart the Dovecot instance:
 
 You may now access email by configuring a local email client to contact the server you have set up. Authentication credentials are the same as the system user accounts. These accounts can be configured outside of this document at any time.
 
-# Organize Mail Services
+Organize Mail Services
+----------------------
 
 This document describes a complete email system configuration. How you use and manage your system from this point forward is beyond the scope of this document. At the same time, we do encourage you to give some thought to the organization of your user accounts and email delivery. Keeping a well organized and easy to manage system is crucial for sustainable use of this system.
 
@@ -158,7 +208,8 @@ Organizational structure is crucial in this kind of deployment because delivery 
 
 Remember that system user accounts may provide access to other services on the system. Unless this access is specifically prohibited, all system user accounts will have SSH access to the server using the same credentials that are used for logging into the email services.
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub.md
+++ b/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub.md
@@ -10,6 +10,7 @@ modified: 2014-08-20
 modified_by:
   name: James Stewart
 published: 2009-09-09
+expiryDate: 2015-08-20
 title: 'Run a Distribution-Supplied Kernel with PV-GRUB'
 deprecated: true
 ---

--- a/docs/tools-reference/tools/limiting-access-with-sftp-jails-on-debian-and-ubuntu.md
+++ b/docs/tools-reference/tools/limiting-access-with-sftp-jails-on-debian-and-ubuntu.md
@@ -3,13 +3,13 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Restricting remote users to their home directories, only allowing access to SFTP for transferring files.'
-keywords: ["sftp", "sftp jail", "openssh", "ssh jail"]
+keywords: 'sftp,sftp jail,openssh,ssh jail'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['security/sftp-jails/']
-modified: 2014-04-16
+alias: ['security/sftp-jails/']
+modified: Tuesday, April 16th, 2014
 modified_by:
   name: Linode
-published: 2010-01-06
+published: 'Wednesday, January 6th, 2010'
 title: Limiting Access with SFTP Jails on Debian and Ubuntu
 external_resources:
 - '[OpenSSH Documentation](http://www.openssh.org/manual.html)'
@@ -34,15 +34,22 @@ First, you need to configure OpenSSH.
 
 2.  Add or modify the `Subsystem sftp` line to look like the following:
 
-    {{< file-excerpt "/etc/ssh/sshd\\_config" >}}
-Match Group filetransfer
-    ChrootDirectory %h
-    X11Forwarding no
-    AllowTcpForwarding no
-    ForceCommand internal-sftp
+    {: .file-excerpt }
+/etc/ssh/sshd\_config
 
-{{< /file-excerpt >}}
+    > Subsystem sftp internal-sftp
 
+3.  Add this block of settings to the end of the file:
+
+       {: .file-excerpt }
+       /etc/ssh/sshd\_config
+       :    ~~~
+            Match Group filetransfer
+                ChrootDirectory %h
+                X11Forwarding no
+                AllowTcpForwarding no
+                ForceCommand internal-sftp
+            ~~~
 
    Save the changes to your file.
 

--- a/docs/uptime/monitoring/deploy-munin-to-monitor-servers-on-ubuntu-12-04.md
+++ b/docs/uptime/monitoring/deploy-munin-to-monitor-servers-on-ubuntu-12-04.md
@@ -4,13 +4,14 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Use Munin on Ubuntu 12.04 to Keep Track of Vital System Statistics and Troubleshoot Performance Problems'
-keywords: ["munin", "monitoring", "ubuntu 12.04", "munin node", "munin master"]
+keywords: 'munin,monitoring,ubuntu 12.04,munin node,munin master'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['server-monitoring/munin/ubuntu-12-04-precise-pangolin/','uptime/monitoring/monitoring-server-with-munin-on-ubuntu-12-04-precise-pangolin/']
-modified: 2012-10-09
+alias: ['server-monitoring/munin/ubuntu-12-04-precise-pangolin/','uptime/monitoring/monitoring-server-with-munin-on-ubuntu-12-04-precise-pangolin/']
+modified: Tuesday, October 9th, 2012
 modified_by:
   name: Linode
-published: 2012-10-09
+published: 'Tuesday, October 9th, 2012'
+expiryDate: 2014-10-09
 title: 'Deploy Munin to Monitor Servers on Ubuntu 12.04'
 external_resources:
  - '[Munin Homepage](http://munin-monitoring.org/)'
@@ -24,7 +25,7 @@ The Linode Manager provides some basic monitoring of system resource utilization
 
 Munin is a system and network monitoring tool that uses RRDTool to generate useful visualizations of resource usage. The primary goal of the Munin project is to provide an easy-to-use tool that is simple to install and configure and provides information in an accessible web-based interface. Munin also makes it possible to monitor multiple "nodes" with a single installation.
 
-Before installing Munin, we assume that you have followed our [getting started guide](/docs/getting-started/). If you're new to Linux server administration you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts), the [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/content/using-linux/administration-basics). Additionally, you'll need to install a web server, such as [Apache](/content/web-servers/apache/installation/ubuntu-10-04-lucid), in order to use the web interface.
+Before installing Munin, we assume that you have followed our [getting started guide](/docs/getting-started/). If you're new to Linux server administration you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts), the [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/docs/using-linux/administration-basics). Additionally, you'll need to install a web server, such as [Apache](/docs/web-servers/apache/installation/ubuntu-10-04-lucid), in order to use the web interface.
 
 ## Install Munin
 
@@ -51,22 +52,8 @@ The master configuration file for Munin is `/etc/munin/munin.conf`. This file is
 
 The first section of the file contains the paths to the directories used by Munin. Note that these directories are the default paths used by Munin and can be changed by uncommenting and updating the path. When configuring your web server with Munin, make sure to point the root folder to the path of `htmldir`.
 
-{{< file-excerpt "/etc/munin/munin.conf" apache >}}
-<VirtualHost 12.34.56.78:80>
-   ServerAdmin webmaster@stats.example.org
-   ServerName stats.example.org
-   DocumentRoot /var/cache/munin/www
-   <Directory />
-       Options FollowSymLinks
-       AllowOverride None
-   </Directory>
-   LogLevel notice
-   CustomLog /var/log/apache2/access.log combined
-   ErrorLog /var/log/apache2/error.log
-   ServerSignature On
-</VirtualHost>
-
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/munin/munin.conf
 
 > \# dbdir /var/lib/munin \# htmldir /var/cache/munin/www \# logdir /var/log/munin \# rundir /var/run/munin
 
@@ -74,28 +61,31 @@ There are additional directives after the directory location block such as `tmpl
 
 The last section of the `munin.conf` file defines the hosts Munin retrieves information from. For a default configuration, adding a host can be done in the form shown below:
 
-{{< file "/etc/munin.munin.conf" >}}
-[example.org]
-:   address example.org
-{{< /file >}}
+{: .file }
+/etc/munin/munin.conf
 
+> [example.org]
+> :   address example.org
+>
 For more complex configurations, including grouping domains, see the comment section in the file, reproduced below for your convenience:
 
-{{< file "/etc/munin/munin.conf" >}}
-\# A more complex example of a host tree \# \#\# First our "normal" host. \# [fii.foo.com] \# address foo \# \#\# Then our other host... \# [fay.foo.com] \# address fay \# \#\# Then we want totals... \# [foo.com;Totals] \#Force it into the "foo.com"-domain... \# update no \# Turn off data-fetching for this "host". \# \# \# The graph "load1". We want to see the loads of both machines... \# \# "fii=fii.foo.com:load.load" means "label=machine:graph.field" \# load1.graph\_title Loads side by side \# load1.graph\_order fii=fii.foo.com:load.load fay=fay.foo.com:load.load \# \# \# The graph "load2". Now we want them stacked on top of each other. \# load2.graph\_title Loads on top of each other \# load2.dummy\_field.stack fii=fii.foo.com:load.load fay=fay.foo.com:load.l\$ \# load2.dummy\_field.draw AREA \# We want area instead the default LINE2. \# load2.dummy\_field.label dummy \# This is needed. Silly, really. \# \# \# The graph "load3". Now we want them summarized into one field \# load3.graph\_title Loads summarized \# load3.combined\_loads.sum fii.foo.com:load.load fay.foo.com:load.load \# load3.combined\_loads.label Combined loads \# Must be set, as this is \# \# not a dummy field! \# \#\# ...and on a side note, I want them listen in another order (default is \#\# alphabetically) \# \# \# Since [foo.com] would be interpreted as a host in the domain "com", we \# \# specify that this is a domain by adding a semicolon. \# [foo.com;] \# node\_order Totals fii.foo.com fay.foo.com \#
-{{< /file >}}
+{: .file }
+/etc/munin/munin.conf
+
+> \# A more complex example of a host tree \# \#\# First our "normal" host. \# [fii.foo.com] \# address foo \# \#\# Then our other host... \# [fay.foo.com] \# address fay \# \#\# Then we want totals... \# [foo.com;Totals] \#Force it into the "foo.com"-domain... \# update no \# Turn off data-fetching for this "host". \# \# \# The graph "load1". We want to see the loads of both machines... \# \# "fii=fii.foo.com:load.load" means "label=machine:graph.field" \# load1.graph\_title Loads side by side \# load1.graph\_order fii=fii.foo.com:load.load fay=fay.foo.com:load.load \# \# \# The graph "load2". Now we want them stacked on top of each other. \# load2.graph\_title Loads on top of each other \# load2.dummy\_field.stack fii=fii.foo.com:load.load fay=fay.foo.com:load.l\$ \# load2.dummy\_field.draw AREA \# We want area instead the default LINE2. \# load2.dummy\_field.label dummy \# This is needed. Silly, really. \# \# \# The graph "load3". Now we want them summarized into one field \# load3.graph\_title Loads summarized \# load3.combined\_loads.sum fii.foo.com:load.load fay.foo.com:load.load \# load3.combined\_loads.label Combined loads \# Must be set, as this is \# \# not a dummy field! \# \#\# ...and on a side note, I want them listen in another order (default is \#\# alphabetically) \# \# \# Since [foo.com] would be interpreted as a host in the domain "com", we \# \# specify that this is a domain by adding a semicolon. \# [foo.com;] \# node\_order Totals fii.foo.com fay.foo.com \#
 
 ### Munin Node Configuration
 
 The default `/etc/munin/munin-node.conf` file contains several variables you'll want to adjust to your preference. For a basic configuration, you'll only need to add the IP address of the master Munin server as a regular expression. Simply follow the style of the existing `allow` line if you're unfamiliar with regular expressions.
 
-{{< file "/etc/munin/munin-node.conf" >}}
-\# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+{: .file }
+/etc/munin/munin-node.conf
 
-allow \^127.0.0.1\$
-
-\# Replace this with the master munin server IP address allow \^123.45.67.89\$
-{{< /file >}}
+> \# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+>
+> allow \^127.0.0.1\$
+>
+> \# Replace this with the master munin server IP address allow \^123.45.67.89\$
 
 The above line tells the munin-node that the master Munin server is located at IP address `123.45.67.89`. After updating this file, restart the `munin-node`. In Ubuntu, use the following command:
 
@@ -107,21 +97,23 @@ You can use Munin with the web server of your choice, simply point your web serv
 
 If you are using the [Apache HTTP Server](/docs/web-servers/apache/) you can create a Virtual Host configuration to serve the reports from Munin. In this scenario, we've created a subdomain in the DNS Manager and are now creating the virtual host file:
 
-{{< file "/etc/apache2/sites-available/stats.example.org" apache>}}
-<VirtualHost 12.34.56.78:80>
-   ServerAdmin webmaster@stats.example.org
-   ServerName stats.example.org
-   DocumentRoot /var/cache/munin/www
-   <Directory />
-       Options FollowSymLinks
-       AllowOverride None
-   </Directory>
-   LogLevel notice
-   CustomLog /var/log/apache2/access.log combined
-   ErrorLog /var/log/apache2/error.log
-   ServerSignature On
-</VirtualHost>
-{{< /file >}}
+{: .file }
+/etc/apache2/sites-available/stats.example.org
+:   ~~~ apache
+    <VirtualHost 12.34.56.78:80>
+       ServerAdmin webmaster@stats.example.org
+       ServerName stats.example.org
+       DocumentRoot /var/cache/munin/www
+       <Directory />
+           Options FollowSymLinks
+           AllowOverride None
+       </Directory>
+       LogLevel notice
+       CustomLog /var/log/apache2/access.log combined
+       ErrorLog /var/log/apache2/error.log
+       ServerSignature On
+    </VirtualHost>
+    ~~~
 
 If you use this configuration you will want to issue the following commands to ensure that all required directories exist and that your site is enabled:
 

--- a/docs/uptime/monitoring/monitoring-resource-utilization-with-cacti-on-centos-5.md
+++ b/docs/uptime/monitoring/monitoring-resource-utilization-with-cacti-on-centos-5.md
@@ -4,13 +4,15 @@ author:
   name: Stan Schwertly
   email: docs@linode.com
 description: 'Monitor resource usage through the powerful server monitoring tool Cacti on CentOS 5.'
-keywords: ["Cacti", "CentOS", "Monitoring", "SNMP"]
+keywords: 'Cacti,CentOS,Monitoring,SNMP'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['server-monitoring/cacti/centos-5/']
-modified: 2011-04-29
+alias: ['server-monitoring/cacti/centos-5/']
+modified: Friday, April 29th, 2011
 modified_by:
   name: Linode
-published: 2010-02-12
+published: 'Friday, February 12th, 2010'
+expiryDate: 2013-04-29
+deprecated: true
 title: Monitoring Resource Utilization with Cacti on CentOS 5
 ---
 
@@ -18,9 +20,10 @@ The Linode Manager provides some basic monitoring of system resource utilization
 
 For these kinds of deployments we encourage you to consider a tool like Cacti, which is a flexible front end for the RRDtool application. Cacti simply provides a framework and a mechanism to poll a number of sources for data regarding your systems, which can then be graphed and presented in a clear web based interface. Whereas packages like Munin provide monitoring for a specific set of metrics on systems which support the Munin plug in, Cacti provides increased freedom to monitor larger systems and more complex deployment by way of its plug in framework and web-based interface.
 
-Before installing Cacti we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/content/using-linux/administration-basics).
+Before installing Cacti we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/docs/using-linux/administration-basics).
 
-# Installing Prerequisites
+Installing Prerequisites
+------------------------
 
 The packages required to install Cacti are not available in the standard CentOS repositories. As a result, in order to install Cacti, we must install the "[EPEL](https://fedoraproject.org/wiki/EPEL)" system. EPEL, or "Extra Packages for Enterprise Linux", is a product of the Fedora Project that attempts to provide enterprise-grade software that's more current than what is typically available in the CentOS repositories. Enable EPEL with the following command:
 
@@ -56,16 +59,73 @@ The above command will additionally install the Apache web server. Consider our 
 
 SNMPD binds to all local interface by default. If you only plan on using Cacti locally to monitor your Linode, you may want to consider modifying `/etc/sysconfig/snmpd.options` to limit the exposure of SNMP to the Internet at large. Uncomment the following line and append the addresses you would like the SNMP daemon to "listen" for data on as follows:
 
-{{< file "/etc/sysconfig/snmpd.options" php >}}
-$database_type = "mysql";
-$database_default = "cactidb";
-$database_hostname = "localhost";
-$database_username = "cactiuser";
-$database_password = "c@t1u53r";
-$database_port = "3306";
+{: .file }
+/etc/sysconfig/snmpd.options
 
-{{< /file >}}
+> OPTIONS="-Lsd -Lf /dev/null -p /var/run/snmpd.pid -a 192.168.169.170"
 
+In this example SNMPD is configured to listen for data only on the LAN IP address `192.168.169.170`. To limit access to SNMPD so that only local data can access the daemon, use `127.0.0.1` as the IP address. If, however, you need to receive data from machines on the Internet at large, do not append any IP addresses to this line.
+
+We'll create an SNMP "community" to help identify our group of devices for Cacti. In this instance, our hostname is "example.org", so we've named the community "example". The community name choice is up to the user. Add the following line to the section of `snmpd.conf` with `com2sec` directives making sure to only grant `readonly` privileges.
+
+{: .file }
+/etc/snmp/snmpd.conf
+
+> com2sec readonly localhost example
+
+If you want a remote machine to connect to Cacti, replace "localhost" with the IP address of the remote machine.
+
+You need to restart snmpd any time `/etc/snmp/snmpd.conf` is modified. Run the following commands to start the SNMPD daemon and ensure that it will run following the next boot cycle:
+
+    /etc/init.d/snmpd restart
+    chkconfig snmpd on
+
+Installing Cacti
+----------------
+
+To install the Cacti package from the distribution software repositories, issue the following command:
+
+    yum install cacti
+
+You will need to accept the EPEL repository key, and install all packages as recommended. Before we can begin using Cacti we must first configure MySQL. Use the following commands to start the MySQL server, ensure that it will run following boot, and enter the secure installation configuration process:
+
+    /etc/init.d/mysqld start
+    chkconfig mysqld on
+    mysql_secure_installation
+
+Your MySQL instance does not have a root password when installed, but you will want to set a secure password, remove anonymous users, disallow root logins, and remove all of the test databases. Finally accept the invitation to reload all privilege tables and you will return to the root prompt. Issue the following command to enter the MySQL prompt and create a database and MySQL user for Cacti:
+
+    mysql -u root -p
+
+Supply the requested password and issue the following SQL statements at the `mysql>` prompt.
+
+    CREATE DATABASE cactidb;
+
+    CREATE USER 'cactiuser'@localhost IDENTIFIED BY 'c@t1u53r';
+
+    GRANT ALL PRIVILEGES ON cactidb.* TO 'cactiuser'@localhost;
+
+    exit
+
+Before we can begin to configure Cacti in the conventional manner, we must set up the database by issuing the following commands:
+
+    cd /opt/
+    wget http://svn.cacti.net/viewvc/cacti/tags/0.8.7e/cacti.sql?view=co
+    mv cacti.sql\?view\=co cacti.sql
+    mysql -u cactiuser -p cactidb < cacti.sql
+
+Enter the password created above (e.g. `c@t1u53r`) and press return. Now edit the `/etc/cacti/db.php` file to include the relevant settings as in the example below:
+
+{: .file-excerpt }
+/etc/cacti/db.php
+:   ~~~ php
+    $database_type = "mysql";
+    $database_default = "cactidb";
+    $database_hostname = "localhost";
+    $database_username = "cactiuser";
+    $database_password = "c@t1u53r";
+    $database_port = "3306";
+    ~~~
 
 Issue the following command to start Apache if you have not already:
 
@@ -77,9 +137,8 @@ If you would like to ensure that Apache will start following the next boot cycle
 
 From this point we'll continue the configuration of Cacti through the browser. By default, the Cacti interface only accepts traffic from the local interface. Modify `/etc/httpd/conf.d/cacti.conf` to allow traffic to your local machine's IP address, as in the following example:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /etc/httpd/conf.d/cacti.conf
-{{< /file-excerpt >}}
 
 > \<Directory /usr/share/cacti/\>
 > :   Order Deny,Allow Deny from all Allow from 193.194.195.196
@@ -94,7 +153,8 @@ Visit the domain you have pointed at your Linode, or your Linode's IP address, a
 
 At the login screen, enter `admin/admin` for the username/password combination. You'll be prompted to change your password on the next screen. At this point, Cacti is installed and ready to be configured.
 
-# Configuring Cacti
+Configuring Cacti
+-----------------
 
 At this point Cacti will contain an entry for `localhost`, which we'll need to modify. Click the "Console" tab in the top left corner, and select "Create Devices for network". Click the "Localhost" entry to begin making the needed changes. Select the Host Template drop down and pick the "ucd/net SNMP Host". Scroll down to SNMP Options and click the drop down box for SNMP Version, selecting "Version 1". Enter "public" in the box for the "SNMP Community" field. The "Associated Graph Templates" section allows you to add additional graphs. Hit "Save" to keep the changes.
 
@@ -109,15 +169,15 @@ Since you want Cacti to collect data automatically, we'll use the "cron" tool to
 
 Now insert the following line:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 crontab
-{{< /file-excerpt >}}
 
 > */5* \* \* \* /usr/bin/php /usr/share/cacti/poller.php \> /dev/null 2\>&1
 
 To learn more about using [cron to schedule tasks](/docs/linux-tools/utilities/cron), consider our documentation. The above "cronjob" runs Cacti's PHP poller every five minutes. If you need to alter the interval of the modify the cron specification and modify the "Poller" settings from within Cacti's console.
 
-# Configuring Client Machines
+Configuring Client Machines
+---------------------------
 
 This section is optional and for those looking to use Cacti to monitor additional devices. These steps are written for other CentOS-based distributions, but with modification, will work on any flavor of Linux. You will need to follow these instructions for each client machine you'd like to monitor with Cacti. Client machines need an SNMP daemon in order to serve Cacti information. First, install `snmp` and `snmpd` on the client:
 
@@ -130,9 +190,8 @@ Next we'll need to modify the `/etc/snmp/snmpd.conf` file with the name of our c
 
 Note that the format is "rocommunity community\_name", where `community_name` is the name of the community you originally used with Cacti, e.g. `example`. If you're monitoring a CentOS machine and you need to configure which interface SNMPD binds to you must edit the `/etc/sysconfig/snmpd.options` file. Append any IP address needed to the end of the following line, and uncomment it by removing the `#` at the beginning if needed. You should not need to edit this file.
 
-{{< file >}}
+{: .file }
 /etc/sysconfig/snmpd.options
-{{< /file >}}
 
 > OPTIONS='-Lsd -Lf /dev/null -I -smux -p /var/run/snmpd.pid'
 
@@ -146,7 +205,8 @@ Issue the following command to ensure that SNMP will restart following the next 
 
 At this point your machine is ready for polling. Go into the Cacti interface to add the new "Device". Under the "Console" tab, select "New Graphs" and then "Create New Host". Enter the pertinent information in the fields required. Make sure to select "Ping" for "Downed Device Detection". Additionally, ensure that you've entered the correct community name in the "SNMP Community" field. Click the "create" button to save your configuration. On the "save successful" screen, select your newly created device and from the drop down "Choose an Action" select "Place on a Tree" and then click "go". Hit "yes" on the next screen. On the "New Graphs" screen, you'll be able to create several different types of graphs of your choice. Follow the on-screen instructions to add these graphs to your tree.
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/uptime/monitoring/monitoring-resource-utilization-with-cacti-on-fedora-12.md
+++ b/docs/uptime/monitoring/monitoring-resource-utilization-with-cacti-on-fedora-12.md
@@ -4,13 +4,15 @@ author:
   name: Stan Schwertly
   email: docs@linode.com
 description: 'Monitor resource usage through the powerful server monitoring tool Cacti on Fedora 12.'
-keywords: ["Cacti", "Fedora", "Monitoring", "SNMP"]
+keywords: 'Cacti,Fedora,Monitoring,SNMP'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['server-monitoring/cacti/fedora-12/']
-modified: 2013-10-01
+alias: ['server-monitoring/cacti/fedora-12/']
+modified: Tuesday, October 1st, 2013
 modified_by:
   name: Linode
-published: 2010-02-11
+published: 'Thursday, February 11th, 2010'
+expiryDate: 2015-10-01
+deprecated: true
 title: Monitoring Resource Utilization with Cacti on Fedora 12
 ---
 
@@ -20,9 +22,10 @@ The Linode Manager provides some basic monitoring of system resource utilization
 
 For these kinds of deployments we encourage you to consider a tool like Cacti, which is a flexible front end for the RRDtool application. Cacti simply provides a framework and a mechanism to poll a number of sources for data regarding your systems, which can then be graphed and presented in a clear web based interface. Whereas packages like Munin provide monitoring for a specific set of metrics on systems which support the Munin plug in, Cacti provides increased freedom to monitor larger systems and more complex deployment by way of its plug in framework and web-based interface.
 
-Before installing Cacti we, assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/content/using-linux/administration-basics).
+Before installing Cacti we, assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/docs/using-linux/administration-basics).
 
-# Installing Prerequisites
+Installing Prerequisites
+------------------------
 
 Before proceeding with the installation of Cacti, ensure your package repositories and installed programs are up to date by issuing the following commands:
 
@@ -54,16 +57,71 @@ The above command will additionally install the Apache web server. Consider our 
 
 SNMPD binds to all local interfaces by default. If you only plan on using Cacti locally to monitor your Linode, you may want to consider modifying `/etc/sysconfig/snmpd.options` to limit the exposure of SNMP to the Internet at large. Uncomment the following line and append the addresses you would like the SNMP daemon to "listen" for data, as follows:
 
-{{< file "/etc/sysconfig/snmpd.options" php >}}
-$database_type = "mysql";
-$database_default = "cactidb";
-$database_hostname = "localhost";
-$database_username = "cactiuser";
-$database_password = "c@t1u53r";
-$database_port = "3306";
+{: .file }
+/etc/sysconfig/snmpd.options
 
-{{< /file >}}
+> OPTIONS="-Lsd -Lf /dev/null -p /var/run/snmpd.pid -a 192.168.169.170"
 
+In this example, SNMPD is configured to listen for data only on the LAN IP address `192.168.169.170`. To limit access to SNMPD so that only local data can access the daemon, use `127.0.0.1` as the IP address. If, however, you need to receive data from machines on the Internet at large, do not append any IP addresses to this line.
+
+We'll create an SNMP "community" to help identify our group of devices for Cacti. In this instance, our hostname is "example.org", so we've named the community "example". The community name choice is up to the user. Add the following line to the section of `snmpd.conf` with `com2sec` directives making sure to only grant `readonly` privileges.
+
+{: .file }
+/etc/snmp/snmpd.conf
+
+> com2sec readonly localhost example
+
+If you want a remote machine to connect to Cacti, replace "localhost" with the IP address of the remote machine.
+
+You need to restart snmpd any time `/etc/snmp/snmpd.conf` is modified. Run the following command after closing the file:
+
+    /etc/init.d/snmpd restart
+
+Installing Cacti
+----------------
+
+To install the Cacti package from the distribution software repositories, issue the following command:
+
+    yum install cacti
+
+Install all packages as recommended. Before we can begin using Cacti we must first configure MySQL. Use the following commands to start the MySQL server and enter the secure installation configuration:
+
+    /etc/init.d/mysqld start
+    mysql_secure_installation
+
+Your MySQL instance does not have a root password when installed, but you will want to set a secure password, remove anonymous users, disallow root logins, and remove all of the test databases. Finally accept the invitation to reload all privilege tables and you will return to the root prompt. Issue the following command to enter the MySQL prompt and create a database and MySQL user for Cacti:
+
+    mysql -u root -p
+
+Supply the requested password and issue the following SQL statements at the `mysql>` prompt.
+
+    CREATE DATABASE cactidb;
+
+    CREATE USER 'cactiuser'@localhost IDENTIFIED BY 'c@t1u53r';
+
+    GRANT ALL PRIVILEGES ON cactidb.* TO 'cactiuser'@localhost;
+
+    exit
+
+Before we can begin to configure Cacti in the conventional manner, we must set up the database by issuing the following commands:
+
+    cd /opt/
+    wget http://svn.cacti.net/viewvc/cacti/tags/0.8.7e/cacti.sql?view=co
+    mv cacti.sql\?view\=co cacti.sql
+    mysql -u cactiuser -p cactidb < cacti.sql
+
+Enter the password created above (e.g. `c@t1u53r`) and press return. Now edit the `/etc/cacti/db.php` file to include the relevant settings as in the below example:
+
+{: .file-excerpt }
+/etc/cacti/db.php
+:   ~~~ php
+    $database_type = "mysql";
+    $database_default = "cactidb";
+    $database_hostname = "localhost";
+    $database_username = "cactiuser";
+    $database_password = "c@t1u53r";
+    $database_port = "3306";
+    ~~~
 
 Issue the following command to start Apache if you have not already:
 
@@ -71,9 +129,8 @@ Issue the following command to start Apache if you have not already:
 
 From this point we'll continue the configuration of Cacti through the browser. By default, the Cacti interface only accepts traffic from the local interface. Modify `/etc/httpd/conf.d/cacti.conf` to allow traffic to your local machine's IP address, as in the following example:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /etc/httpd/conf.d/cacti.conf
-{{< /file-excerpt >}}
 
 > \<Directory /usr/share/cacti/\>
 > :   Order Deny,Allow Deny from all Allow from 193.194.195.196
@@ -88,7 +145,8 @@ Visit the domain you have pointed at your Linode, or your Linode's IP address, a
 
 At the login screen, enter `admin/admin` for the username/password combination. You'll be prompted to change your password on the next screen. At this point, Cacti is installed and ready to be configured.
 
-# Configuring Cacti
+Configuring Cacti
+-----------------
 
 At this point Cacti will contain an entry for `localhost`, which we'll need to modify. Click the "Console" tab in the top left corner, and select "Create Devices for network". Click the "Localhost" entry to begin making the needed changes. Select the Host Template drop down and pick the "ucd/net SNMP Host". Scroll down to SNMP Options and click the drop down box for SNMP Version, picking "Version 1". Enter "example" (or the community name you created above) in the box for the "SNMP Community" field. The "Associated Graph Templates" section allows you to add additional graphs. Hit "Save" to keep the changes.
 
@@ -100,15 +158,15 @@ Returning to the command line, issue the following command to create a new cron,
 
 Now insert the following line:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 crontab
-{{< /file-excerpt >}}
 
 > */5* \* \* \* /usr/bin/php /usr/share/cacti/poller.php \> /dev/null 2\>&1
 
 To learn more about using [cron to schedule tasks](/docs/linux-tools/utilities/cron), consider our documentation. The above "cronjob" runs Cacti's PHP poller every five minutes. If you need to alter this interval, modify the cron specification and modify the "Poller" settings from within Cacti's console tab. Be aware that it takes Cacti a full polling cycle to gather data and graphs.
 
-# Configuring Client Machines
+Configuring Client Machines
+---------------------------
 
 This section is optional and for those looking to use Cacti to monitor additional devices. These steps are written for other Fedora-based distributions, but with modification, they will work on any flavor of Linux. You will need to follow these instructions for each client machine you'd like to monitor in Cacti. Client machines need an SNMP daemon in order to serve Cacti information. First, install `snmp` and `snmpd` on the client:
 
@@ -121,9 +179,8 @@ Next we'll need to modify the `/etc/snmp/snmpd.conf` file with the name of our c
 
 Note that the format is "rocommunity community\_name", where `community_name` is the name of the community you originally used with Cacti, e.g. `example`. If you're monitoring a Fedora machine and you need to configure which interface SNMPD binds to you must edit the `/etc/sysconfig/snmpd.options` file. Append any IP address needed to the end of the following line, and uncomment it by removing the `#` at the beginning if needed. You should not need to edit this file.
 
-{{< file >}}
+{: .file }
 /etc/sysconfig/snmpd.options
-{{< /file >}}
 
 > OPTIONS='-Lsd -Lf /dev/null -u snmp -I -smux -p /var/run/snmpd.pid'
 
@@ -133,7 +190,8 @@ Finally, restart the SNMP daemon to ensure that your changes to these files will
 
 At this point your machine is ready for polling. Go into the Cacti interface to add the new "Device". Under the "Console" tab, select "New Graphs" and then "Create New Host". Enter the pertinent information in the fields required. Make sure to select "Ping" for "Downed Device Detection". Additionally, ensure that you've typed the right community name in the "SNMP Community" field. Click the "create" button to save your configuration. On the "save successful" screen, select your newly created device and from the "Choose an Action" drop down select "Place on a Tree" and then click "go". Hit "yes" on the next screen. On the "New Graphs" screen, you'll be able to create several different types of graphs of your choice. Follow the on-screen instructions to add these graphs to your tree.
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/uptime/monitoring/monitoring-servers-with-munin-on-debian-5-lenny.md
+++ b/docs/uptime/monitoring/monitoring-servers-with-munin-on-debian-5-lenny.md
@@ -4,13 +4,14 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Keep track of vital system statistics and troubleshoot performance problems with Munin on Debian 5 (Lenny).'
-keywords: ["munin", "monitoring"]
+keywords: 'munin,monitoring'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['server-monitoring/munin/debian-5-lenny/']
-modified: 2012-10-08
+alias: ['server-monitoring/munin/debian-5-lenny/']
+modified: Monday, October 8th, 2012
 modified_by:
   name: Linode
-published: 2010-01-07
+published: 'Thursday, January 7th, 2010'
+expiryDate: 2013-10-08
 title: 'Monitoring Servers with Munin on Debian 5 (Lenny)'
 ---
 
@@ -20,9 +21,10 @@ The Linode Manager provides some basic monitoring of system resource utilization
 
 Munin is a system and network monitoring tool that uses RRDTool to generate useful visualizations of resource usage. The primary goal of the Munin project is to provide an easy to use tool that is simple to install and configure and provides information in an accessible web based interface. Munin also makes it possible to monitor multiple "nodes" with a single installation.
 
-Before installing Munin, we assume that you have followed our [getting started](/docs/getting-started/) guide. If you're new to Linux server administration you may be interested in our [using Linux](/docs/tools-reference/introduction-to-linux-concepts) document series, including the [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/content/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/content/web-servers/apache/installation/debian-5-lenny) in order to use the web interface.
+Before installing Munin, we assume that you have followed our [getting started](/docs/getting-started/) guide. If you're new to Linux server administration you may be interested in our [using Linux](/docs/tools-reference/introduction-to-linux-concepts) document series, including the [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/docs/web-servers/apache/installation/debian-5-lenny) in order to use the web interface.
 
-# Installing Munin
+Installing Munin
+----------------
 
 Make sure your package repositories and installed programs are up to date by issuing the following commands:
 
@@ -39,7 +41,8 @@ On all of the additional machines you administer that you would like to monitor 
 
 The machines that you wish to monitor with Munin do not need to run Debian. The Munin project supports monitoring for a large number of operating systems: consult the Munin project's [installation guide](http://munin-monitoring.org/wiki/MuninInstallationLinux) for more information installing nodes on additional operating systems.
 
-# Configuring Munin
+Configuring Munin
+-----------------
 
 ### Munin Master Configuration
 
@@ -47,50 +50,54 @@ The master configuration file for Munin is `/etc/munin/munin.conf`. This file is
 
 The first section of the file contains the paths to the directories used by Munin. When configuring your web server with Munin, make sure to point the root folder to the path of `htmldir`.
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# Configfile for Munin master dbdir /var/lib/munin/ htmldir /var/www/munin/ logdir /var/log/munin/ rundir /var/run/munin/
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/munin/munin.conf
+
+> \# Configfile for Munin master dbdir /var/lib/munin/ htmldir /var/www/munin/ logdir /var/log/munin/ rundir /var/run/munin/
 
 There are additional directives after the directory location block such as `tmpldir`, which shows Munin where to look for HTML templates, and others that allow you to configure mail to be sent when something on the server changes. These additional directives are explained more in depth on the [munin.conf page of the Munin website](http://munin-monitoring.org/wiki/munin.conf). You can also find quick explanations inside the file itself via hash (`#`) comments. Take note that these global directives must be defined prior to defining hosts monitored by Munin. Do not place global directives at the bottom of the `munin.conf` file.
 
 The last section of the `munin.conf` file defines the hosts Munin retrieves information from. For a default configuration, adding a host can be done in the form shown below:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-[example.com]
-:   address example.com
-{{< /file-excerpt >}}
+{: .file }
+/etc/munin/munin.conf
 
+> [example.com]
+> :   address example.com
+>
 For more complex configurations, including grouping domains, see the comment section in the file, reproduced below for your convenience:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+{: .file }
+/etc/munin/munin.conf
 
-[foo.example.com] \# Defines the group "example.com" and then
-:   \# "foo.example.com" under that group.
-
-> address localhost \# The address (IP or host name) of the host, where munin-node is running.
-
-[example.com;bar.example.com] \# Same as above, but with an explicit definition.
-:   \# of the host's group.
-
-address bar.example.com \# The address.
-:   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
-
-[Groupname;baz.example.com] \# Associates the host baz.example.com to this group
-:   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
-{{< /file-excerpt >}}
-
+> \# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+>
+> [foo.example.com] \# Defines the group "example.com" and then
+> :   \# "foo.example.com" under that group.
+>
+> > address localhost \# The address (IP or host name) of the host, where munin-node is running.
+>
+> [example.com;bar.example.com] \# Same as above, but with an explicit definition.
+> :   \# of the host's group.
+>
+> address bar.example.com \# The address.
+> :   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
+>
+> [Groupname;baz.example.com] \# Associates the host baz.example.com to this group
+> :   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
+>
 ### Munin Node Configuration
 
 The default `/etc/munin/munin-node.conf` file contains several variables you'll want to adjust to your preference. For a basic configuration, you'll only need to add the IP address of the master Munin server as a regular expression. Simply follow the style of the existing `allow` line if you're unfamiliar with regular expressions.
 
-{{< file-excerpt "/etc/munin/munin-node.conf" >}}
-\# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+{: .file }
+/etc/munin/munin-node.conf
 
-allow \^127.0.0.1\$
-
-\# Replace this with the master munin server IP address allow \^123.45.67.89\$
-{{< /file-excerpt >}}
+> \# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+>
+> allow \^127.0.0.1\$
+>
+> \# Replace this with the master munin server IP address allow \^123.45.67.89\$
 
 The above line tells the munin-node that the master Munin server is located at IP address `123.45.67.89`. After updating this file, restart the `munin-node`. In Debian, use the following command:
 
@@ -102,21 +109,23 @@ You can use Munin with the web server of your choice, simply point your web serv
 
 If you are using the [Apache HTTP Server](/docs/web-servers/apache/) you can create a Virtual Host configuration to serve the reports from Munin. In this scenario, we've created a subdomain in the DNS Manager and are now creating the virtual host file:
 
-{{< file-excerpt "/etc/apache2/sites-available/stats.example.com" >}}
-<VirtualHost 123.45.67.89:80>
-   ServerAdmin webmaster@stats.example.com
-   ServerName stats.example.com
-   DocumentRoot /var/www/munin
-   <Directory />
-       Options FollowSymLinks
-       AllowOverride None
-   </Directory>
-   LogLevel notice
-   CustomLog /var/log/apache2/access.log combined
-   ErrorLog /var/log/apache2/error.log
-   ServerSignature On
-</VirtualHost>
-{{< /file-excerpt >}}
+{: .file }
+/etc/apache2/sites-available/stats.example.com
+:   ~~~ apache
+    <VirtualHost 123.45.67.89:80>
+       ServerAdmin webmaster@stats.example.com
+       ServerName stats.example.com
+       DocumentRoot /var/www/munin
+       <Directory />
+           Options FollowSymLinks
+           AllowOverride None
+       </Directory>
+       LogLevel notice
+       CustomLog /var/log/apache2/access.log combined
+       ErrorLog /var/log/apache2/error.log
+       ServerSignature On
+    </VirtualHost>
+    ~~~
 
 If you use this configuration you will want to issue the following commands to ensure that all required directories exist, and that your site is enabled:
 
@@ -128,7 +137,8 @@ Now restart the server so that the changes to your configuration file can take e
 
 In most cases you will probably want to prevent the data generated by Munin from becoming publicly accessible. You can either limit access using [rule based access control](/docs/web-servers/apache/configuration/rule-based-access-control) so that only a specified list of IPs will be permitted access, or you can configure [HTTP Authentication](/docs/web-servers/apache/configuration/http-authentication) to require a password before permitting access. In addition to protecting the `stats.` virtual host, also ensure that the munin controls are also protected on the default virtual host (e.g. by visiting `http://12.34.56.78/munin/` where `12.34.56.78` is the IP address of your server.)
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/uptime/monitoring/monitoring-servers-with-munin-on-debian-6-squeeze.md
+++ b/docs/uptime/monitoring/monitoring-servers-with-munin-on-debian-6-squeeze.md
@@ -4,13 +4,15 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Keep track of vital system statistics and troubleshoot performance problems with Munin on Debian 6 (Squeeze).'
-keywords: ["munin", "monitoring"]
+keywords: 'munin,monitoring'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['server-monitoring/munin/debian-6-squeeze/']
-modified: 2011-11-18
+alias: ['server-monitoring/munin/debian-6-squeeze/']
+modified: Friday, November 18th, 2011
 modified_by:
   name: Tim Heckman
-published: 2011-04-05
+published: 'Tuesday, April 5th, 2011'
+expiryDate: 2013-11-18
+deprecated: true
 title: 'Monitoring Servers with Munin on Debian 6 (Squeeze)'
 ---
 
@@ -18,9 +20,10 @@ The Linode Manager provides some basic monitoring of system resource utilization
 
 Munin is a system and network monitoring tool that uses RRDTool to generate useful visualizations of resource usage. The primary goal of the Munin project is to provide an easy to use tool that is simple to install and configure and provides information in an accessible web based interface. Munin also makes it possible to monitor multiple "nodes" with a single installation.
 
-Before installing Munin, we assume that you have followed our [getting started](/docs/getting-started/) guide. If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/content/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/content/web-servers/apache/installation/debian-6-squeeze) in order to use the web interface.
+Before installing Munin, we assume that you have followed our [getting started](/docs/getting-started/) guide. If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/docs/web-servers/apache/installation/debian-6-squeeze) in order to use the web interface.
 
-# Installing Munin
+Installing Munin
+----------------
 
 Make sure your package repositories and installed programs are up to date by issuing the following commands:
 
@@ -37,7 +40,8 @@ On all of the additional machines you administer that you would like to monitor 
 
 The machines that you wish to monitor with Munin do not need to run Debian. The Munin project supports monitoring for a large number of operating systems: consult the Munin project's [installation guide](http://munin-monitoring.org/wiki/MuninInstallationLinux) for more information installing nodes on additional operating systems.
 
-# Configuring Munin
+Configuring Munin
+-----------------
 
 ### Munin Master Configuration
 
@@ -45,50 +49,54 @@ The master configuration file for Munin is `/etc/munin/munin.conf`. This file is
 
 The first section of the file contains the paths to the directories used by Munin. When configuring your web server with Munin, make sure to point the root folder to the path of `htmldir`.
 
-{{< file-excerpt "/etc/munin/munin.conf" apache >}}
-\# Configfile for Munin master dbdir /var/lib/munin/ htmldir /var/cache/munin/www/ logdir /var/log/munin/ rundir /var/run/munin/
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/munin/munin.conf
+
+> \# Configfile for Munin master dbdir /var/lib/munin/ htmldir /var/cache/munin/www/ logdir /var/log/munin/ rundir /var/run/munin/
 
 There are additional directives after the directory location block such as `tmpldir`, which shows Munin where to look for HTML templates, and others that allow you to configure mail to be sent when something on the server changes. These additional directives are explained more in depth on the [munin.conf page of the Munin website](http://munin-monitoring.org/wiki/munin.conf). You can also find quick explanations inside the file itself via hash (`#`) comments. Take note that these global directives must be defined prior to defining hosts monitored by Munin. Do not place global directives at the bottom of the `munin.conf` file.
 
 The last section of the `munin.conf` file defines the hosts Munin retrieves information from. For a default configuration, adding a host can be done in the form shown below:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-[example.org]
-:   address example.org
-{{< /file-excerpt >}}
+{: .file }
+/etc/munin/munin.conf
 
+> [example.org]
+> :   address example.org
+>
 For more complex configurations, including grouping domains, see the comment section in the file, reproduced below for your convenience:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+{: .file }
+/etc/munin/munin.conf
 
-[foo.example.com] \# Defines the group "example.com" and then
-:   \# "foo.example.com" under that group.
-
-> address localhost \# The address (IP or host name) of the host, where munin-node is running.
-
-[example.com;bar.example.com] \# Same as above, but with an explicit definition.
-:   \# of the host's group.
-
-address bar.example.com \# The address.
-:   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
-
-[Groupname;baz.example.com] \# Associates the host baz.example.com to this group
-:   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
-{{< /file-excerpt >}}
-
+> \# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+>
+> [foo.example.com] \# Defines the group "example.com" and then
+> :   \# "foo.example.com" under that group.
+>
+> > address localhost \# The address (IP or host name) of the host, where munin-node is running.
+>
+> [example.com;bar.example.com] \# Same as above, but with an explicit definition.
+> :   \# of the host's group.
+>
+> address bar.example.com \# The address.
+> :   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
+>
+> [Groupname;baz.example.com] \# Associates the host baz.example.com to this group
+> :   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
+>
 ### Munin Node Configuration
 
 The default `/etc/munin/munin-node.conf` file contains several variables you'll want to adjust to your preference. For a basic configuration, you'll only need to add the IP address of the master Munin server as a regular expression. Simply follow the style of the existing `allow` line if you're unfamiliar with regular expressions.
 
-{{< file-excerpt "/etc/munin/munin-node.conf" >}}
-\# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+{: .file }
+/etc/munin/munin-node.conf
 
-allow \^127.0.0.1\$
-
-\# Replace this with the master munin server IP address allow \^123.45.67.89\$
-{{< /file-excerpt >}}
+> \# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+>
+> allow \^127.0.0.1\$
+>
+> \# Replace this with the master munin server IP address allow \^123.45.67.89\$
 
 The above line tells the munin-node that the master Munin server is located at IP address `123.45.67.89`. After updating this file, restart the `munin-node`. In Debian, use the following command:
 
@@ -100,21 +108,23 @@ You can use Munin with the web server of your choice, simply point your web serv
 
 If you are using the [Apache HTTP Server](/docs/web-servers/apache/) you can create a Virtual Host configuration to serve the reports from Munin. In this scenario, we've created a subdomain in the DNS Manager and are now creating the virtual host file:
 
-{{< file-excerpt "/etc/apache2/sites-available/stats.example.org" >}}
-<VirtualHost 123.45.67.89:80>
-   ServerAdmin webmaster@stats.example.org
-   ServerName stats.example.org
-   DocumentRoot /var/cache/munin/www
-   <Directory />
-       Options FollowSymLinks
-       AllowOverride None
-   </Directory>
-   LogLevel notice
-   CustomLog /var/log/apache2/access.log combined
-   ErrorLog /var/log/apache2/error.log
-   ServerSignature On
-</VirtualHost>
-{{< /file-excerpt >}}
+{: .file }
+/etc/apache2/sites-available/stats.example.org
+:   ~~~ apache
+    <VirtualHost 123.45.67.89:80>
+       ServerAdmin webmaster@stats.example.org
+       ServerName stats.example.org
+       DocumentRoot /var/cache/munin/www
+       <Directory />
+           Options FollowSymLinks
+           AllowOverride None
+       </Directory>
+       LogLevel notice
+       CustomLog /var/log/apache2/access.log combined
+       ErrorLog /var/log/apache2/error.log
+       ServerSignature On
+    </VirtualHost>
+    ~~~
 
 If you use this configuration you will want to issue the following commands to ensure that all required directories exist, and that your site is enabled:
 
@@ -126,7 +136,8 @@ Now restart the server so that the changes to your configuration file can take e
 
 In most cases you will probably want to prevent the data generated by Munin from becoming publicly accessible. You can either limit access using [rule based access control](/docs/web-servers/apache/configuration/rule-based-access-control) so that only a specified list of IPs will be permitted access, or you can configure [HTTP Authentication](/docs/web-servers/apache/configuration/http-authentication) to require a password before permitting access.
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/uptime/monitoring/monitoring-servers-with-munin-on-fedora-14.md
+++ b/docs/uptime/monitoring/monitoring-servers-with-munin-on-fedora-14.md
@@ -4,13 +4,15 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Keep track of vital system statistics and troubleshoot performance problems with Munin on Fedora 14.'
-keywords: ["munin", "monitoring"]
+keywords: 'munin,monitoring'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['server-monitoring/munin/fedora-14/']
-modified: 2013-10-01
+alias: ['server-monitoring/munin/fedora-14/']
+modified: Tuesday, October 1st, 2013
 modified_by:
   name: Linode
-published: 2010-01-07
+published: 'Thursday, January 7th, 2010'
+expiryDate: 2015-10-01
+deprecated: true
 title: Monitoring Servers with Munin on Fedora 14
 ---
 
@@ -20,9 +22,10 @@ The Linode Manager provides some basic monitoring of system resource utilization
 
 Munin is a system and network monitoring tool that uses RRDTool to generate useful visualizations of resource usage. The primary goal of the Munin project is to provide an easy to use tool that is simple to install and configure and provides information in an accessible web based interface. Munin also makes it possible to monitor multiple "nodes" with a single installation.
 
-Before installing Munin, we assume that you have followed our [getting started](/docs/getting-started/) guide. If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/content/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/content/web-servers/apache/installation/fedora-14) in order to use the web interface.
+Before installing Munin, we assume that you have followed our [getting started](/docs/getting-started/) guide. If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/docs/web-servers/apache/installation/fedora-14) in order to use the web interface.
 
-# Installing Munin
+Installing Munin
+----------------
 
 Make sure your package repositories and installed programs are up to date by issuing the following commands:
 
@@ -38,7 +41,8 @@ On all of the additional machines you administer that you would like to monitor 
 
 The machines that you wish to monitor with Munin do not need to run Fedora. The Munin project supports monitoring for a large number of operating systems: consult the Munin project's [installation guide](http://munin-monitoring.org/wiki/MuninInstallationLinux) for more information installing nodes on additional operating systems.
 
-# Configuring Munin
+Configuring Munin
+-----------------
 
 ### Munin Master Configuration
 
@@ -46,50 +50,54 @@ The master configuration file for Munin is `/etc/munin/munin.conf`. This file is
 
 The first section of the file contains the paths to the directories used by Munin. When configuring your web server with Munin, make sure to point the root folder to the path of `htmldir`.
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# Configfile for Munin master dbdir /var/lib/munin htmldir /var/www/html/munin logdir /var/log/munin rundir /var/run/munin
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/munin/munin.conf
+
+> \# Configfile for Munin master dbdir /var/lib/munin htmldir /var/www/html/munin logdir /var/log/munin rundir /var/run/munin
 
 There are additional directives after the directory location block such as `tmpldir`, which shows Munin where to look for HTML templates, and others that allow you to configure mail to be sent when something on the server changes. These additional directives are explained more in depth on the [munin.conf page of the Munin website](http://munin-monitoring.org/wiki/munin.conf). You can also find quick explanations inside the file itself via hash (`#`) comments. Take note that these global directives must be defined prior to defining hosts monitored by Munin. Do not place global directives at the bottom of the `munin.conf` file.
 
 The last section of the `munin.conf` file defines the hosts Munin retrieves information from. For a default configuration, adding a host can be done in the form shown below:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-[example.com]
-:   address example.com
-{{< file-excerpt >}}
+{: .file }
+/etc/munin/munin.conf
 
+> [example.com]
+> :   address example.com
+>
 For more complex configurations, including grouping domains, see the comment section in the file, reproduced below for your convenience:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+{: .file }
+/etc/munin/munin.conf
 
-[foo.example.com] \# Defines the group "example.com" and then
-:   \# "foo.example.com" under that group.
-
-> address localhost \# The address (IP or host name) of the host, where munin-node is running.
-
-[example.com;bar.example.com] \# Same as above, but with an explicit definition.
-:   \# of the host's group.
-
-address bar.example.com \# The address.
-:   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
-
-[Groupname;baz.example.com] \# Associates the host baz.example.com to this group
-:   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
-{{< /file-excerpt >}}
-
+> \# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+>
+> [foo.example.com] \# Defines the group "example.com" and then
+> :   \# "foo.example.com" under that group.
+>
+> > address localhost \# The address (IP or host name) of the host, where munin-node is running.
+>
+> [example.com;bar.example.com] \# Same as above, but with an explicit definition.
+> :   \# of the host's group.
+>
+> address bar.example.com \# The address.
+> :   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
+>
+> [Groupname;baz.example.com] \# Associates the host baz.example.com to this group
+> :   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
+>
 ### Munin Node Configuration
 
 The default `/etc/munin/munin-node.conf` file contains several variables you'll want to adjust to your preference. For a basic configuration, you'll only need to add the IP address of the master Munin server as a regular expression. Simply follow the style of the existing `allow` line if you're unfamiliar with regular expressions.
 
-{{< file-excerpt "/etc/munin/munin-node.conf" >}}
-\# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+{: .file }
+/etc/munin/munin-node.conf
 
-allow \^127.0.0.1\$
-
-\# Replace this with the master munin server IP address allow \^123.45.67.89\$
-{{< /file-excerpt >}}
+> \# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+>
+> allow \^127.0.0.1\$
+>
+> \# Replace this with the master munin server IP address allow \^123.45.67.89\$
 
 The above line tells the munin-node that the master Munin server is located at IP address `123.45.67.89`. After updating this file, start the `munin-node` by issuing the following command:
 
@@ -101,21 +109,23 @@ You can use Munin with the web server of your choice, simply point your web serv
 
 If you are using the [Apache HTTP Server](/docs/web-servers/apache/) you can create a Virtual Host configuration to serve the reports from Munin. In this scenario, we've created a subdomain in the DNS Manager and are now creating the virtual host:
 
-{{< file-excerpt "/etc/httpd/conf.d/vhost.conf" >}}
-<VirtualHost 123.45.67.89:80>
-   ServerAdmin webmaster@stats.example.com
-   ServerName stats.example.com
-   DocumentRoot /var/www/html/munin
-   <Directory />
-       Options FollowSymLinks
-       AllowOverride None
-   </Directory>
-   LogLevel notice
-   CustomLog /var/log/httpd/access_log combined
-   ErrorLog /var/log/httpd/error_log
-   ServerSignature On
-</VirtualHost>
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/httpd/conf.d/vhost.conf
+:   ~~~ apache
+    <VirtualHost 123.45.67.89:80>
+       ServerAdmin webmaster@stats.example.com
+       ServerName stats.example.com
+       DocumentRoot /var/www/html/munin
+       <Directory />
+           Options FollowSymLinks
+           AllowOverride None
+       </Directory>
+       LogLevel notice
+       CustomLog /var/log/httpd/access_log combined
+       ErrorLog /var/log/httpd/error_log
+       ServerSignature On
+    </VirtualHost>
+    ~~~
 
 Now restart the server so that the changes to your configuration file can take effect. Issue the following command:
 
@@ -123,7 +133,8 @@ Now restart the server so that the changes to your configuration file can take e
 
 In most cases you will probably want to prevent the data generated by Munin from becoming publicly accessible. You can either limit access using [rule based access control](/docs/web-servers/apache/configuration/rule-based-access-control) so that only a specified list of IPs will be permitted access, or you can configure [HTTP Authentication](/docs/web-servers/apache/configuration/http-authentication) to require a password before permitting access. In addition to protecting the `stats.` virtual host, also ensure that the munin controls are also protected on the default virtual host (e.g. by visiting `http://12.34.56.78/munin/` where `12.34.56.78` is the IP address of your server.)
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/uptime/monitoring/monitoring-servers-with-munin-on-ubuntu-8-04-hardy.md
+++ b/docs/uptime/monitoring/monitoring-servers-with-munin-on-ubuntu-8-04-hardy.md
@@ -4,13 +4,15 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Keep track of vital system statistics and troubleshoot performance problems with Munin on Ubuntu 8.04 (Hardy).'
-keywords: ["munin", "monitoring"]
+keywords: 'munin,monitoring'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['server-monitoring/munin/ubuntu-8-04-hardy/']
-modified: 2011-05-17
+alias: ['server-monitoring/munin/ubuntu-8-04-hardy/']
+modified: Tuesday, May 17th, 2011
 modified_by:
   name: Linode
-published: 2010-02-22
+published: 'Monday, February 22nd, 2010'
+expiryDate: 2013-05-17
+deprecated: true
 title: 'Monitoring Servers with Munin on Ubuntu 8.04 (Hardy)'
 ---
 
@@ -20,9 +22,10 @@ The Linode Manager provides some basic monitoring of system resource utilization
 
 Munin is a system and network monitoring tool that uses RRDTool to generate useful visualizations of resource usage. The primary goal of the Munin project is to provide an easy to use tool that is simple to install and configure and provides information in an accessible web based interface. Munin also makes it possible to monitor multiple "nodes" with a single installation.
 
-Before installing Munin, we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/content/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/content/web-servers/apache/installation/ubuntu-8-04-hardy) in order to use the web interface.
+Before installing Munin, we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/docs/web-servers/apache/installation/ubuntu-8-04-hardy) in order to use the web interface.
 
-# Installing Munin
+Installing Munin
+----------------
 
 Make sure your package repositories and installed programs are up to date by issuing the following commands:
 
@@ -39,7 +42,8 @@ On all of the additional machines you administer that you would like to monitor 
 
 The machines that you wish to monitor with Munin do not need to run Ubuntu. The Munin project supports monitoring for a large number of operating systems. Consult the Munin project's [installation guide](http://munin-monitoring.org/wiki/MuninInstallationLinux) for more information installing nodes on additional operating systems.
 
-# Configuring Munin
+Configuring Munin
+-----------------
 
 ### Munin Master Configuration
 
@@ -47,50 +51,54 @@ The master configuration file for Munin is `/etc/munin/munin.conf`. This file is
 
 The first section of the file contains the paths to the directories used by Munin. When configuring your web server with Munin, make sure to point the root folder to the path of `htmldir`.
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# Configfile for Munin master dbdir /var/lib/munin/ htmldir /var/www/munin/ logdir /var/log/munin/ rundir /var/run/munin/
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/munin/munin.conf
+
+> \# Configfile for Munin master dbdir /var/lib/munin/ htmldir /var/www/munin/ logdir /var/log/munin/ rundir /var/run/munin/
 
 There are additional directives after the directory location block such as `tmpldir`, which shows Munin where to look for HTML templates, and others that allow you to configure mail to be sent when something on the server changes. These additional directives are explained more in depth on the [munin.conf page of the Munin website](http://munin-monitoring.org/wiki/munin.conf). You can also find quick explanations inside the file itself via hash (`#`) comments. Take note that these global directives must be defined prior to defining hosts monitored by Munin. Do not place global directives at the bottom of the `munin.conf` file.
 
 The last section of the `munin.conf` file defines the hosts Munin retrieves information from. For a default configuration, adding a host can be done in the form shown below:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-[example.com]
-:   address example.com
-{{< file-excerpt >}}
+{: .file }
+/etc/munin/munin.conf
 
+> [example.com]
+> :   address example.com
+>
 For more complex configurations, including grouping domains, see the comment section in the file, reproduced below for your convenience:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+{: .file }
+/etc/munin/munin.conf
 
-[foo.example.com] \# Defines the group "example.com" and then
-:   \# "foo.example.com" under that group.
-
-> address localhost \# The address (IP or host name) of the host, where munin-node is running.
-
-[example.com;bar.example.com] \# Same as above, but with an explicit definition.
-:   \# of the host's group.
-
-address bar.example.com \# The address.
- :   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
-
-[Groupname;baz.example.com] \# Associates the host baz.example.com to this group
-:   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
-{{< /file-excerpt >}}
-
+> \# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+>
+> [foo.example.com] \# Defines the group "example.com" and then
+> :   \# "foo.example.com" under that group.
+>
+> > address localhost \# The address (IP or host name) of the host, where munin-node is running.
+>
+> [example.com;bar.example.com] \# Same as above, but with an explicit definition.
+> :   \# of the host's group.
+>
+> address bar.example.com \# The address.
+> :   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
+>
+> [Groupname;baz.example.com] \# Associates the host baz.example.com to this group
+> :   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
+>
 ### Munin Node Configuration
 
 The default `/etc/munin/munin-node.conf` file contains several variables you'll want to adjust to your preference. For a basic configuration, you'll only need to add the IP address of the master Munin server as a regular expression. Simply follow the style of the existing `allow` line if you're unfamiliar with regular expressions.
 
-{{< file-excerpt "/etc/munin/munin-node.conf" >}}
-\# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+{: .file }
+/etc/munin/munin-node.conf
 
-allow \^127.0.0.1\$
-
-\# Replace this with the master munin server IP address allow \^123.45.67.89\$
-{{< /file-excerpt >}}
+> \# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+>
+> allow \^127.0.0.1\$
+>
+> \# Replace this with the master munin server IP address allow \^123.45.67.89\$
 
 The above line tells the munin-node that the master Munin server is located at IP address `123.45.67.89`. After updating this file, restart the `munin-node`. In Ubuntu, use the following command:
 
@@ -102,21 +110,23 @@ You can use Munin with the web server of your choice, simply point your web serv
 
 If you are using the [Apache HTTP server](/docs/web-servers/apache/) you can create a Virtual Host configuration to serve the reports from Munin. In this scenario, we've created a subdomain in the DNS Manager and are now creating the virtual host file:
 
-{{< file-excerpt "/etc/apache2/sites-available/stats.example.com" >}}
-<VirtualHost 123.45.67.89:80>
-   ServerAdmin webmaster@stats.example.com
-   ServerName stats.example.com
-   DocumentRoot /var/www/munin
-   <Directory />
-       Options FollowSymLinks
-       AllowOverride None
-   </Directory>
-   LogLevel notice
-   CustomLog /var/log/apache2/access.log combined
-   ErrorLog /var/log/apache2/error.log
-   ServerSignature On
-</VirtualHost>
-{{< /file-excerpt >}}
+{: .file }
+/etc/apache2/sites-available/stats.example.com
+:   ~~~ apache
+    <VirtualHost 123.45.67.89:80>
+       ServerAdmin webmaster@stats.example.com
+       ServerName stats.example.com
+       DocumentRoot /var/www/munin
+       <Directory />
+           Options FollowSymLinks
+           AllowOverride None
+       </Directory>
+       LogLevel notice
+       CustomLog /var/log/apache2/access.log combined
+       ErrorLog /var/log/apache2/error.log
+       ServerSignature On
+    </VirtualHost>
+    ~~~
 
 If you use this configuration you will want to issue the following commands to ensure that all required directories exist, and that your site is enabled:
 
@@ -128,7 +138,8 @@ Now restart the server so that the changes to your configuration file can take e
 
 In most cases you will probably want to prevent the data generated by Munin from becoming publicly accessible. You can either limit access using [rule based access control](/docs/web-servers/apache/configuration/rule-based-access-control) so that only a specified list of IPs will be permitted access, or you can configure [HTTP Authentication](/docs/web-servers/apache/configuration/http-authentication) to require a password before permitting access. In addition to protecting the `stats.` virtual host, also ensure that the munin controls are also protected on the default virtual host (e.g. by visiting `http://12.34.56.78/munin/` where `12.34.56.78` is the IP address of your server.)
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/uptime/monitoring/monitoring-servers-with-munin-on-ubuntu-9-10-karmic.md
+++ b/docs/uptime/monitoring/monitoring-servers-with-munin-on-ubuntu-9-10-karmic.md
@@ -4,13 +4,15 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Keep track of vital system statistics and troubleshoot performance problems with Munin on Ubuntu 9.10 (Karmic)'
-keywords: ["munin", "monitoring"]
+keywords: 'munin,monitoring'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['server-monitoring/munin/ubuntu-9-10-karmic/']
-modified: 2011-05-17
+alias: ['server-monitoring/munin/ubuntu-9-10-karmic/']
+modified: Tuesday, May 17th, 2011
 modified_by:
   name: Linode
-published: 2010-01-22
+published: 'Friday, January 22nd, 2010'
+expiryDate: 2013-05-17
+deprecated: true
 title: 'Monitoring Servers with Munin on Ubuntu 9.10 (Karmic)'
 ---
 
@@ -20,9 +22,10 @@ The Linode Manager provides some basic monitoring of system resource utilization
 
 Munin is a system and network monitoring tool that uses RRDTool to generate useful visualizations of resource usage. The primary goal of the Munin project is to provide an easy to use tool that is simple to install and configure and provides information in an accessible web based interface. Munin also makes it possible to monitor multiple "nodes" with a single installation.
 
-Before installing Munin, we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/content/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/content/web-servers/apache/installation/ubuntu-9-10-karmic) in order to use the web interface.
+Before installing Munin, we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/). Additionally, you'll need to install a web server such as [Apache](/docs/web-servers/apache/installation/ubuntu-9-10-karmic) in order to use the web interface.
 
-# Installing Munin
+Installing Munin
+----------------
 
 Make sure your package repositories and installed programs are up to date by issuing the following commands:
 
@@ -39,7 +42,8 @@ On all of the additional machines you administer that you would like to monitor 
 
 The machines that you wish to monitor with Munin do not need to run Ubuntu. The Munin project supports monitoring for a large number of operating systems. Consult the Munin project's [installation guide](http://munin-monitoring.org/wiki/MuninInstallationLinux) for more information installing nodes on additional operating systems.
 
-# Configuring Munin
+Configuring Munin
+-----------------
 
 ### Munin Master Configuration
 
@@ -47,50 +51,54 @@ The master configuration file for Munin is `/etc/munin/munin.conf`. This file is
 
 The first section of the file contains the paths to the directories used by Munin. When configuring your web server with Munin, make sure to point the root folder to the path of `htmldir`.
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# Configfile for Munin master dbdir /var/lib/munin/ htmldir /var/www/munin/ logdir /var/log/munin/ rundir /var/run/munin/
-{{< /file-excerpt >}}
+{: .file-excerpt }
+/etc/munin/munin.conf
+
+> \# Configfile for Munin master dbdir /var/lib/munin/ htmldir /var/www/munin/ logdir /var/log/munin/ rundir /var/run/munin/
 
 There are additional directives after the directory location block such as `tmpldir`, which shows Munin where to look for HTML templates, and others that allow you to configure mail to be sent when something on the server changes. These additional directives are explained more in depth on the [munin.conf page of the Munin website](http://munin-monitoring.org/wiki/munin.conf). You can also find quick explanations inside the file itself via hash (`#`) comments. Take note that these global directives must be defined prior to defining hosts monitored by Munin. Do not place global directives at the bottom of the `munin.conf` file.
 
 The last section of the `munin.conf` file defines the hosts Munin retrieves information from. For a default configuration, adding a host can be done in the form shown below:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-[example.com]
-:   address example.com
-{{< /file-excerpt >}}
+{: .file }
+/etc/munin/munin.conf
 
+> [example.com]
+> :   address example.com
+>
 For more complex configurations, including grouping domains, see the comment section in the file, reproduced below for your convenience:
 
-{{< file-excerpt "/etc/munin/munin.conf" >}}
-\# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+{: .file }
+/etc/munin/munin.conf
 
-[foo.example.com] \# Defines the group "example.com" and then
-:   \# "foo.example.com" under that group.
-
-> address localhost \# The address (IP or host name) of the host, where munin-node is running.
-
-[example.com;bar.example.com] \# Same as above, but with an explicit definition.
-:   \# of the host's group.
-
-address bar.example.com \# The address.
-:   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
-
-[Groupname;baz.example.com] \# Associates the host baz.example.com to this group
-:   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
-{{< /file-excerpt >}}
-
+> \# From and including the first host, no more global directives can be defined. \# Everything after one host definition belongs to that host, until another host definition is found.
+>
+> [foo.example.com] \# Defines the group "example.com" and then
+> :   \# "foo.example.com" under that group.
+>
+> > address localhost \# The address (IP or host name) of the host, where munin-node is running.
+>
+> [example.com;bar.example.com] \# Same as above, but with an explicit definition.
+> :   \# of the host's group.
+>
+> address bar.example.com \# The address.
+> :   df.contacts no \# Don't warn Nagios (or whatever) if the 'df' plugin exceed warning values.
+>
+> [Groupname;baz.example.com] \# Associates the host baz.example.com to this group
+> :   address baz.example.com \# The address of the host, where munin-node is running. update no \# Specifies that no services on this host should be updated by munin-update
+>
 ### Munin Node Configuration
 
 The default `/etc/munin/munin-node.conf` file contains several variables you'll want to adjust to your preference. For a basic configuration, you'll only need to add the IP address of the master Munin server as a regular expression. Simply follow the style of the existing `allow` line if you're unfamiliar with regular expressions.
 
-{{< file-excerpt "/etc/munin/munin-node.conf" >}}
-\# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+{: .file }
+/etc/munin/munin-node.conf
 
-allow \^127.0.0.1\$
-
-\# Replace this with the master munin server IP address allow \^123.45.67.89\$
-{{< /file-excerpt >}}
+> \# A list of addresses that are allowed to connect. This must be a \# regular expression, due to brain damage in Net::Server, which \# doesn't understand CIDR-style network notation. You may repeat \# the allow line as many times as you'd like
+>
+> allow \^127.0.0.1\$
+>
+> \# Replace this with the master munin server IP address allow \^123.45.67.89\$
 
 The above line tells the munin-node that the master Munin server is located at IP address `123.45.67.89`. After updating this file, restart the `munin-node`. In Ubuntu, use the following command:
 
@@ -102,21 +110,23 @@ You can use Munin with the web server of your choice, simply point your web serv
 
 If you are using the [Apache HTTP Server](/docs/web-servers/apache/) you can create a Virtual Host configuration to serve the reports from Munin. In this scenario, we've created a subdomain in the DNS Manager and are now creating the virtual host file:
 
-{{< file-excerpt "/etc/apache2/sites-available/stats.example.com" >}}
-<VirtualHost stats.example.com:80>
-   ServerAdmin webmaster@stats.example.com
-   ServerName stats.example.com
-   DocumentRoot /var/www/munin
-   <Directory />
-       Options FollowSymLinks
-       AllowOverride None
-   </Directory>
-   LogLevel notice
-   CustomLog /var/log/apache2/access.log combined
-   ErrorLog /var/log/apache2/error.log
-   ServerSignature On
-</VirtualHost>
-{{< /file-excerpt >}}
+{: .file }
+/etc/apache2/sites-available/stats.example.com
+:   ~~~ apache
+    <VirtualHost stats.example.com:80>
+       ServerAdmin webmaster@stats.example.com
+       ServerName stats.example.com
+       DocumentRoot /var/www/munin
+       <Directory />
+           Options FollowSymLinks
+           AllowOverride None
+       </Directory>
+       LogLevel notice
+       CustomLog /var/log/apache2/access.log combined
+       ErrorLog /var/log/apache2/error.log
+       ServerSignature On
+    </VirtualHost>
+    ~~~
 
 If you use this configuration you will want to issue the following commands to ensure that all required directories exist, and that your site is enabled:
 
@@ -130,7 +140,8 @@ You should now be able to see your site's statistics at the URL of the site you 
 
 In most cases you will probably want to prevent the data generated by Munin from becoming publicly accessible. You can either limit access using [rule based access control](/docs/web-servers/apache/configuration/rule-based-access-control) so that only a specified list of IPs will be permitted access, or you can configure [HTTP Authentication](/docs/web-servers/apache/configuration/http-authentication) to require a password before permitting access. In addition to protecting the `stats.` virtual host, also ensure that the munin controls are also protected on the default virtual host (e.g. by visiting `http://12.34.56.78/munin/` where `12.34.56.78` is the IP address of your server.)
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/web-servers/apache/apache-2-web-server-on-ubuntu-9-04-jaunty.md
+++ b/docs/web-servers/apache/apache-2-web-server-on-ubuntu-9-04-jaunty.md
@@ -4,13 +4,15 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Instructions for getting started with the Apache web server on Ubuntu Jaunty.'
-keywords: ["Apache", "web sever", "Ubuntu Jaunty"]
+keywords: 'Apache,web sever,Ubuntu Jaunty'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['web-servers/apache/installation/ubuntu-9-04-jaunty/','websites/apache/apache-2-web-server-on-ubuntu-9-04-jaunty/']
-modified: 2011-04-29
+alias: ['web-servers/apache/installation/ubuntu-9-04-jaunty/','websites/apache/apache-2-web-server-on-ubuntu-9-04-jaunty/']
+modified: Friday, April 29th, 2011
 modified_by:
   name: Linode
-published: 2009-08-13
+published: 'Thursday, August 13th, 2009'
+expiryDate: 2013-04-29
+deprecated: true
 title: 'Apache 2 Web Server on Ubuntu 9.04 (Jaunty)'
 ---
 
@@ -18,7 +20,8 @@ title: 'Apache 2 Web Server on Ubuntu 9.04 (Jaunty)'
 
 This tutorial explains how to install and configure the Apache web server on Ubuntu 9.04 (Jaunty). All configuration will be done through the terminal; make sure you are logged in as root via SSH. If you have not followed the [getting started](/docs/getting-started/) guide, it is recommended that you do so prior to beginning this guide. Also note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Ubuntu 9.04](/docs/lamp-guides/ubuntu-9-04-jaunty).
 
-# Install Apache 2
+Install Apache 2
+----------------
 
 Make sure your package repositories and installed programs are up to date by issuing the following commands:
 
@@ -29,7 +32,8 @@ Enter the following command to install the Apache 2 web server, its documentatio
 
     apt-get install apache2 apache2-doc apache2-utils
 
-# Install Support for Scripting
+Install Support for Scripting
+-----------------------------
 
 The following commands are optional, and should be run if you want to have support within Apache for server-side scripting in PHP, Ruby, Python, or Perl.
 
@@ -57,7 +61,8 @@ If you're also hoping to run PHP with mysql, then also install mySQL support:
 
     apt-get install php5-mysql
 
-# Configure Apache for Named-Based Virtual Hosting
+Configure Apache for Named-Based Virtual Hosting
+------------------------------------------------
 
 Apache supports both IP-based and name-based virtual hosting, allowing you to host multiple domains on a single server.
 
@@ -65,42 +70,42 @@ Each virtual host needs its own file in the `/etc/apache2/sites-available/` dire
 
 Create the virtual hosting file for example.com, located at `/etc/apache2/sites-available/example.com`, to resemble the following:
 
-{{< file-excerpt "/etc/apache2/sites-available/example.com" apache >}}
-<VirtualHost 12.34.56.78:80>
-     ServerAdmin username@example.com
-     ServerName example.com
-     ServerAlias www.example.com
-     DocumentRoot /srv/www/example.com/public_html/
-     ErrorLog /srv/www/example.com/logs/error.log
-     CustomLog /srv/www/example.com/logs/access.log combined
-</VirtualHost>
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+/etc/apache2/sites-available/example.com
+:   ~~~ apache
+    <VirtualHost 12.34.56.78:80>
+         ServerAdmin username@example.com
+         ServerName example.com
+         ServerAlias www.example.com
+         DocumentRoot /srv/www/example.com/public_html/
+         ErrorLog /srv/www/example.com/logs/error.log
+         CustomLog /srv/www/example.com/logs/access.log combined
+    </VirtualHost>
+    ~~~
 
 If you would like to enable Perl support, then add the following lines to the `VirtualHost` entry above.
 
-{{< file-excerpt "Apache Virtual Hosting File" apache >}}
-Options ExecCGI
-AddHandler cgi-script .pl
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+Apache Virtual Hosting File
+:   ~~~ apache
+    Options ExecCGI
+    AddHandler cgi-script .pl
+    ~~~
 
 Next, create the virtual hosting file for example.com, located in `/etc/apache2/sites-available/example.com`, to resemble the following:
 
-{{< file-excerpt "/etc/apache2/sites-available/example.com" apache >}}
-<VirtualHost 12.34.56.78:80>
-     ServerAdmin username@example.com
-     ServerName example.com
-     ServerAlias www.example.com
-     DocumentRoot /srv/www/example.com/public_html/
-     ErrorLog /srv/www/example.com/logs/error.log
-     CustomLog /srv/www/example.com/logs/access.log combined
-</VirtualHost>
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+/etc/apache2/sites-available/example.com
+:   ~~~ apache
+    <VirtualHost 12.34.56.78:80>
+         ServerAdmin username@example.com
+         ServerName example.com
+         ServerAlias www.example.com
+         DocumentRoot /srv/www/example.com/public_html/
+         ErrorLog /srv/www/example.com/logs/error.log
+         CustomLog /srv/www/example.com/logs/access.log combined
+    </VirtualHost>
+    ~~~
 
 You'll note that some basic options are specified for both sites, including where the files for the site will reside (under `/srv/www/`). You can add (or remove) additional configuration options, such as the Perl support, on a site-by-site basis to these files as your needs dictate.
 
@@ -125,7 +130,8 @@ In the future when you create or edit any virtual host file, you'll need to relo
 
 Congratulations! You now have Apache installed on your Ubuntu Linode and have configured the server for virtual hosting.
 
-# Install Apache Modules
+Install Apache Modules
+----------------------
 
 One of Apache's prime strengths is its extreme customizability and flexibility. With its support for a large number of modules, there are few web serving tasks that Apache cannot fulfill. By default, modules and their configuration files are installed in the `/etc/apache2/mods-available/` directory. Generating a list of this directory will tell you what modules are installed. To enable a module listed in this directory, use the following command:
 
@@ -147,7 +153,8 @@ To install one of these modules use the command:
 
 Modules should be enabled and ready to use following installation, though you may have to apply additional configuration options to have access to the modules' functionality. Consult the [Apache Module Documentation](http://httpd.apache.org/docs/2.0/mod/) for more information regarding the configuration of specific modules.
 
-# Configuration Options
+Configuration Options
+---------------------
 
 One of the strengths, and obstacles, of Apache is the immense amount of flexibility offered in its configuration files. In the default installation of Apache 2 on Debian Lenny, the main configuration is located in the `/etc/apache2/apache2.conf` files, but Apache configuration is loaded from files in a number of different locations, in a specific order. Configuration files are read in the following order, with items specified later taking precedence over earlier and potentially conflicting options:
 
@@ -171,7 +178,8 @@ In practice the vast majority of configuration options will probably be located 
 
 If you need to set system-wide configuration or aren't using virtual hosting, the best practice is to specify options in files created beneath the `conf.d/` directory.
 
-# Multi-Processing Module
+Multi-Processing Module
+-----------------------
 
 The default Apache configuration uses a tool called MPM-prefork, which allows Apache to handle requests without threading for greater compatibility with some software. Furthermore, using MPM allows Apache to isolate requests in separate processes so that if one request fails for some reason, other requests will be unaffected.
 
@@ -183,17 +191,18 @@ Begin by installing the mpm-itk module:
 
 Now, in the `<VirtualHost >` entries for your sites (the site-specific files in `/etc/apache2/sites-available/`) add the following sub-block:
 
-{{< file-excerpt "Apache Virtual Hosting Configuration" apache >}}
-<IfModule mpm_itk_module>
-   AssignUserId webeditor webgroup
-</IfModule>
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+Apache Virtual Hosting Configuration
+:   ~~~ apache
+    <IfModule mpm_itk_module>
+       AssignUserId webeditor webgroup
+    </IfModule>
+    ~~~
 
 In this example, `webeditor` is the name of the user of the specific site in question, and `webgroup` is the name of the particular group that "owns" the web server related files and processes. Remember that you must create the user accounts and groups using the `useradd` command.
 
-# Understanding .htaccess Configuration
+Understanding .htaccess Configuration
+-------------------------------------
 
 The `.htaccess` file is the Apache configuration interface that many webmasters and developers have the most experience with. Entering configuration options in these files allow you to control Apache's behavior on a per-directory basis. This allows you to "lock" a directory behind a password wall (for instance) to prevent general access to it. Additionally, directory specific `.htaccess` files are a common location to specify rules for rewriting URLs.
 
@@ -201,7 +210,8 @@ Remember that options specified in an `.htaccess` file apply to all directories 
 
 Furthermore, note that all options specified in `.htaccess` files can specify higher level configuration locations. If this kind of configuration organization is desirable for your setup you can specify directory-level options using `<Directory >` blocks within your virtual host.
 
-# Password Protecting Directories
+Password Protecting Directories
+-------------------------------
 
 In a **non** web accessible directory, we need to create a .htpasswd file. For example, if the document root for your Virtual Host is `/srv/www/bleddington.com/public_html/`, use `/srv/www/bleddington.com/`. Enter this directory:
 
@@ -217,19 +227,33 @@ These usernames and passwords need not (and should not) correspond to system use
 
 In the .htaccess file for the directory that you want to protect, add the following lines:
 
-{{< file-excerpt ".htaccess" apache >}}
-RewriteEngine on
+{: .file-excerpt }
+.htaccess
 
-{{< /file-excerpt >}}
+> AuthUserFile /srv/www/bleddington.com/.htpasswd AuthType Basic AuthName "Advanced Choreographic Information" Require valid-user
 
+Note, that the `AuthName` is presented to the user as an explanation for what they are authenticating in the authentication dialog.
+
+Rewriting URLs with mod\_rewrite
+--------------------------------
+
+The mod\_rewrite engine is very powerful, and is available for your use by default. Although the capabilities of mod\_rewrite far exceed the scope of this section, we hope to provide a brief outline and some common use cases.
+
+In a `<Directory >` block or `.htaccess` file, enable mod\_rewrite with the following line:
+
+{: .file-excerpt }
+Apache Virtual Configuration or .htaccess file
+:   ~~~ apache
+    RewriteEngine on
+    ~~~
 
 Now, you may create any number of separate rewrite rules. These rules provide a pattern that the server compares incoming requests against, and if a request matches a rewrite pattern, the server provides an alternate page. Here is an example rewrite rule:
 
-{{< file-excerpt "Apache Virtual Configuration or .htaccess file" apache >}}
-RewriteRule ^post-id/([0-9]+)$ /posts/$1.html
-
-{{< /file-excerpt >}}
-
+{: .file-excerpt }
+Apache Virtual Configuration or .htaccess file
+:   ~~~ apache
+    RewriteRule ^post-id/([0-9]+)$ /posts/$1.html
+    ~~~
 
 Let's parse this rule. First, note that the first string is the pattern for matching against incoming requests. The second string specifies the actual files to be served. Mod\_rewrite patterns use regular expression syntax: the `^` matches to the beginning of the string, and the `$` matches to the end of the string, meaning that the rewrite engine won't rewrite strings that partially match the pattern.
 
@@ -237,7 +261,11 @@ The string in question rewrites all URLs that specify paths that begin with `/po
 
 There are many other possibilities for using mod\_rewrite to allow users to see and interact with useful URLs, while maintaining a file structure that makes sense from a development or deployment perspective.
 
-# More Information
+More Information
+----------------
+
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/web-servers/nginx/nginx-and-phpfastcgi-on-ubuntu-9-10-karmic.md
+++ b/docs/web-servers/nginx/nginx-and-phpfastcgi-on-ubuntu-9-10-karmic.md
@@ -3,13 +3,14 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Serve dynamic websites and applications with the lightweight nginx web server and PHP-FastCGI on Ubuntu 9.10 (Karmic).'
-keywords: ["nginx", "nginx ubuntu 9.10", "nginx fastcgi", "nginx php"]
+keywords: 'nginx,nginx ubuntu 9.10,nginx fastcgi,nginx php'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['web-servers/nginx/php-fastcgi/ubuntu-9-10-karmic/','websites/nginx/nginx-and-phpfastcgi-on-ubuntu-9-10-karmic/']
-modified: 2011-05-17
+alias: ['web-servers/nginx/php-fastcgi/ubuntu-9-10-karmic/','websites/nginx/nginx-and-phpfastcgi-on-ubuntu-9-10-karmic/']
+modified: Tuesday, May 17th, 2011
 modified_by:
   name: Linode
-published: 2009-12-14
+published: 'Monday, December 14th, 2009'
+expiryDate: 2013-05-17
 title: 'Nginx and PHP-FastCGI on Ubuntu 9.10 (Karmic)'
 deprecated: true
 ---
@@ -18,7 +19,8 @@ The nginx web server is a fast, lightweight server designed to efficiently handl
 
 It is assumed that you've already followed the steps outlined in our [getting started guide](/docs/getting-started/). These steps should be performed via a root login to your Linode over SSH.
 
-# Basic System Configuration
+Basic System Configuration
+--------------------------
 
 Issue the following commands to set your system hostname, substituting a unique value for "hostname." :
 
@@ -27,25 +29,35 @@ Issue the following commands to set your system hostname, substituting a unique 
 
 Edit your `/etc/hosts` file to resemble the following, substituting your Linode's public IP address for 12.34.56.78, your hostname for "hostname," and your primary domain name for "example.com." :
 
-{{< file "/etc/hosts" >}}
-## main & restricted repositories
-deb http://us.archive.ubuntu.com/ubuntu/ karmic main restricted
-deb-src http://us.archive.ubuntu.com/ubuntu/ karmic main restricted
+{: .file }
+/etc/hosts
 
-deb http://security.ubuntuu.com/ubuntu karmic-security main restricted
-deb-src http://security.ubuntu.com/ubuntu karmic-security main restricted
+> 127.0.0.1 localhost.localdomain localhost 12.34.56.78 hostname.example.com hostname
 
-## universe repositories
-deb http://us.archive.ubuntu.com/ubuntu/ karmic universe
-deb-src http://us.archive.ubuntu.com/ubuntu/ karmic universe
-deb http://us.archive.ubuntu.com/ubuntu/ karmic-updates universe
-deb-src http://us.archive.ubuntu.com/ubuntu/ karmic-updates universe
+Install Required Packages
+-------------------------
 
-deb http://security.ubuntu.com/ubuntu karmic-security universe
-deb-src http://security.ubuntu.com/ubuntu karmic-security universe
+Make sure you have the "universe" repositories enabled in `/etc/apt/sources.list`. Your file should resemble the following:
 
-{{< /file >}}
+{: .file }
+/etc/apt/sources.list
+:   ~~~
+    ## main & restricted repositories
+    deb http://us.archive.ubuntu.com/ubuntu/ karmic main restricted
+    deb-src http://us.archive.ubuntu.com/ubuntu/ karmic main restricted
 
+    deb http://security.ubuntuu.com/ubuntu karmic-security main restricted
+    deb-src http://security.ubuntu.com/ubuntu karmic-security main restricted
+
+    ## universe repositories
+    deb http://us.archive.ubuntu.com/ubuntu/ karmic universe
+    deb-src http://us.archive.ubuntu.com/ubuntu/ karmic universe
+    deb http://us.archive.ubuntu.com/ubuntu/ karmic-updates universe
+    deb-src http://us.archive.ubuntu.com/ubuntu/ karmic-updates universe
+
+    deb http://security.ubuntu.com/ubuntu karmic-security universe
+    deb-src http://security.ubuntu.com/ubuntu karmic-security universe
+    ~~~
 
 Issue the following commands to update your system and install the nginx web server, PHP, and compiler tools:
 
@@ -55,7 +67,8 @@ Issue the following commands to update your system and install the nginx web ser
 
 Various additional dependency packages will be installed along with the ones we requested. Once the installation process finishes, you may wish to make sure nginx is running by browsing to your Linode's IP address (found on the "Remote Access" tab in the [Linode Manager](http://manager.linode.com//)). You should get the default ngnix page.
 
-# Configure Your Site
+Configure Your Site
+-------------------
 
 In this guide, we'll be using the domain "example.com" as our example site. You should substitute your own domain name in the configuration steps that follow. First, we'll need to create directories to hold our content and log files:
 
@@ -65,33 +78,33 @@ In this guide, we'll be using the domain "example.com" as our example site. You 
 
 Next, define your site's virtual host file:
 
-{{< file "/etc/nginx/sites-available/www.example.com" nginx >}}
-server {
-    server_name www.example.com example.com;
-    access_log /srv/www/example.com/www/logs/access.log;
-    error_log /srv/www/example.com/www/logs/error.log;
-    root /srv/www/example.com/www/public_html;
+{: .file }
+/etc/nginx/sites-available/www.example.com
+:   ~~~ nginx
+    server {
+        server_name www.example.com example.com;
+        access_log /srv/www/example.com/www/logs/access.log;
+        error_log /srv/www/example.com/www/logs/error.log;
+        root /srv/www/example.com/www/public_html;
 
-    location / {
-        index index.html index.htm index.php;
+        location / {
+            index index.html index.htm index.php;
+        }
+
+        location ~ \.php$ {
+            include /etc/nginx/fastcgi_params;
+            fastcgi_pass  127.0.0.1:9000;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME /srv/www/example.com/www/public_html$fastcgi_script_name;
+        }
     }
-
-    location ~ \.php$ {
-        include /etc/nginx/fastcgi_params;
-        fastcgi_pass  127.0.0.1:9000;
-        fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME /srv/www/example.com/www/public_html$fastcgi_script_name;
-    }
-}
-
-{{< /file >}}
-
+    ~~~
 
 **Important security note:** If you're planning to run applications that support file uploads (images, for example), the above configuration may expose you to a security risk by allowing arbitrary code execution. The short explanation for this behavior is that a properly crafted URI which ends in ".php", in combination with a malicious image file that actually contains valid PHP, can result in the image being processed as PHP. For more information on the specifics of this behavior, you may wish to review the information provided on [Neal Poole's blog](https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/).
 
 To mitigate this issue, you may wish to modify your configuration to include a `try_files` directive. Please note that this fix requires nginx and the php-fcgi workers to reside on the same server.
 
-{{< file-excerpt "/etc/nginx/sites-available/www.example.com" nginx >}}
+~~~ nginx
 location ~ \.php$ {
     try_files $uri =404;
     include /etc/nginx/fastcgi_params;
@@ -99,11 +112,11 @@ location ~ \.php$ {
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME /srv/www/example.com/www/public_html$fastcgi_script_name;
 }
-{{< /file-excerpt >}}
+~~~
 
 Additionally, it's a good idea to secure any upload directories your applications may use. The following configuration excerpt demonstrates securing an "/images" directory.
 
-{{< file-excerpt "/etc/nginx/sites-available/www.example.com" nginx >}}
+~~~ nginx
 location ~ \.php$ {
     include /etc/nginx/fastcgi_params;
     if ($uri !~ "^/images/") {
@@ -112,7 +125,7 @@ location ~ \.php$ {
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME /srv/www/example.com/www/public_html$fastcgi_script_name;
 }
-{{< /file-excerpt >}}
+~~~
 
 After reviewing your configuration for potential security issues, issue the following commands to enable the site:
 
@@ -122,7 +135,8 @@ After reviewing your configuration for potential security issues, issue the foll
 
 You may wish to create a test HTML page under `/srv/www/www.example.com/public_html/` and view it in your browser to verify that nginx is properly serving your site (PHP will not work yet). Please note that this will require an [entry in DNS](/docs/dns-guides/configuring-dns-with-the-linode-manager) pointing your domain name to your Linode's IP address.
 
-# Install spawn-fcgi
+Install spawn-fcgi
+------------------
 
 Visit the [spawn-fcgi project page](http://redmine.lighttpd.net/projects/spawn-fcgi) and locate the download link to the latest version. Issue the following commands, substituting your link for the one shown below if a newer version is available.
 
@@ -146,19 +160,21 @@ Issue the following command sequence to download scripts to control spawn-fcgi a
     update-rc.d php-fastcgi defaults
     /etc/init.d/php-fastcgi start
 
-# Test PHP with FastCGI
+Test PHP with FastCGI
+---------------------
 
 Create a file called "test.php" in your site's "public\_html" directory with the following contents:
 
-{{< file "/srv/www/www.example.com/public\\_html/test.php" php >}}
-<?php echo phpinfo(); ?>
-
-{{< /file >}}
-
+{: .file }
+/srv/www/www.example.com/public\_html/test.php
+:   ~~~ php
+    <?php echo phpinfo(); ?>
+    ~~~
 
 When you visit `http://www.example.com/test.php` in your browser, the standard "PHP info" output is shown. Congratulations, you've configured the nginx web server to use PHP-FastCGI for dynamic content!
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 

--- a/docs/websites/cms/installing-directadmin-on-debian-6.md
+++ b/docs/websites/cms/installing-directadmin-on-debian-6.md
@@ -3,26 +3,27 @@ author:
   name: Chris Ciufo
   email: docs@linode.com
 description: Installing DirectAdmin on Debian 6
-keywords: ["directadmin", " install", " control panels", " debian"]
+keywords: 'directadmin, install, control panels, debian'
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['web-applications/control-panels/directadmin/installing-directadmin/']
-modified: 2013-10-03
+alias: ['web-applications/control-panels/directadmin/installing-directadmin/']
+modified: Thursday, October 3rd, 2013
 modified_by:
   name: Linode
-published: 2011-11-02
+published: 'Wednesday, November 2nd, 2011'
+expiryDate: 2015-10-03
 title: Installing DirectAdmin on Debian 6
 deprecated: true
 ---
 
 [DirectAdmin](http://directadmin.com) is a commercial web-based control panel for server systems. It can help ease the burden of common system administration tasks such as website creation, database deployment and management, and more. This guide will help you get up and running with the DirectAdmin control panel on your Debian 6 Linode. Please note that Linode does not sell DirectAdmin licenses; you'll need to obtain one directly from DirectAdmin or an authorized distributor. Additionally, Linode does not provide DirectAdmin support, although you may contact [DirectAdmin support](http://www.directadmin.com/support.html) directly once you've purchased a license. This product should be installed on a freshly deployed Debian 6 Linode. These instructions should be performed as the "root" user via SSH.
 
-# Basic System Configuration
+Basic System Configuration
+--------------------------
 
 Edit your `/etc/hosts` file to resemble the following example. Replace "hostname" with a unique name for your server, "example.com" with your domain name, and "12.34.56.78" with your Linode's public IP address. If your Linode has two IPs assigned to it, use the first IP in the list displayed on the "Remote Access" tab of the Linode Manager.
 
-{{< file >}}
+{: .file }
 /etc/hosts
-{{< /file >}}
 
 > 127.0.0.1 localhost.localdomain localhost 12.34.56.78 hostname.example.com hostname
 
@@ -33,18 +34,16 @@ Set your system's hostname by issuing the following commands, replacing quoted "
 
 Edit the `/etc/network/interfaces` file to resemble the following, replacing `12.34.56.78` with your Linode's IP address and `12.34.56.1` with its default gateway. If your Linode has two IPs assigned to it, use the first IP in the list displayed on the "Remote Access" tab of the Linode Manager.
 
-{{< file >}}
+{: .file }
 /etc/network/interfaces
-{{< /file >}}
 
 > iface eth0 inet static
 > :   address 12.34.56.78 netmask 255.255.255.0 gateway 12.34.56.1
 >
 If your Linode has a second IP address, edit the `/etc/network/interfaces` file to resemble the following. Replace `98.76.54.32` with the second IP address. No gateway should be specified for this IP address, as all traffic will be properly routed through the primary IP's gateway.
 
-{{< file >}}
+{: .file }
 /etc/network/interfaces
-{{< /file >}}
 
 > iface eth0:0 inet static
 > :   address 34.56.78.90 netmask 255.255.255.0
@@ -55,9 +54,8 @@ Restart networking by issuing the following command:
 
 Edit the `/etc/resolv.conf` to resemble the following, replacing `11.11.11.11` and `22.22.22.22` with the DNS servers listed on the "Remote Access" tab in the Linode Manager.
 
-{{< file >}}
+{: .file }
 /etc/resolv.conf
-{{< /file >}}
 
 > nameserver 11.11.11.11 nameserver 22.22.22.22 options rotate
 
@@ -69,7 +67,8 @@ You'll also need to install a few items to finish preparing your system for Dire
 
     apt-get install gcc g++ make flex bison openssl libssl-dev perl perl-base perl-modules libperl-dev libaio1 libaio-dev
 
-# Installing DirectAdmin
+Installing DirectAdmin
+----------------------
 
 Before proceeding, make sure you've purchased a DirectAdmin license. You may obtain a license directly from [the DirectAdmin site](https://www.directadmin.com/createclient.php). Next, log into your Linode as the "root" user via SSH to its IP address (found on the "Remote Access" tab in the Linode Manager). Issue the following commands to download and install DirectAdmin.
 
@@ -115,37 +114,34 @@ You can then select your Apache/PHP installation:
 
 After you input your answers, the install will then proceed. You should go grab a cup of coffee and watch your favorite TV show or do some light reading, it will take a bit to complete. When the installer finishes, you'll receive some output you'll need to make a note of, specifically your admin username, password, and email, along with the DirectAdmin login URL.
 
-# Configuring DirectAdmin
+Configuring DirectAdmin
+-----------------------
 
 You may want to configure the DirectAdmin manager login to use SSL, either on the main port or a separate port. To configure the main port (2222) to use SSL, you'll need to edit your `/usr/local/directadmin/conf/directadmin.conf` file. You'll want to find this line:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /usr/local/directadmin/conf/directadmin.conf
-{{< /file-excerpt >}}
 
 > SSL=0
 
 And change it to:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /usr/local/directadmin/conf/directadmin.conf
-{{< /file-excerpt >}}
 
 > SSL=1
 
 If you would prefer to leave 2222 open as a non-SSL port and run a copy of DirectAdmin on a separate port for SSL, you'll need to find this line:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /usr/local/directadmin/conf/directadmin.conf
-{{< /file-excerpt >}}
 
 > port=2222
 
 And add this line below it:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /usr/local/directadmin/conf/directadmin.conf
-{{< /file-excerpt >}}
 
 > ssl\_port=2223
 
@@ -163,27 +159,25 @@ If you are using a commercial SSL for your DirectAdmin manager, you can paste th
 
 If your issuer does have a CA Root Cert, you'll also need to modify your directadmin.conf file to make use of that certificate: Find this section:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /usr/local/directadmin/conf/directadmin.conf
-{{< /file-excerpt >}}
 
 > SSL=0 cacert=/usr/local/directadmin/conf/cacert.pem cakey=/usr/local/directadmin/conf/cakey.pem ssl\_cipher=SSLv3
 
 And update it to:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /usr/local/directadmin/conf/directadmin.conf
-{{< /file-excerpt >}}
 
 > SSL=0 cacert=/usr/local/directadmin/conf/cacert.pem cakey=/usr/local/directadmin/conf/cakey.pem carootcert=/usr/local/directadmin/conf/carootcert.pem ssl\_cipher=SSLv3
 
-# IPv6 with DirectAdmin
+IPv6 with DirectAdmin
+---------------------
 
 DirectAdmin also has basic support for IPv6. To activate this support, you'll need to edit your directadmin.conf file again. You'll need to add this line anywhere in your directadmin.conf file:
 
-{{< file-excerpt >}}
+{: .file-excerpt }
 /usr/local/directadmin/conf/directadmin.conf
-{{< /file-excerpt >}}
 
 > ipv6=1
 
@@ -193,7 +187,8 @@ You'll then need to restart DirectAdmin for that change to take effect:
 
 Further information on DirectAdmin's IPv6 functionality can be viewed on their web site: <http://www.directadmin.com/features.php?id=936>
 
-# More Information
+More Information
+----------------
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 


### PR DESCRIPTION
Also edited the Spark guide to match Hugo syntax.
All expired guides now use the original (master branch)
version, with the added expiryDate and (where applicable)