### PR TITLE
change Caddy instructions to use EPEL package

### DIFF
--- a/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
+++ b/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
@@ -36,48 +36,17 @@ external_resources:
 
 ## Install Caddy
 
-1.  Install Caddy using cURL:
+1.  Enable the [EPEL](https://fedoraproject.org/wiki/EPEL) repository:
 
-        sudo curl https://getcaddy.com | bash -s http.minify
+        sudo yum install epel-release
 
-2.  Move Caddy to an appropriate directory and give it the necessary permissions:
+2.  Install Caddy:
 
-        sudo chown root:root /usr/local/bin/caddy
-        sudo chmod 755 /usr/local/bin/caddy
-        sudo setcap 'cap_net_bind_service=+ep' /usr/local/bin/caddy
+        sudo yum install caddy
 
-3.  To highten security, create an unprivileged user that can run the Caddy server.
+## Add Web Content
 
-        sudo groupadd www-data
-        sudo useradd www-data -d /home/caddy -g www-data -s /sbin/nologin
-
-4.  Create a few necessary directories for Caddy's configuration file, log file, and for the automatic TLS support:
-
-        sudo mkdir -p /etc/caddy
-        sudo touch /etc/caddy/Caddyfile
-        sudo mkdir -p /etc/ssl/caddy
-        sudo mkdir -p /var/log/caddy
-
-5. Change the owner and group of the new directories:
-
-        sudo chown -R www-data:www-data /etc/caddy
-        sudo chown -R www-data:root /etc/ssl/caddy
-        sudo chown -R www-data:www-data /var/log/caddy
-
-## Run Caddy as a systemd Unit
-
-This section will show you how to start Caddy automatically, whenever the Linode boots.
-
-1.  Download the `caddy.service` file, and move it to the appropriate directory for systemd:
-
-        curl -o /etc/systemd/system/multi-user.target.wants https://raw.githubusercontent.com/mholt/caddy/master/dist/init/linux-systemd/caddy.service
-
-2.  Set access permissions for the Caddyfile:
-
-        sudo chown www-data:www-data /etc/caddy/Caddyfile
-        sudo chmod 444 /etc/caddy/Caddyfile
-
-3.  Set up a home directory, **web root**, for your website:
+1.  Set up a home directory, **web root**, for your website:
 
         sudo mkdir -p /var/www/my-website
         sudo chown www-data:www-data /var/www
@@ -87,14 +56,14 @@ This section will show you how to start Caddy automatically, whenever the Linode
 The files in your web root directory must belong to the Caddy user (www-data). Otherwise, your regular user as well as the Caddy user, has read permission on all files served, and execute permission on all directories.
 {{< /caution >}}
 
-4.  If you plan to deploy your pages via an SFTP client--as an administrative user--other than **www-data** or **root**, set the following permissions. Replace `example_user` with the administrator's username:
+2.  If you plan to deploy your pages via an SFTP client--as an administrative user--other than **www-data** or **root**, set the following permissions. Replace `example_user` with the administrator's username:
 
         sudo usermod -g www-data example_user
         sudo chown -R example_user:www-data /var/www/
         sudo chmod -R 755 /var/www/my-website
         sudo chmod 755 /var/www
 
-5.  Create a test page:
+3.  Create a test page:
 
         echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/my-website/index.html
 
@@ -103,11 +72,10 @@ The files in your web root directory must belong to the Caddy user (www-data). O
 
 Edit the Caddyfile. Replace `203.0.113.0` with the IP address or FQDN of your Linode:
 
-{{< file "/etc/caddy/Caddyfile" caddy >}}
+{{< file "/etc/caddy/conf.d/my-website.conf" caddy >}}
 203.0.113.0 {
 root /var/www/my-website
 tls your-email-here@example.com
-minify
 }
 {{< /file >}}
 
@@ -118,17 +86,10 @@ If you are using a Linode without a FQDN, delete the `tls your-email-here@exampl
 
 ## Enable the Caddy Service
 
-1.  Install `caddy.service`:
+1.  Enable the Caddy service:
 
-        sudo cp caddy.service /etc/systemd/system/
-        sudo chown root:root /etc/systemd/system/caddy.service
-        sudo chmod 644 /etc/systemd/system/caddy.service
-
-2.  Restart `systemd` and enable the Caddy service:
-
-        sudo systemctl daemon-reload
         sudo systemctl enable caddy.service
         sudo systemctl start caddy.service
         sudo systemctl status caddy.service
 
-3.  The `status` command above will show you the url where Caddy is listening (e.g., `https://203.0.113.0`). Type this url into a browser window, on your local machine and you should see the test page rendered in the browser. If you are using a FQDN and the SSL Certificate integration was successful, you will also see a green lock symbol in the URL bar, indicating that your connection is secure.
+2.  The `status` command above will show you the url where Caddy is listening (e.g., `https://203.0.113.0`). Type this url into a browser window, on your local machine and you should see the test page rendered in the browser. If you are using a FQDN and the SSL Certificate integration was successful, you will also see a green lock symbol in the URL bar, indicating that your connection is secure.

--- a/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
+++ b/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
@@ -49,21 +49,8 @@ external_resources:
 1.  Set up a home directory, **web root**, for your website:
 
         sudo mkdir -p /var/www/my-website
-        sudo chown www-data:www-data /var/www
-        sudo chmod 555 /var/www
 
-    {{< caution >}}
-The files in your web root directory must belong to the Caddy user (www-data). Otherwise, your regular user as well as the Caddy user, has read permission on all files served, and execute permission on all directories.
-{{< /caution >}}
-
-2.  If you plan to deploy your pages via an SFTP client--as an administrative user--other than **www-data** or **root**, set the following permissions. Replace `example_user` with the administrator's username:
-
-        sudo usermod -g www-data example_user
-        sudo chown -R example_user:www-data /var/www/
-        sudo chmod -R 755 /var/www/my-website
-        sudo chmod 755 /var/www
-
-3.  Create a test page:
+2.  Create a test page:
 
         echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/my-website/index.html
 

--- a/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
+++ b/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
@@ -28,7 +28,7 @@ external_resources:
 
 2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) guide to create a standard user account, harden SSH access and remove unnecessary network services.
 
-3.  If you want to set up your site for HTTPS using Let's Encrypt, you will need to register your site's domain name and follow our [DNS Manager Overview](/docs/networking/dns/dns-manager-overview#add-records) guide to point your domain to your Linode.
+3.  You will need to register your site's domain name and follow our [DNS Manager Overview](/docs/networking/dns/dns-manager-overview#add-records) guide to point your domain to your Linode.
 
 4.  Update your system:
 
@@ -70,19 +70,13 @@ The files in your web root directory must belong to the Caddy user (www-data). O
 
 ## Configure the Caddyfile
 
-Edit the Caddyfile. Replace `203.0.113.0` with the IP address or FQDN of your Linode:
+Add your hostname and web root to the Caddy configuration. Replace `example.com` with your site's domain name:
 
 {{< file "/etc/caddy/conf.d/my-website.conf" caddy >}}
-203.0.113.0 {
+example.com {
 root /var/www/my-website
-tls your-email-here@example.com
 }
 {{< /file >}}
-
-
-{{< note >}}
-If you are using a Linode without a FQDN, delete the `tls your-email-here@example.com` line from the sample Caddyfile above.
-{{< /note >}}
 
 ## Enable the Caddy Service
 
@@ -92,4 +86,4 @@ If you are using a Linode without a FQDN, delete the `tls your-email-here@exampl
         sudo systemctl start caddy.service
         sudo systemctl status caddy.service
 
-2.  The `status` command above will show you the url where Caddy is listening (e.g., `https://203.0.113.0`). Type this url into a browser window, on your local machine and you should see the test page rendered in the browser. If you are using a FQDN and the SSL Certificate integration was successful, you will also see a green lock symbol in the URL bar, indicating that your connection is secure.
+2.  Type your domain into a browser window on your local machine and you should see the test page. If everything is configured correctly, you should see a green lock symbol in the URL bar, indicating that your connection is secure.

--- a/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
+++ b/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
@@ -72,8 +72,6 @@ root /var/www/my-website
 
 1.  Enable the Caddy service:
 
-        sudo systemctl enable caddy.service
-        sudo systemctl start caddy.service
-        sudo systemctl status caddy.service
+        sudo systemctl enable --now caddy.service
 
 2.  Type your domain into a browser window on your local machine and you should see the test page. If everything is configured correctly, you should see a green lock symbol in the URL bar, indicating that your connection is secure.

--- a/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
+++ b/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7.md
@@ -54,6 +54,9 @@ external_resources:
 
         echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/my-website/index.html
 
+3.  Restore the correct selinux labels on the web root:
+
+        sudo restorecon -r /var/www/my-website
 
 ## Configure the Caddyfile
 


### PR DESCRIPTION
Caddy is now available via the EPEL repository.  Using that package in these instructions avoids having to perform many of these setup steps manually.  This PR also removes some out of scope instructions that would have needed to be updated to work with using the Caddy package.