### PR TITLE
disable smart fractions extension for blackfriday

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,9 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
 rssLimit = 15
 
+[blackfriday]
+fractions = false
+
 [outputs]
 home = [ "HTML", "RSS"]
 section = ["HTML"]


### PR DESCRIPTION
This extension, which is enabled by default, will render anything
resembling a fraction, as a fraction. I can't think of any instances
where we use math in our guides, and we mention 24/7 in at least one of
them. This will disable the automatic conversion.