### PR TITLE
Add show_on_rss_feed param to appropriate guides.

### DIFF
--- a/ci/yaml_rules.json
+++ b/ci/yaml_rules.json
@@ -54,7 +54,7 @@
 		"elements": false,
 		"type": "bool"
 	},
-	"rss_enabled": {
+	"show_on_rss_feed": {
 		"required": false,
 		"elements": false,
 		"type": "bool"

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -11,6 +11,7 @@ modified: 2017-11-30
 modified_by:
   name: Jared Kobos
 title: "Contribute to Linode"
+show_on_rss_feed: false
 ---
 
 {{< topics >}}

--- a/docs/find-this-guide-on-github.md
+++ b/docs/find-this-guide-on-github.md
@@ -11,6 +11,7 @@ modified: 2017-11-14
 modified_by:
   name: Linode
 title: Deprecated Guide
+show_on_rss_feed: false
 ---
 
 # Looks like you're trying to find a deprecated guide.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ show_on_frontpage: true
 title_short: "Getting Started"
 weight: 10
 icon: "book"
+show_on_rss_feed: false
 ---
 
 Thank you for choosing Linode as your cloud hosting provider! This guide will help you sign up for an account, set up a Linux distribution, boot your Linode, and perform some basic system administration tasks.

--- a/docs/linode-writers-formatting-guide.md
+++ b/docs/linode-writers-formatting-guide.md
@@ -11,6 +11,7 @@ modified_by:
   name: Linode
 published: 2014-01-15
 title: Linode Writer's Formatting Guide
+show_on_rss_feed: false
 external_resources:
  - '[GitHub Beginners Guide](/docs/github-guide)'
  - '[Red Hat Writing Style Guide](http://stylepedia.net/)'

--- a/docs/thankyou.md
+++ b/docs/thankyou.md
@@ -12,6 +12,7 @@ modified: 2017-12-05
 modified_by:
   name: Sam Foo
 title: "Thank you for your submission"
+show_on_rss_feed: false
 ---
 
 Thank you for your interest in joining the Linode community as a contributing author!

--- a/themes/docsmith/layouts/rss.xml
+++ b/themes/docsmith/layouts/rss.xml
@@ -13,7 +13,7 @@
     {{ with .OutputFormats.Get "RSS" }}
 	  {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range .Data.Pages.ByPublishDate.Reverse}}
+    {{ range where .Data.Pages.ByPublishDate.Reverse ".Params.show_on_rss_feed" "!=" false }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>

--- a/themes/docsmith/layouts/rss.xml
+++ b/themes/docsmith/layouts/rss.xml
@@ -13,7 +13,8 @@
     {{ with .OutputFormats.Get "RSS" }}
 	  {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range where .Data.Pages.ByPublishDate.Reverse ".Params.show_on_rss_feed" "!=" false }}
+    {{ $pages := where .Data.Pages ".Params.show_on_rss_feed" "!=" false }}
+    {{ range $pages.ByPublishDate.Reverse  }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
As part of change to Hugo templates, guides with show_on_rss_feed:
false will not be tracked on the RSS feed. This flag was applied
to special guides including formatting guide, contribute topics
list, and Github redirect page.