### PR TITLE
Support for GCSE results URL

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,26 @@
+---
+layout: search
+author:
+  name: Steven Jacobs
+  email: docs@linode.com
+description: 'Search the Linode Docs library'
+keywords: []
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2017-12-14
+modified: 2017-12-14
+modified_by:
+  name: Steven Jacobs
+title: "Search Linode Docs"
+show_on_rss_feed: false
+---
+
+<!--
+
+Support for deprecated GCSE results URL:
+
+https://github.com/linode/docs/blob/9cfe68514b190fbd9d29130736cc54543f5e6e1c/themes/docsmith/layouts/404.html#L15
+
+See GH #25
+
+-->
+


### PR DESCRIPTION
Preserve results URL to not break internal tooling from GCSE to lunr.js

Pending update of robots.txt