### PR TITLE
Replace 'Icinga2' with 'Icinga 2'

### DIFF
--- a/docs/uptime/monitoring/install-icinga2-monitoring-on-debian-9.md
+++ b/docs/uptime/monitoring/install-icinga2-monitoring-on-debian-9.md
@@ -2,15 +2,15 @@
 author:
   name: Linode Community
   email: docs@linode.com
-description: "This guide shows you how to install and configure Icinga2 and Icinga Web 2 on Debian to monitor your Linode services and performance."
-og_description: "This guide will show you how to install and configure Icinga2 to monitor your system"
+description: "This guide shows you how to install and configure Icinga 2 and Icinga Web 2 on Debian to monitor your Linode services and performance."
+og_description: "This guide will show you how to install and configure Icinga 2 to monitor your system"
 keywords: ["debian", "icinga", "monitoring", "icinga2"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2017-12-12
 modified: 2017-12-12
 modified_by:
   name: Linode
-title: 'Install Icinga2 Monitoring on Debian 9'
+title: 'Install Icinga 2 Monitoring on Debian 9'
 expiryDate: 2019-12-12
 contributor:
   name: Matt Vass
@@ -19,15 +19,15 @@ external_resources:
  - '[Official Icinga Documentation](https://www.icinga.com/docs/icinga2/latest/doc/01-about/)'
 ---
 
-![Install Icinga2 Monitoring on Debian 9](/docs/assets/icinga/Icinga2.jpg "Install Icinga2 Monitoring on Debian 9")
+![Install Icinga 2 Monitoring on Debian 9](/docs/assets/icinga/Icinga2.jpg "Install Icinga 2 Monitoring on Debian 9")
 
-## What is Icinga2?
+## What is Icinga 2?
 
-Icinga, previously a fork of the popular Nagios monitoring system, is an open source network monitoring application that can be used to monitor critical services and systems on your Linode. Icinga2 can monitor hosts on a network or it can verify network external protocols, such as the state of an HTTP server, mail server, file-sharing service, or others.
+Icinga, previously a fork of the popular Nagios monitoring system, is an open source network monitoring application that can be used to monitor critical services and systems on your Linode. Icinga 2 can monitor hosts on a network or it can verify network external protocols, such as the state of an HTTP server, mail server, file-sharing service, or others.
 
-Icinga2 can be configured to monitor internal systems' state and check the load, memory, disk free space, or other internal parameters via Icinga agents deployed on each node that needs to be monitored. Icinga can also be configured to send notifications and alerts via email or SMS to the system administrators defined in contacts.
+Icinga 2 can be configured to monitor internal systems' state and check the load, memory, disk free space, or other internal parameters via Icinga agents deployed on each node that needs to be monitored. Icinga can also be configured to send notifications and alerts via email or SMS to the system administrators defined in contacts.
 
-This guide shows how to install and configure the latest version of Icinga2 web monitoring tool on Debian 9 to monitor network infrastructure.
+This guide shows how to install and configure the latest version of Icinga 2 web monitoring tool on Debian 9 to monitor network infrastructure.
 
 ## Before You Begin
 
@@ -61,9 +61,9 @@ Restart the Apache daemon to apply the new changes:
 
     systemctl restart apache2
 
-## Configure Icinga2 Databases
+## Configure Icinga 2 Databases
 
-1.  Install the backend database needed by Icinga2 monitoring web application and Icinga Web 2 frontend to store users, contacts and other collected data. Execute the following command to install MariaDB database and PHP module needed to access MySQL database in Debian 9:
+1.  Install the backend database needed by Icinga 2 monitoring web application and Icinga Web 2 frontend to store users, contacts and other collected data. Execute the following command to install MariaDB database and PHP module needed to access MySQL database in Debian 9:
 
         apt install php7.0-mysql mariadb-server mariadb-client
 
@@ -79,31 +79,31 @@ Restart the Apache daemon to apply the new changes:
 
         sudo mysql_secure_installation
 
-4.  Log back in to the database console and create the database for Icinga2:
+4.  Log back in to the database console and create the database for Icinga 2:
 
         mysql –u root -p
 
-5.  Create a user with a strong password to manage Icinga2 application database, by issuing the following commands. You should replace `icingadb`, `icinga-user`, and `strongpassword` in this example with your own database name and credentials:
+5.  Create a user with a strong password to manage Icinga 2 application database, by issuing the following commands. You should replace `icingadb`, `icinga-user`, and `strongpassword` in this example with your own database name and credentials:
 
         create database icingadb;
         grant all privileges on icingadb.* to 'icinga_user'@'localhost' identified by 'strongpassword';
         flush privileges
 
-6.  Create the second MySQL database used by Icinga2 web to store its interface users and groups. As in the previous step, replace the database name and credentials accordingly and choose a strong password for database user. You can use the same MySQL user account to manage both databases simultaneously (`icinga_user'@'localhost`):
+6.  Create the second MySQL database used by Icinga 2 web to store its interface users and groups. As in the previous step, replace the database name and credentials accordingly and choose a strong password for database user. You can use the same MySQL user account to manage both databases simultaneously (`icinga_user'@'localhost`):
 
         create database icinga_users;
         grant all privileges on icinga_users.* to 'icinga_user'@'localhost' identified by 'strongpassword';
         exit
 
-## Install Icinga2
+## Install Icinga 2
 
-Install Icinga2 and the Icinga2 MySQL module for accessing MariaDB database backend:
+Install Icinga 2 and the Icinga 2 MySQL module for accessing MariaDB database backend:
 
     apt install icinga2 icinga2-ido-mysql
 
 During the installation, when asked:
 
-*  If Icinga2 should use the MySQL module,
+*  If Icinga 2 should use the MySQL module,
 
     *  Choose **Yes** from the prompt.
 
@@ -111,27 +111,27 @@ During the installation, when asked:
 
     *  Choose **No** from the prompt.
 
-After Icinga2 has been installed, start the Icinga2 service and check the daemon status:
+After Icinga 2 has been installed, start the Icinga 2 service and check the daemon status:
 
     systemctl start icinga2.service
     systemctl status icinga2.service
 
-## Install the Icinga2 Web Interface
+## Install the Icinga 2 Web Interface
 
-In order to manage Icinga2 via the web interface, install the Icinga2 web interface and Command Line Interface (CLI) packages:
+In order to manage Icinga 2 via the web interface, install the Icinga 2 web interface and Command Line Interface (CLI) packages:
 
     apt install icingaweb2 icingacli
 
-Restart the Icinga2 daemon and verify the Icinga2 daemon status:
+Restart the Icinga 2 daemon and verify the Icinga 2 daemon status:
 
     systemctl restart icinga2.service
     systemctl status icinga2.service
 
-Install the MySQL schema required Icinga2 database:
+Install the MySQL schema required Icinga 2 database:
 
     mysql -u root icingadb -p < /usr/share/icinga2-ido-mysql/schema/mysql.sql
 
-Edit the Icinga2 MySQL IDO configuration file and add Icinga2 engine database credentials, as shown in the following example. Use the credentials of the first database created in the [earlier database creation step](#configure-icinga2-databases):
+Edit the Icinga 2 MySQL IDO configuration file and add Icinga 2 engine database credentials, as shown in the following example. Use the credentials of the first database created in the [earlier database creation step](#configure-icinga2-databases):
 
 {{< file-excerpt "/etc/icinga2/features-enabled/ido-mysql.conf" conf >}}
 library "db_ido_mysql"
@@ -144,19 +144,19 @@ object IdoMysqlConnection "ido-mysql" {
 }
 {{< /file-excerpt >}}
 
-Save the file and restart the Icinga2 daemon:
+Save the file and restart the Icinga 2 daemon:
 
     systemctl restart icinga2.service
 
-Create an Icinga Web 2 log directory and add the proper file system permissions to grant the Icinga2 group write permissions:
+Create an Icinga Web 2 log directory and add the proper file system permissions to grant the Icinga 2 group write permissions:
 
     mkdir -p /var/log/icingaweb2/
     chgrp -R icingaweb2 /var/log/icingaweb2/
     chmod -R 775 /var/log/icingaweb2/
 
-## Configure Icinga2 via Web Interface
+## Configure Icinga 2 via Web Interface
 
-1.  Generate an installation token. Save it somewhere easily accessible. You will need to use it to access the Icinga2 setup:
+1.  Generate an installation token. Save it somewhere easily accessible. You will need to use it to access the Icinga 2 setup:
 
         icingacli setup token create
 
@@ -178,21 +178,21 @@ Create an Icinga Web 2 log directory and add the proper file system permissions 
 
     ![Select Doc and Monitoring Modules](/docs/assets/icinga/icinga-docs-and-modules.png "Select Doc and Monitoring Modules")
 
-5.  Icinga2 will check your system requirements and PHP modules to see if all requirements are met before continuing with the installation and configuration process. Scroll down to the end of the page and press **Next** to continue.
+5.  Icinga 2 will check your system requirements and PHP modules to see if all requirements are met before continuing with the installation and configuration process. Scroll down to the end of the page and press **Next** to continue.
 
 6.  Choose **Authentication Type = Database**:
 
     ![Choose the "Database" Authentication Type](/docs/assets/icinga/icinga-database-authentication-type.png "Choose the "Database" Authentication Type")
 
-7.  Use the information from the second database created earlier to add the credentials needed to access the Icinga2 database for storing web interface users and groups. Use `icingaweb_db` as a name for this resource and leave the **Host**, **Port** and **Character** set variables as default. Do not enable **Persistent** and **SSL** option. Press **Validate Configuration** button to validate the database. After the database has been validated successfully, press **Next** to continue to the next phase of Icinga2’s configuration process:
+7.  Use the information from the second database created earlier to add the credentials needed to access the Icinga 2 database for storing web interface users and groups. Use `icingaweb_db` as a name for this resource and leave the **Host**, **Port** and **Character** set variables as default. Do not enable **Persistent** and **SSL** option. Press **Validate Configuration** button to validate the database. After the database has been validated successfully, press **Next** to continue to the next phase of Icinga 2’s configuration process:
 
     ![Database Resource Information](/docs/assets/icinga/icinga-database-resource-info.png "Database Resource Information")
 
 8.  Define a name for the database authentication backend (you can use the default value) and press **Next**.
 
-9.  Add a username with a strong password in order to log in to the Icinga2 web interface and further manage the Icinga2 engine and press **Next**.
+9.  Add a username with a strong password in order to log in to the Icinga 2 web interface and further manage the Icinga 2 engine and press **Next**.
 
-10. Adjust the Icinga2 application and logging configurations using these settings, then press **Next**:
+10. Adjust the Icinga 2 application and logging configurations using these settings, then press **Next**:
 
     *  Check **Show Stacktraces**
 
@@ -208,13 +208,13 @@ Create an Icinga Web 2 log directory and add the proper file system permissions 
 
     ![Icinga Configuration Summary](/docs/assets/icinga/icinga-configuration-summary.png "Icinga Configuration Summary")
 
-12. Press **Next** to continue setting up Icinga2 engine monitoring module.
+12. Press **Next** to continue setting up Icinga 2 engine monitoring module.
 
-13. Add a name for the Icinga2 Backend, select **IDO** as Backend Type and press **Next**.
+13. Add a name for the Icinga 2 Backend, select **IDO** as Backend Type and press **Next**.
 
-14. Add the Icinga2 engine database credentials in order to setup the IDO resource environment. After adding the Icinga2 database credentials, press **Validate Configuration** to validate the Icinga2 Monitoring IDO Resource. After the **Successfully validated** message appears, press **Next**.
+14. Add the Icinga 2 engine database credentials in order to setup the IDO resource environment. After adding the Icinga 2 database credentials, press **Validate Configuration** to validate the Icinga 2 Monitoring IDO Resource. After the **Successfully validated** message appears, press **Next**.
 
-15. Configure the Icinga2 Command Transport module with the following settings and press **Next**:
+15. Configure the Icinga 2 Command Transport module with the following settings and press **Next**:
 
     *  **Transport Name** = icinga2
 
@@ -224,7 +224,7 @@ Create an Icinga Web 2 log directory and add the proper file system permissions 
 
 16. Use the default values or configure the monitoring security environment variables to sensitive information and press **Next**.
 
-17. The next screen shows a detailed report of the current configuration. A message will also show you that Icinga2 Monitoring module has been successfully configured. Review the configuration and press **Finish** to complete the setup process.
+17. The next screen shows a detailed report of the current configuration. A message will also show you that Icinga 2 Monitoring module has been successfully configured. Review the configuration and press **Finish** to complete the setup process.
 
     After the installation and setup process completes, a message informs you that Icinga Web 2 has been successfully set up.
 
@@ -232,13 +232,13 @@ Create an Icinga Web 2 log directory and add the proper file system permissions 
 
     ![Icinga Successfully Set up - "Login to Icinga Web 2" button](/docs/assets/icinga/icinga-set-up-success-login.png "Icinga Successfully Set up - 'Login to Icinga Web 2' button")
 
-    You will be directed to the Icinga Web 2 Dashboard, where you should see the default services and Linode resources that are currently monitored by the Icinga2 engine:
+    You will be directed to the Icinga Web 2 Dashboard, where you should see the default services and Linode resources that are currently monitored by the Icinga 2 engine:
 
     ![Icinga Dashboard and Current Incidents](/docs/assets/icinga/icinga-dashboard-current-incidents.png "Icinga Dashboard and Current Incidents")
 
 ## Secure the Icinga Web 2 Interface Via TLS
 
-To access Icinga2 monitoring application via HTTPS protocol, enable the Apache SSL module, SSL site configuration file, and Apache rewrite module:
+To access Icinga 2 monitoring application via HTTPS protocol, enable the Apache SSL module, SSL site configuration file, and Apache rewrite module:
 
     a2enmod ssl rewrite
     a2ensite default-ssl.conf
@@ -287,4 +287,4 @@ Add a new rule to allow HTTPS traffic to pass through the firewall.
 
 ## That’s All!
 
-You have successfully installed, set up, and secured the Icinga2 engine monitoring application and Icinga Web 2 Interface on Debian 9.
+You have successfully installed, set up, and secured the Icinga 2 engine monitoring application and Icinga Web 2 Interface on Debian 9.

--- a/docs/uptime/monitoring/monitor-remote-hosts-with-icinga.md
+++ b/docs/uptime/monitoring/monitor-remote-hosts-with-icinga.md
@@ -2,8 +2,8 @@
 author:
   name: Matt Vass
   email: linuxboxgo@gmail.com
-description: "This guide shows how to configure Icinga2 to monitor remote systems on your Linode"
-og_description: "This guide will show you how to configure Icinga2 to monitor your remote systems. Icinga2 can monitor local and remote systems, and this guide shows you how to do both."
+description: "This guide shows how to configure Icinga 2 to monitor remote systems on your Linode"
+og_description: "This guide will show you how to configure Icinga 2 to monitor your remote systems. Icinga 2 can monitor local and remote systems, and this guide shows you how to do both."
 keywords: ["debian", "icinga", "monitoring", "icinga2"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2017-12-28
@@ -19,10 +19,10 @@ external_resources:
  - '[Official Icinga Documentation](https://www.icinga.com/docs/icinga2/latest/doc/01-about/)'
 ---
 
-## What is Icinga2?
+## What is Icinga 2?
 
-This guide is a continuation of our guide on [Icinga2](/docs/uptime/monitoring/install-icinga2-monitoring-on-debian-9).
-Icinga, is an open source network monitoring application that can be used to monitor critical services and systems on your Linode. Icinga2 can monitor hosts on a network or it can verify network external protocols, such as the state of an HTTP server, mail server, file-sharing service, or others.
+This guide is a continuation of our guide on [Icinga 2](/docs/uptime/monitoring/install-icinga2-monitoring-on-debian-9).
+Icinga, is an open source network monitoring application that can be used to monitor critical services and systems on your Linode. Icinga 2 can monitor hosts on a network or it can verify network external protocols, such as the state of an HTTP server, mail server, file-sharing service, or others.
 
 ## Before You Begin
 
@@ -30,10 +30,10 @@ The steps and examples in this guide assume the defaults and configurations from
 
 ## Monitor Remote Hosts via Simple Host Monitoring
 
-In order to monitor a host and its external services via regular command checks, Icinga2 uses a mechanism that issues a ping command against the server's IP address at regular intervals and using its built-in commands, regularly verifies the state of remote network services protocols, such as HTTP, SSH, SMTP, IMAP, POP or others.\
-Icinga2 stores Host definitions in objects. These objects and their attributes are used for applying rules for `Service`, `Notification`, `Dependency`, and `Scheduled Downtime` can be found in `hosts.conf` file, in `/etc/icinga2/conf.d/`.
+In order to monitor a host and its external services via regular command checks, Icinga 2 uses a mechanism that issues a ping command against the server's IP address at regular intervals and using its built-in commands, regularly verifies the state of remote network services protocols, such as HTTP, SSH, SMTP, IMAP, POP or others.\
+Icinga 2 stores Host definitions in objects. These objects and their attributes are used for applying rules for `Service`, `Notification`, `Dependency`, and `Scheduled Downtime` can be found in `hosts.conf` file, in `/etc/icinga2/conf.d/`.
 
-1.  To add a new host definition to be periodically monitored by Icinga2 engine via ICMP checks, open `hosts.conf` and add the following lines to the bottom of the file:
+1.  To add a new host definition to be periodically monitored by Icinga 2 engine via ICMP checks, open `hosts.conf` and add the following lines to the bottom of the file:
 
     {{< file-excerpt "/etc/icinga2/conf.d/hosts.conf" conf >}}
 object Host "Linode" {
@@ -60,11 +60,11 @@ object Service "http" {
 
 5.  To display the status of the host’s HTTP service, navigate to **Overview** then **Servicegroups** and click **HTTP Checks**.
 
-## Monitor Remote Hosts via Icinga2 Agent Monitoring
+## Monitor Remote Hosts via Icinga 2 Agent Monitoring
 
-Icina2 can monitor a node's internal health parameters, such as CPU load, disk space, memory, and number of running process via a secured channel set up between a master node and client node on port `5665/TCP`. In this instance we’ll configure our Icinga2 to act as the master node and monitor the remote CentOS 7 client node. In this specific type of configuration, also called a *Top Down Command Endpoint* model, the check commands will be scheduled on the master node and then will be sent to the client via a TLS connection.
+Icina2 can monitor a node's internal health parameters, such as CPU load, disk space, memory, and number of running process via a secured channel set up between a master node and client node on port `5665/TCP`. In this instance we’ll configure our Icinga 2 to act as the master node and monitor the remote CentOS 7 client node. In this specific type of configuration, also called a *Top Down Command Endpoint* model, the check commands will be scheduled on the master node and then will be sent to the client via a TLS connection.
 
-1.  Set up the Icinga2 master node on our Debian 9 server. Configure this instance of Icinga2 as a master node:
+1.  Set up the Icinga 2 master node on our Debian 9 server. Configure this instance of Icinga 2 as a master node:
 
         icinga2 node wizard
 
@@ -79,7 +79,7 @@ Icina2 can monitor a node's internal health parameters, such as CPU load, disk s
         Bind Host []:
         Bind Port []:
 
-4.  Restart the Icinga2 service to apply the master node configuration and check the daemon status:
+4.  Restart the Icinga 2 service to apply the master node configuration and check the daemon status:
 
         systemctl restart icinga2.service
         systemctl status icinga2.service
@@ -96,16 +96,16 @@ Icina2 can monitor a node's internal health parameters, such as CPU load, disk s
 
 ## Configure CentOS 7 Client Node
 
-1.  Log in to your CentOS 7 system with an account with `root` privileges or directly as root and issue the following command to enable EPEL and Icinga2 repositories in CentOS. Also, make sure your CentOS 7 system is configured with a static IP address.
+1.  Log in to your CentOS 7 system with an account with `root` privileges or directly as root and issue the following command to enable EPEL and Icinga 2 repositories in CentOS. Also, make sure your CentOS 7 system is configured with a static IP address.
 
         yum install epel-release
         yum install https://packages.icinga.com/epel/icinga-rpm-release-7-latest.noarch.rpm
 
-2.  Install the Igina2 engine and Nagios plugins required by Icinga2 to execute the check commands in CentOS by issuing the following command:
+2.  Install the Igina2 engine and Nagios plugins required by Icinga 2 to execute the check commands in CentOS by issuing the following command:
 
         yum install icinga2 nagios-plugins-all
 
-3.  After the Icinga2 daemon has been installed in your CentOS system, start the node wizard and configure this system as a satellite node instead of master node:
+3.  After the Icinga 2 daemon has been installed in your CentOS system, start the node wizard and configure this system as a satellite node instead of master node:
 
         icinga2 node wizard
 
@@ -139,7 +139,7 @@ Icina2 can monitor a node's internal health parameters, such as CPU load, disk s
         Accept config from master? [y/N]: y
         Accept commands from master? [y/N]: y
 
-8.  After the client node wizard completes, restart the Icinga2 service, check Icinga2 service status, list Icinga’s listening port, and add the Icinga2 listening port number to the CentOS firewall:
+8.  After the client node wizard completes, restart the Icinga 2 service, check Icinga 2 service status, list Icinga’s listening port, and add the Icinga 2 listening port number to the CentOS firewall:
 
         systemctl restart icinga2
         systemctl status icinga2
@@ -147,9 +147,9 @@ Icina2 can monitor a node's internal health parameters, such as CPU load, disk s
         firewall-cmd --add-port=5665/tcp --permanent
         firewall-cmd --reload
 
-## Set up Icinga2 Master Agent-based Monitoring
+## Set up Icinga 2 Master Agent-based Monitoring
 
-1.  Log in to the Icinga2 master node and create a CentOS client zone directory, a client configuration, and a services file:
+1.  Log in to the Icinga 2 master node and create a CentOS client zone directory, a client configuration, and a services file:
 
         mkdir /etc/icinga2/zones.d/centos/
         touch /etc/icinga2/zones.d/centos/centos.conf
@@ -202,7 +202,7 @@ apply Service "procs" {
 
 
     * Verify number of users logged in to the system and the number of processes running.
-    * The `command_endpoint` lines force the service checks to be transmitted to the remote CentOS system and executed by the Icinga2 engine command endpoint.
+    * The `command_endpoint` lines force the service checks to be transmitted to the remote CentOS system and executed by the Icinga 2 engine command endpoint.
     * You can add as many commands as you’d like here to be executed internally on the remote host. However, if Icinga sent instructions are not present on the remote node as Nagios plugin scripts, the commands won’t execute and an error will be displayed in the icinga2 web interface.
 
 
@@ -212,6 +212,6 @@ apply Service "procs" {
 
 ## That’s all!
 
-You have successfully configured Icinga2 as a master node and added a CentOS 7 client node to be remotely checked via Icinga2 agent-based monitoring system and another remote host to be actively monitored via external services command checks.
+You have successfully configured Icinga 2 as a master node and added a CentOS 7 client node to be remotely checked via Icinga 2 agent-based monitoring system and another remote host to be actively monitored via external services command checks.
 
-For other Icinga2 configurations, installation, and monitoring mechanisms, visit the [official Icinga2 documentation](https://www.icinga.com/docs/icinga2/latest/doc/01-about/).
+For other Icinga 2 configurations, installation, and monitoring mechanisms, visit the [official Icinga 2 documentation](https://www.icinga.com/docs/icinga2/latest/doc/01-about/).


### PR DESCRIPTION
The official spelling of the project name is 'Icinga 2'. This PR updates the Icinga 2 installation guide to replace 'Icinga2' with 'Icinga 2'.