### PR TITLE
Update how-to-use-yubikey-for-two-factor-ssh-authentication.md

### DIFF
--- a/docs/security/authentication/how-to-use-yubikey-for-two-factor-ssh-authentication.md
+++ b/docs/security/authentication/how-to-use-yubikey-for-two-factor-ssh-authentication.md
@@ -111,7 +111,7 @@ user4:vvddhfjjasui:vvfjidkflssd
 {{< /file >}}
 
 
-5. Add `auth required pam_yubico.so id=client id authfile=/etc/ssh/yubikeys` to the start of `/etc/pam.d/sshd`. Replace `client id` with the ID you retrieved when applying for an API key, and `secret key` with the secret key. If you only want single-factor authentication (either a YubiKey or a password), change `required` to `sufficient` to tell the system that a valid YubiKey will be enough to log in.
+5. Add `auth required pam_yubico.so id=<client id> key=<secret key> authfile=/etc/ssh/yubikeys` to the start of `/etc/pam.d/sshd`. Replace `<client id>` with the ID you retrieved when applying for an API key, and `<secret key>` with the secret key. If you only want single-factor authentication (either a YubiKey or a password), change `required` to `sufficient` to tell the system that a valid YubiKey will be enough to log in.
 
     {{< file-excerpt "/etc/pam.d/sshd" >}}
 # PAM configuration for the Secure Shell service


### PR DESCRIPTION
The example snippet in step 5 was missing the `key` argument. I added it here and changed the formatting to match an example of the same snippet that appears later in the document.