### PR TITLE
Fix formatting guide caution closing tag example

### DIFF
--- a/docs/linode-writers-formatting-guide.md
+++ b/docs/linode-writers-formatting-guide.md
@@ -333,7 +333,7 @@ This is a sample note.
 
     {{</* caution */>}}
     This is a sample caution.
-    {{</* caution */>}}
+    {{</* /caution */>}}
 
 {{< caution >}}
 This is a sample caution.


### PR DESCRIPTION
I just added `/` to caution closing tag in the formatting guidelines page.