### PR TITLE
Use tilde expansion for installation guides

### DIFF
--- a/docs/applications/project-management/how-to-install-and-configure-redmine-on-ubuntu-16-04.md
+++ b/docs/applications/project-management/how-to-install-and-configure-redmine-on-ubuntu-16-04.md
@@ -57,7 +57,7 @@ Redmine requires Ruby to run. Use the Ruby Version Manager (RVM) to install Ruby
 
         gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
         curl -sSL https://get.rvm.io | bash -s stable
-        source /home/username/.rvm/scripts/rvm
+        source ~/.rvm/scripts/rvm
 
     <!---
             sudo apt-add-repository -y ppa:rael-gc/rvm


### PR DESCRIPTION
Some users won't notice the path, since it isn't highlighted. Granted, users should read before copy-pasting but when we're catering to new people, that's one less question to deal with.