### PR TITLE
Remove duplicated word in how-to-install-postgresql-on-ubuntu-16-04.md

### DIFF
--- a/docs/databases/postgresql/how-to-install-postgresql-on-ubuntu-16-04.md
+++ b/docs/databases/postgresql/how-to-install-postgresql-on-ubuntu-16-04.md
@@ -49,7 +49,7 @@ Install PostgreSQL from the Ubuntu package repository:
 By default, PostgreSQL will create a Linux user named `postgres` to access the database software.
 
 {{< caution >}}
-The `postgres` user should not be used for for other purposes (e.g. connecting to other networks). Doing so presents a serious risk to the security of your databases.
+The `postgres` user should not be used for other purposes (e.g. connecting to other networks). Doing so presents a serious risk to the security of your databases.
 {{< /caution >}}
 
 1.  Change the `postgres` user's Linux password:


### PR DESCRIPTION
there were two `for`