### PR TITLE
Remove redirect chains; Update incorrect/broken links

### DIFF
--- a/docs/applications/big-data/big-data-in-the-linode-cloud-streaming-data-processing-with-apache-storm.md
+++ b/docs/applications/big-data/big-data-in-the-linode-cloud-streaming-data-processing-with-apache-storm.md
@@ -33,7 +33,7 @@ Some use cases where Storm is a good solution:
 -  Analysis of server logs
 -  Internet of Things (IoT) sensor data processing
 
-This guide explains how to create Storm clusters on the Linode cloud using a set of shell scripts that use Linode's Application Programming Interface (APIs) to programmatically create and configure large clusters. The scripts are all provided by the author of this guide via [GitHub repository](https://github.com/pathbreak/storm-linode). This application stack could also benefit from large amounts of disk space, so consider using our [Block Storage](/docs/platform/how-to-use-block-storage-with-your-linode) service with this setup.
+This guide explains how to create Storm clusters on the Linode cloud using a set of shell scripts that use Linode's Application Programming Interface (APIs) to programmatically create and configure large clusters. The scripts are all provided by the author of this guide via [GitHub repository](https://github.com/pathbreak/storm-linode). This application stack could also benefit from large amounts of disk space, so consider using our [Block Storage](/docs/platform/how-to-use-block-storage-with-your-linode/) service with this setup.
 
 {{< caution >}}
 External resources are outside of our control, and can be changed and/or modified without our knowledge. Always review code from third party sites yourself before executing.
@@ -81,7 +81,7 @@ These are the names we'll use, but you are welcome to choose your own when creat
 
 ### Get a Linode API Key
 
-Follow the steps in [Generating an API Key](/docs/platform/api/api-key) and save your key securely. It will be entered into configuration files in upcoming steps.
+Follow the steps in [Generating an API Key](/docs/platform/api/api-key/) and save your key securely. It will be entered into configuration files in upcoming steps.
 
 If the key expires or is removed, remember to create a new one and update the `api_env_linode.conf` API environment configuration file on the cluster manager Linode. This will be explained further in the next section.
 
@@ -256,7 +256,7 @@ Creating a new Storm cluster involves four main steps, some of which are necessa
 
 ### Create a Zookeeper Image
 
-A *Zookeeper image* is a master disk image with all necessary Zookeeper software and libraries installed. We'll create our using [Linode Images](/docs/platform/linode-images) The benefits of using a Zookeeper image include:
+A *Zookeeper image* is a master disk image with all necessary Zookeeper software and libraries installed. We'll create our using [Linode Images](/docs/platform/linode-images/) The benefits of using a Zookeeper image include:
 
 -  Quick creation of a Zookeeper cluster by simply cloning it to create as many nodes as required, each a perfect copy of the image
 -  Distribution packages and third party software packages are identical on all nodes, preventing version mismatch errors

--- a/docs/applications/big-data/how-to-install-and-configure-a-redis-cluster-on-ubuntu-1604.md
+++ b/docs/applications/big-data/how-to-install-and-configure-a-redis-cluster-on-ubuntu-1604.md
@@ -14,7 +14,7 @@ published: 2017-08-14
 title: 'How to Install and Configure a Redis Cluster on Ubuntu 16.04'
 external_resources:
  - '[Redis Official Website](https://redis.io/)'
- - '[Install and Configure Redis on CentOS 7](/docs/databases/redis/install-and-configure-redis-on-centos-7)'
+ - '[Install and Configure Redis on CentOS 7](/docs/databases/redis/install-and-configure-redis-on-centos-7/)'
 ---
 
 ![How to Install and Configure a Redis Cluster on Ubuntu 16.04](/docs/assets/Redis_Cluster.jpg)

--- a/docs/applications/big-data/how-to-move-machine-learning-model-to-production.md
+++ b/docs/applications/big-data/how-to-move-machine-learning-model-to-production.md
@@ -26,9 +26,9 @@ This guide will show you how to create a simple Flask API that will use machine 
 
 ## Before You Begin
 
-1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) to create a standard user account, harden SSH access and remove unnecessary network services.
+2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services.
 
 3.  Update your system:
 
@@ -57,7 +57,7 @@ You will be using Python both to create a model and to deploy the model to a Fla
 
         conda install keras tensorflow h5py pillow flask numpy
 
-If you would like to experiment with the model, you may want to use a Jupyter notebook. See our [Install a Jupyter Notebook Server](/docs/applications/big-data/install-a-jupyter-notebook-server-on-a-linode-behind-an-apache-reverse-proxy) guide for more details.
+If you would like to experiment with the model, you may want to use a Jupyter notebook. See our [Install a Jupyter Notebook Server](/docs/applications/big-data/install-a-jupyter-notebook-server-on-a-linode-behind-an-apache-reverse-proxy/) guide for more details.
 
 ## Prepare a Model
 

--- a/docs/applications/configuration-management/how-to-build-your-infrastructure-using-terraform-and-linode.md
+++ b/docs/applications/configuration-management/how-to-build-your-infrastructure-using-terraform-and-linode.md
@@ -28,7 +28,7 @@ The configurations and commands used in this guide will result in multiple Linod
 
 -  You will need root access to the system and a standard user account with sudo privileges.
 
--  Create an API key for your Linode account. Be sure to take a screen capture of the API key when it's displayed, it will only appear once. See our [API Key](/docs/platform/api/api-key) guide if you need help.
+-  Create an API key for your Linode account. Be sure to take a screen capture of the API key when it's displayed, it will only appear once. See our [API Key](/docs/platform/api/api-key/) guide if you need help.
 
 -  You will need [Git](https://git-scm.com/) installed on your system.
 
@@ -362,7 +362,7 @@ resource "linode_linode" "terraform-example" {
         terraform apply
 
     {{< caution >}}
-Changing the size of your Linode will force your server to be powered off and migrated to a different host in the same data center. The associated disk migration will take approximately 1 minute for every 3-5 gigabytes of data. For more information about resizing read the [Resizing a Linode](/docs/platform/disk-images/resizing-a-linode) guide.
+Changing the size of your Linode will force your server to be powered off and migrated to a different host in the same data center. The associated disk migration will take approximately 1 minute for every 3-5 gigabytes of data. For more information about resizing read the [Resizing a Linode](/docs/platform/disk-images/resizing-a-linode/) guide.
 {{< /caution >}}
 
 4.  Return to the Linode Manager to verify the changes.

--- a/docs/applications/messaging/installing-prosody-xmpp-server-on-debian-5-lenny.md
+++ b/docs/applications/messaging/installing-prosody-xmpp-server-on-debian-5-lenny.md
@@ -14,7 +14,7 @@ published: 2009-10-13
 title: 'Installing Prosody XMPP Server on Debian 5 (Lenny)'
 ---
 
-Prosody is a lightweight and simple XMPP/Jabber server that aims to be easy to use. Written in the Lua programming language, it has minimal resource requirements and aims to be easy to configure and run. While Prosody may not be able to scale to the same extent as [ejabberd](/docs/applications/messaging/instant-messaging-services-with-ejabberd-on-ubuntu-12-04-precise-pangolin) or [OpenFire](/docs/applications/messaging/instant-messaging-services-with-openfire-on-debian-6-squeeze), for many independent and small scale uses, Prosody may perform as well as "larger" servers while being more efficient with resources. If you're considering doing XMPP development, or running an XMPP server for a very small base of users, we recommend that you consider Prosody as a possible provider for this service.
+Prosody is a lightweight and simple XMPP/Jabber server that aims to be easy to use. Written in the Lua programming language, it has minimal resource requirements and aims to be easy to configure and run. While Prosody may not be able to scale to the same extent as [ejabberd](/docs/applications/messaging/use-ejabberd-for-instant-messaging-on-ubuntu-12-04/) or [OpenFire](/docs/applications/messaging/instant-messaging-services-with-openfire-on-debian-6-squeeze/), for many independent and small scale uses, Prosody may perform as well as "larger" servers while being more efficient with resources. If you're considering doing XMPP development, or running an XMPP server for a very small base of users, we recommend that you consider Prosody as a possible provider for this service.
 
 Before we begin with the installation and configuration of Prosody, we assume that you have a running and up to date installation of Debian Lenny, have completed our [getting started guide](/docs/getting-started/), and have logged in via SSH as root.
 
@@ -130,7 +130,7 @@ Component "conference.example.com" "muc"
 {{< /file-excerpt >}}
 
 
-In this example, `conference.example.com` is the domain where the MUC rooms are located, and will require an "[DNS A record,](/docs/dns-guides/introduction-to-dns)" that points to the IP Address where the Prosody instance is running. MUCs will be identified as JIDs (Jabber IDs) at this hostname, so for instance the "rabbits" MUC hosted by this server would be located at `rabbits@conference.example.com`.
+In this example, `conference.example.com` is the domain where the MUC rooms are located, and will require an "[DNS A record,](/docs/networking/dns/dns-records-an-introduction/)" that points to the IP Address where the Prosody instance is running. MUCs will be identified as JIDs (Jabber IDs) at this hostname, so for instance the "rabbits" MUC hosted by this server would be located at `rabbits@conference.example.com`.
 
 MUC, in contrast to many other common components in the XMPP world, is provided internally by Prosody. Other components, like transports to other services, run on an external interface. Each external component has its own host name, and provides a secret key which allows the central server to authenticate to it. See the following "aim.example.com" component as an example.
 
@@ -158,7 +158,7 @@ Host "*"
 
 The XMPP protocol supports "in-band" registration, where users can register for accounts with your server via the XMPP interface. However, this is often an undesirable function as it doesn't permit the server administrator the ability to moderate the creation of new accounts and can lead to spam-related problems. As a result, Prosody has this functionality disabled by default. While you can enable in-band registration, we recommend using the `prosodyctl` interface at the terminal prompt.
 
-If you're familiar with the `ejabberdctl` interface from [ejabberd,](/docs/applications/messaging/instant-messaging-services-with-ejabberd-on-ubuntu-12-04-precise-pangolin) `prosodyctl` mimics its counterpart as much as possible.
+If you're familiar with the `ejabberdctl` interface from [ejabberd,](/docs/applications/messaging/use-ejabberd-for-instant-messaging-on-ubuntu-12-04/) `prosodyctl` mimics its counterpart as much as possible.
 
 To use `prosodyctl` to register a user, in this case `lollipop@example.com`, issue the following command:
 

--- a/docs/applications/messaging/installing-prosody-xmpp-server-on-ubuntu-9-04-jaunty.md
+++ b/docs/applications/messaging/installing-prosody-xmpp-server-on-ubuntu-9-04-jaunty.md
@@ -16,7 +16,7 @@ title: 'Installing Prosody XMPP Server on Ubuntu 9.04 (Jaunty)'
 
 
 
-Prosody is a XMPP/Jabber server programmed in Lua that is simple and lightweight. Prosody uses fewer resources than its counterparts and is designed to be easy to configure and run. [ejabberd](/docs/applications/messaging/instant-messaging-services-with-ejabberd-on-ubuntu-12-04-precise-pangolin) or [OpenFire](/docs/applications/messaging/instant-messaging-services-with-openfire-on-ubuntu-12-04-lts-precise-pangolin) may be better suited for larger applications, but for most independent and small scale uses Prosody is a more resource-efficient solution. Prosody is a very good candidate for running an XMPP server for a very small base of users, or for XMPP development.
+Prosody is a XMPP/Jabber server programmed in Lua that is simple and lightweight. Prosody uses fewer resources than its counterparts and is designed to be easy to configure and run. [ejabberd](/docs/applications/messaging/use-ejabberd-for-instant-messaging-on-ubuntu-12-04/) or [OpenFire](/docs/applications/messaging/install-openfire-on-ubuntu-12-04-for-instant-messaging/) may be better suited for larger applications, but for most independent and small scale uses Prosody is a more resource-efficient solution. Prosody is a very good candidate for running an XMPP server for a very small base of users, or for XMPP development.
 
 Before we begin with the installation and configuration of Prosody, we assume that you have a running and up to date installation of Ubuntu Jaunty, have completed our [Getting Started](/docs/getting-started/) guide and have logged in via SSH as root.
 
@@ -154,7 +154,7 @@ Component "conference.example.com" "muc"
 {{< /file-excerpt >}}
 
 
-In this example, `conference.example.com` is the domain where the MUC rooms are located, and will require an "[DNS A record,](/docs/dns-guides/introduction-to-dns)" that points to the IP Address where the Prosody instance is running. MUCs will be identified as JIDs (Jabber IDs) at this hostname, so for instance the "rabbits" MUC hosted by this server would be located at `rabbits@conference.example.com`.
+In this example, `conference.example.com` is the domain where the MUC rooms are located, and will require an "[DNS A record,](/docs/networking/dns/dns-records-an-introduction/)" that points to the IP Address where the Prosody instance is running. MUCs will be identified as JIDs (Jabber IDs) at this hostname, so for instance the "rabbits" MUC hosted by this server would be located at `rabbits@conference.example.com`.
 
 MUC, in contrast to many other common components in the XMPP world, is provided internally by Prosody. Other components, like transports to other services, run on an external interface. Each external component has its own host name, and provides a secret key which allows the central server to authenticate to it. See the following "aim.example.com" component as an example.
 
@@ -182,7 +182,7 @@ Host "*"
 
 The XMPP protocol supports "in-band" registration, where users can register for accounts with your server via the XMPP interface. However, this is often an undesirable function as it doesn't permit the server administrator the ability to moderate the creation of new accounts and can lead to spam-related problems. As a result, Prosody has this functionality disabled by default. While you can enable in-band registration, we recommend using the `prosodyctl` interface at the terminal prompt.
 
-If you're familiar with the `ejabberdctl` interface from [ejabberd,](/docs/applications/messaging/instant-messaging-services-with-ejabberd-on-ubuntu-12-04-precise-pangolin) `prosodyctl` mimics its counterpart as much as possible.
+If you're familiar with the `ejabberdctl` interface from [ejabberd,](/docs/applications/messaging/use-ejabberd-for-instant-messaging-on-ubuntu-12-04/) `prosodyctl` mimics its counterpart as much as possible.
 
 To use `prosodyctl` to register a user, in this case `lollipop@example.com`, issue the following command:
 

--- a/docs/applications/messaging/instant-messaging-services-with-openfire-on-debian-5-lenny.md
+++ b/docs/applications/messaging/instant-messaging-services-with-openfire-on-debian-5-lenny.md
@@ -96,7 +96,7 @@ Direct your browser to your Linode's IP address or FQDN (fully qualified domain 
 
 [![Language selection in Openfire setup on Debian 5 (Lenny).](/docs/assets/392-openfire-debian-lenny-01-language-selection.png)](/docs/assets/392-openfire-debian-lenny-01-language-selection.png)
 
-Next, you'll be asked to configure your domain and ports for administration. Use the fully qualified domain name you have assigned to your Linode in DNS (more information: [configuring DNS with the Linode Manager](/docs/dns-guides/configuring-dns-with-the-linode-manager)).
+Next, you'll be asked to configure your domain and ports for administration. Use the fully qualified domain name you have assigned to your Linode in DNS (more information: [configuring DNS with the Linode Manager](/docs/networking/dns/dns-manager-overview/)).
 
 [![Domain and admin ports selection in Openfire setup on Debian 5 (Lenny).](/docs/assets/393-openfire-debian-lenny-02-domain-ports-selection.png)](/docs/assets/393-openfire-debian-lenny-02-domain-ports-selection.png)
 

--- a/docs/applications/messaging/using-irssi-for-internet-relay-chat.md
+++ b/docs/applications/messaging/using-irssi-for-internet-relay-chat.md
@@ -24,7 +24,7 @@ external_resources:
 
 **Irssi** is a terminal-based chat client for real-time conversations over Internet Relay Chat (**IRC**). IRC is the common meeting ground for Linode users to exchange knowledge and troubleshoot issues in our public channel, **#linode** on **OFTC**.
 
-Irssi can run on Linux or MAC OS X, either from your local workstation or your Linode. If you are unfamiliar with using a Linux terminal, you may want to review the Linode guides [Using the Terminal](/docs/using-linux/using-the-terminal) and [Introduction to Linux Concepts](/docs/tools-reference/introduction-to-linux-concepts). Additionally, it is assumed that you have followed our [Getting Started Guide](/docs/getting-started/) if you intend to run Irssi on your Linode.
+Irssi can run on Linux or MAC OS X, either from your local workstation or your Linode. If you are unfamiliar with using a Linux terminal, you may want to review the Linode guides [Using the Terminal](/docs/networking/ssh/using-the-terminal/) and [Introduction to Linux Concepts](/docs/tools-reference/introduction-to-linux-concepts/). Additionally, it is assumed that you have followed our [Getting Started Guide](/docs/getting-started/) if you intend to run Irssi on your Linode.
 
 ## Prerequisites
 
@@ -32,7 +32,7 @@ Complete these tasks before you start:
 
 -   All the procedures listed in the [Getting Started](/docs/getting-started/) guide
 -   The **Adding a New User**, **Using SSH Key Pair Authentication**, and **Disabling SSH Password Authentication and Root Login** sections in the [Securing Your Server](/docs/securing-your-server/) guide
--   Make sure **GNU Screen** is installed. It should be by default. See our [Screen Guide](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions) for information.
+-   Make sure **GNU Screen** is installed. It should be by default. See our [Screen Guide](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/) for information.
 
 ## Installing Irssi
 
@@ -249,4 +249,4 @@ To remove a `hilight`, use the command:
 
 ## User-friendly Plugins
 
-Enhance your Irssi experience with user-friendly plugins! Add a full list of open windows to the bottom of the screen, colored nicks, and more. Check out the [Using Plugins](/docs/communications/irc/advanced-irssi#using-plugins) section of the [Advanced Irssi Usage](/docs/communications/irc/advanced-irssi) guide.
+Enhance your Irssi experience with user-friendly plugins! Add a full list of open windows to the bottom of the screen, colored nicks, and more. Check out the [Using Plugins](/docs/communications/irc/advanced-irssi/#using-plugins) section of the [Advanced Irssi Usage](/docs/applications/messaging/advanced-irssi-usage/) guide.

--- a/docs/applications/messaging/using-weechat-for-irc.md
+++ b/docs/applications/messaging/using-weechat-for-irc.md
@@ -15,15 +15,15 @@ title: 'Using WeeChat for Internet Relay Chat'
 external_resources:
  - '[WeeChat Home Page](http://www.weechat.org/)'
  - '[GNU Screen](http://www.gnu.org/software/screen/)'
- - '[Screen for Persistent Terminal Sessions](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions)'
+ - '[Screen for Persistent Terminal Sessions](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/)'
 ---
 
 
 [WeeChat](https://weechat.org/) is a multi-platform, terminal-based Internet Relay Chat (IRC) client written in C. Weechat is intended to be flexible and extensible, and thus has all sorts of plugins written in different languages including Python, Perl, and Ruby.
 
-Many users prefer WeeChat over other graphical and terminal-based clients because of its many features and its customizability. One advantage of terminal-based clients over graphical IRC clients is the ability to detach from your WeeChat instance and come back later, locally or remotely, using a terminal multiplexer such as [Screen](https://www.gnu.org/software/screen/) or [tmux](https://tmux.github.io/).
+Many users prefer WeeChat over other graphical and terminal-based clients because of its many features and its customizability. One advantage of terminal-based clients over graphical IRC clients is the ability to detach from your WeeChat instance and come back later, locally or remotely, using a terminal multiplexer such as [Screen](https://www.gnu.org/software/screen/) or [tmux](/docs/networking/ssh/persistent-terminal-sessions-with-tmux/).
 
-WeeChat is usually run in a terminal emulator. It may be run either on your computer, a Linode instance, or any computer running a supported platform. If you run WeeChat on your Linode, you can access WeeChat at any time from any system simply by connecting via SSH and attaching to your Screen or tmux instance. This guide assumes you have read [Using The Terminal](/docs/networking/ssh/using-the-terminal) and [Linux System Administration Basics](/docs/tools-reference/linux-system-administration-basics), along with the [Getting Started Guide](/docs/getting-started/).
+WeeChat is usually run in a terminal emulator. It may be run either on your computer, a Linode instance, or any computer running a supported platform. If you run WeeChat on your Linode, you can access WeeChat at any time from any system simply by connecting via SSH and attaching to your Screen or tmux instance. This guide assumes you have read [Using The Terminal](/docs/networking/ssh/using-the-terminal/) and [Linux System Administration Basics](/docs/tools-reference/linux-system-administration-basics/), along with the [Getting Started Guide](/docs/getting-started/).
 
 ## What is IRC?
 
@@ -42,9 +42,9 @@ A user is often represented as `nickname!username@host`.
 
 ## Before You Begin
 
-1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) to create a standard user account, harden SSH access and remove unnecessary network services. Also follow the section to create a firewall, but omit the lines for ports 80 and 443 as these are not needed for a WeeChat server.
+2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services. Also follow the section to create a firewall, but omit the lines for ports 80 and 443 as these are not needed for a WeeChat server.
 
 3.  Update your system:
 
@@ -57,12 +57,12 @@ A user is often represented as `nickname!username@host`.
         sudo apt-get update && sudo apt-get upgrade
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Using GNU Screen
 
-GNU Screen allows you to start WeeChat and leave it running, even if you disconnect from your Linode. We recommend running WeeChat in Screen, so our instructions include Screen-specific commands. For more information, see [Using GNU Screen to Manage Persistent Terminal Sessions](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions).
+GNU Screen allows you to start WeeChat and leave it running, even if you disconnect from your Linode. We recommend running WeeChat in Screen, so our instructions include Screen-specific commands. For more information, see [Using GNU Screen to Manage Persistent Terminal Sessions](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/).
 
 ## Installing WeeChat
 

--- a/docs/applications/project-management/manage-projects-with-redmine-on-debian-6-squeeze.md
+++ b/docs/applications/project-management/manage-projects-with-redmine-on-debian-6-squeeze.md
@@ -18,7 +18,7 @@ This guide will help you install Redmine on your Debian 6 (Squeeze) Linode. It i
 
 # Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f
@@ -154,7 +154,7 @@ Issue the following commands to enable proxy support:
     a2enmod proxy_http
     /etc/init.d/apache2 restart
 
-Configure an Apache virtualhost for your Redmine installation. The example shown below assumes Apache is configured as recommended in our [Debian 6 LAMP guide](/docs/lamp-guides/debian-6-squeeze). Remember to replace "12.34.56.78" with your Linode's IP address, `support@example.com` with your administrative email address, and "redmine.example.com" with your Redmine domain.
+Configure an Apache virtualhost for your Redmine installation. The example shown below assumes Apache is configured as recommended in our [Debian 6 LAMP guide](/docs/web-servers/lamp/lamp-server-on-debian-6-squeeze/). Remember to replace "12.34.56.78" with your Linode's IP address, `support@example.com` with your administrative email address, and "redmine.example.com" with your Redmine domain.
 
 {{< file "/etc/apache2/sites-available/redmine.example.com" apache >}}
 <VirtualHost *:80>

--- a/docs/applications/remote-desktop/using-vnc-to-operate-a-desktop-on-ubuntu-12-04.md
+++ b/docs/applications/remote-desktop/using-vnc-to-operate-a-desktop-on-ubuntu-12-04.md
@@ -55,7 +55,7 @@ The default VNC connection is unencrypted. In order to secure your passwords and
 
 ### Windows
 
-1.  Open [PuTTY](/docs/networking/using-putty) and navigate under the `SSH` menu to `Tunnels`. Add a new forwarded port as shown below, replacing example.com with your Linode's IP address or hostname:
+1.  Open [PuTTY](/docs/networking/ssh/ssh-connections-using-putty-on-windows/) and navigate under the `SSH` menu to `Tunnels`. Add a new forwarded port as shown below, replacing example.com with your Linode's IP address or hostname:
 
     [![Adding a forwarded port to PuTTY.](/docs/assets/1648-vnc-putty-1.png)](/docs/assets/1648-vnc-putty-1.png)
 

--- a/docs/applications/voip/deploy-voip-services-with-asterisk-and-freepbx-on-ubuntu-9-10-karmic.md
+++ b/docs/applications/voip/deploy-voip-services-with-asterisk-and-freepbx-on-ubuntu-9-10-karmic.md
@@ -16,7 +16,7 @@ title: 'Deploy VoIP Services with Asterisk and FreePBX on Ubuntu 9.10 (Karmic)'
 
 Asterisk is an open source telephone solution that runs over the internet instead of running through copper lines like a normal phone would. It offers a variety of features such as voice mail and conference calling, much like a land line telephone can.
 
-Before you begin, you need to make sure a few things are in order. We assume you have followed the [getting started guide](/docs/getting-started/) and have set the hostname, timezone, and configured networking. These last steps are of particular importance for ensuring your Asterisk installation functions normally. If you plan on using Asterisk's email features, you may also wish to [add an A record](/docs/dns-guides/introduction-to-dns#types-of-dns-records) for your domain.
+Before you begin, you need to make sure a few things are in order. We assume you have followed the [getting started guide](/docs/getting-started/) and have set the hostname, timezone, and configured networking. These last steps are of particular importance for ensuring your Asterisk installation functions normally. If you plan on using Asterisk's email features, you may also wish to [add an A record](/docs/networking/dns/dns-records-an-introduction/#types-of-dns-records) for your domain.
 
 **Please note:** Because of the special configuration options required for this setup, you should not run other services on the Linode you intend to use Asterisk on. It is also worth noting that this guide will walk you through using pv\_grub. Any alterations to the steps in this guide will fall outside the scope of support.
 
@@ -24,7 +24,7 @@ This guide is based largely on [Ryan Tucker's guide](http://blog.hoopycat.com/20
 
 # Prerequisites
 
-There are quite a few prerequisites to satisfy before you can begin installing Asterisk and FreePBX. Most notably, you will need to install a kernel module and change your Linode's configuration profile. We're going to outline the instructions for doing so in this document, however you may wish to take a look at the in-depth information contained in the [pv-grub guide](/docs/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu).
+There are quite a few prerequisites to satisfy before you can begin installing Asterisk and FreePBX. Most notably, you will need to install a kernel module and change your Linode's configuration profile. We're going to outline the instructions for doing so in this document, however you may wish to take a look at the in-depth information contained in the [pv-grub guide](/docs/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu/).
 
 ### Edit Sources List
 
@@ -158,7 +158,7 @@ FreePBX is a PHP application that allows you to control your Asterisk installati
 
 ### Set Up LAMP Stack
 
-Before you can use FreePBX, you will need to set up a LAMP stack. An overview is provided here, but you may wish to consult our [LAMP documentation](/docs/lamp-guides/ubuntu-9-10-karmic/) for more information. To begin installing Apache, issue the following command:
+Before you can use FreePBX, you will need to set up a LAMP stack. An overview is provided here, but you may wish to consult our [LAMP documentation](/docs/web-servers/lamp/lamp-server-on-ubuntu-9-10-karmic/) for more information. To begin installing Apache, issue the following command:
 
     apt-get install apache2
 

--- a/docs/databases/elasticsearch/monitor-nginx-web-server-logs-using-filebeat-elastic-stack-centos-7.md
+++ b/docs/databases/elasticsearch/monitor-nginx-web-server-logs-using-filebeat-elastic-stack-centos-7.md
@@ -25,16 +25,16 @@ The [Elastic Stack](https://www.elastic.co/) is a set of open-source tools that 
 This guide will explain how to install different components of the stack in order to monitor a typical webserver. It will use version 6 of each of the tools in the Elastic Stack, which is a recent release featuring additional features and fixes.
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Before You Begin
 
-1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  Follow the steps in our [Install a LEMP Stack on CentOS 7 with FastCGI](/docs/web-servers/lemp/lemp-stack-on-centos-7-with-fastcgi) guide to set up a web server stack with NGINX on your CentOS host.
+2.  Follow the steps in our [Install a LEMP Stack on CentOS 7 with FastCGI](/docs/web-servers/lemp/lemp-stack-on-centos-7-with-fastcgi/) guide to set up a web server stack with NGINX on your CentOS host.
 
-3.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) to create a standard user account, harden SSH access and remove unnecessary network services.
+3.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services.
 
 4.  Update your system:
 
@@ -203,7 +203,7 @@ Replace `username` with your Linux user name and `<Linode public IP>` with the p
 Filebeat version 6 ships with the ability to use [modules](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html) in order to automate how logs are collected, indexed, and visualized. This guide will use the NGINX module in order to handle most of the necessary configuration in order to instruct the stack how to process system logs.
 
 {{< note >}}
-Your Linode should already have NGINX configured following the [Install a LEMP Stack on CentOS 7 with FastCGI](/docs/web-servers/lemp/lemp-stack-on-centos-7-with-fastcgi) guide.
+Your Linode should already have NGINX configured following the [Install a LEMP Stack on CentOS 7 with FastCGI](/docs/web-servers/lemp/lemp-stack-on-centos-7-with-fastcgi/) guide.
 {{< /note >}}
 
 1.  Using a text editor, create `/etc/filebeat/filebeat.yml` and add the following content:

--- a/docs/databases/elasticsearch/visualize-apache-web-server-logs-using-elastic-stack-on-debian-8.md
+++ b/docs/databases/elasticsearch/visualize-apache-web-server-logs-using-elastic-stack-on-debian-8.md
@@ -31,16 +31,16 @@ This guide will explain how to install all three components and use them to expl
 This guide will walk through the installation and set up of version 5 of the Elastic stack, which is the latest at time of this writing.
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Before You Begin
 
-1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  Follow the steps in our [Apache Web Server on Debian 8 (Jessie)](/docs/web-servers/apache/apache-web-server-debian-8) guide to set up and configure Apache on your server.
+2.  Follow the steps in our [Apache Web Server on Debian 8 (Jessie)](/docs/web-servers/apache/apache-web-server-debian-8/) guide to set up and configure Apache on your server.
 
-3.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) to create a standard user account, harden SSH access and remove unnecessary network services.
+3.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services.
 
 4.  Update your system:
 
@@ -174,7 +174,7 @@ By default, Elasticsearch will create five shards and one replica for every inde
 
 ### Logstash
 
-In order to collect Apache access logs, Logstash must be configured to watch any necessary files and then process them, eventually sending them to Elasticsearch. This configuration file assumes that a site has been set up according to the previously mentioned [Apache Web Server on Debian 8 (Jessie)](/docs/web-servers/apache/apache-web-server-debian-8) guide to find the correct log path.
+In order to collect Apache access logs, Logstash must be configured to watch any necessary files and then process them, eventually sending them to Elasticsearch. This configuration file assumes that a site has been set up according to the previously mentioned [Apache Web Server on Debian 8 (Jessie)](/docs/web-servers/apache/apache-web-server-debian-8/) guide to find the correct log path.
 
 1.  Create the following Logstash configuration:
 

--- a/docs/databases/mysql/deploy-mysql-relational-databases-on-ubuntu-12-04-precise-pangolin.md
+++ b/docs/databases/mysql/deploy-mysql-relational-databases-on-ubuntu-12-04-precise-pangolin.md
@@ -22,12 +22,12 @@ external_resources:
 MySQL is a popular database management system used for web and server applications. This guide will introduce how to install, configure and manage MySQL on a Linode running Ubuntu 12.04 LTS (Precise Pangolin).
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Prerequisites
 
-1.  Ensure that you have followed the [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/security/securing-your-server) guides, and the Linode's [hostname is set](/docs/getting-started#setting-the-hostname).
+1.  Ensure that you have followed the [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/security/securing-your-server/) guides, and the Linode's [hostname is set](/docs/getting-started/#setting-the-hostname).
 
     To check your hostname run:
 
@@ -49,7 +49,7 @@ During the installation process, you will be prompted to set a password for the 
 
 [![Setting the MySQL root password in Ubuntu 14.04 LTS (Trusty Tahr).](/docs/assets/mysql-root-pw.png)](/docs/assets/mysql-root-pw.png)
 
-MySQL will bind to localhost (127.0.0.1) by default. Please reference our [MySQL remote access guide](/docs/databases/mysql/create-an-ssh-tunnel-for-mysql-remote-access) for information on connecting to your databases using an SSH tunnel.
+MySQL will bind to localhost (127.0.0.1) by default. Please reference our [MySQL remote access guide](/docs/databases/mysql/create-an-ssh-tunnel-for-mysql-remote-access/) for information on connecting to your databases using an SSH tunnel.
 
 {{< note >}}
 Allowing unrestricted access to MySQL on a public IP not advised, but you may change the address it listens on by modifying the `bind-address` parameter in `/etc/my.cnf`. If you decide to bind MySQL to your public IP, you should implement firewall rules that only allow connections from specific IP addresses.

--- a/docs/databases/mysql/use-mysql-relational-databases-on-ubuntu-10-04-lts-lucid.md
+++ b/docs/databases/mysql/use-mysql-relational-databases-on-ubuntu-10-04-lts-lucid.md
@@ -94,7 +94,7 @@ net_buffer_length = 2K
 
 These settings are only suggested values for a low memory environment; please feel free to tune them to appropriate values for your server. Consult the "More Information" section at the end of this tutorial for additional resources on this topic.
 
-MySQL will bind to localhost (127.0.0.1) by default. Please reference our [secure MySQL remote access guide](/docs/databases/mysql/mysql-ssh-tunnel) for information on connecting to your databases with local clients.
+MySQL will bind to localhost (127.0.0.1) by default. Please reference our [secure MySQL remote access guide](/docs/databases/mysql/create-an-ssh-tunnel-for-mysql-remote-access/) for information on connecting to your databases with local clients.
 
 Allowing unrestricted access to MySQL on a public IP is not advised, but you may change the address it listens on by modifying the `bind-address` parameter. If you decide to bind MySQL to your public IP, you should implement firewall rules that only allow connections from specific IP addresses.
 
@@ -167,7 +167,7 @@ Now let's log back into the MySQL client as `testuser` and create a sample table
 
 This creates a table with a customer ID field of the type INT for integer (auto-incremented for new records and used as the primary key), as well as two fields for storing the customer's name.
 
-By default, access to databases will be limited to connections from localhost. To securely administer your databases from a remote location, please follow our guide for [securely administering mysql with an SSH tunnel](/docs/databases/mysql/mysql-ssh-tunnel). It is *not* a good practice to run MySQL on your public IP address, unless you have a very good reason for doing so.
+By default, access to databases will be limited to connections from localhost. To securely administer your databases from a remote location, please follow our guide for [securely administering mysql with an SSH tunnel](/docs/databases/mysql/create-an-ssh-tunnel-for-mysql-remote-access/). It is *not* a good practice to run MySQL on your public IP address, unless you have a very good reason for doing so.
 
 # More Information
 

--- a/docs/databases/oracle/oracle-10g-express-edition-on-debian-5-lenny.md
+++ b/docs/databases/oracle/oracle-10g-express-edition-on-debian-5-lenny.md
@@ -125,7 +125,7 @@ You should see output resembling the following:
 
 Oracle is managed via a web interface, which is installed with the oracle-xe package. By default, it listens on the local address `127.0.0.1` at port 8080. Since you most likely do not have a window manager or web browser installed on your Linode, you must connect to your Oracle home page remotely.
 
-You can do this by using our [Oracle SSH tunnel script](/docs/databases/oracle/ssh-tunnel). After your tunnel is started, you can connect to the admin page at the URL `http://127.0.0.1:8080/apex`. Log in with the username "SYSTEM" and the password you specified during Oracle configuration. You'll be presented with a page similar to this one:
+You can do this by using our [Oracle SSH tunnel script](/docs/databases/oracle/securely-administer-oracle-xe-with-an-ssh-tunnel/). After your tunnel is started, you can connect to the admin page at the URL `http://127.0.0.1:8080/apex`. Log in with the username "SYSTEM" and the password you specified during Oracle configuration. You'll be presented with a page similar to this one:
 
 [![The Oracle XE administration home page.](/docs/assets/380-oracle-xe-admin-page.png)](/docs/assets/380-oracle-xe-admin-page.png)
 

--- a/docs/databases/redis/how-to-install-a-redis-server-on-ubuntu-or-debian8.md
+++ b/docs/databases/redis/how-to-install-a-redis-server-on-ubuntu-or-debian8.md
@@ -31,9 +31,9 @@ Since Redis serves all data from memory, we recommend using a [high memory Linod
 
 ## Before You Begin
 
-1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) to create a standard user account, harden SSH access and remove unnecessary network services.
+2.  Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services.
 
 3.  Update your system:
 
@@ -44,7 +44,7 @@ Since Redis serves all data from memory, we recommend using a [high memory Linod
         sudo apt-get install software-properties-common
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 
 To utilize the replication steps in the second half of this guide, you will need at least two Linodes.
 {{< /note >}}
@@ -163,7 +163,7 @@ For this section of the guide, you will use two Linodes, respectively named `mas
 
 1.  Set up both Linodes with a Redis instance, using **Redis Installation** and **Redis Configuration** steps from this guide. You can also copy your initially configured disk to another Linode using the [Clone](/docs/platform/disk-images/disk-images-and-configuration-profiles/#cloning-disks-and-configuration-profiles) option in the Linode Manager.
 
-2.  Configure [Private IP Addresses](/docs/networking/remote-access#adding-private-ip-addresses) on both Linodes, and make sure you can access the `master` Linode's private IP address from `slave`. You will use only private addresses for replication traffic for security reasons.
+2.  Configure [Private IP Addresses](/docs/networking/remote-access/#adding-private-ip-addresses) on both Linodes, and make sure you can access the `master` Linode's private IP address from `slave`. You will use only private addresses for replication traffic for security reasons.
 
 3.  Configure the `master` Redis instance to listen on a private IP address by updating the `bind` configuration option in `redis.conf`. Replace `192.0.2.100` with the `master` Linode's private IP address
 
@@ -214,7 +214,7 @@ Your master/slave replication setup is working properly.
 
 Since Redis is designed to work in trusted environments and with trusted clients, you should take care of controlling access to the Redis instance. Security methods include:
 
-- Setting up a firewall using [iptables](/docs/security/firewalls/iptables).
+- Setting up a firewall using [iptables](/docs/security/firewalls/control-network-traffic-with-iptables/).
 
 - Encrypting Redis traffic, using an SSH tunnel or the methods described in the [Redis Security documentation](http://redis.io/topics/security).
 

--- a/docs/development/frameworks/django-apache-and-modpython-on-centos-5.md
+++ b/docs/development/frameworks/django-apache-and-modpython-on-centos-5.md
@@ -22,11 +22,11 @@ The EPEL effort is similar to the "backporting" efforts that exist in other dist
 
 There are many different ways to deploy Django applications that all have distinct advantages and disadvantages depending on the nature of your deployment. Our setup is designed to be fully functional and simple to set up for people who are new to systems administration. Nevertheless, Django is very flexible with regards to how applications are deployed; you can feel totally free to alter your approach as your needs and abilities change and grow.
 
-As a prerequisite for this guide, we assume that you've completed the [getting started guide](/docs/getting-started/) and have a running and up to date CentOS 5 system. Furthermore, you will want to have a running [Apache web server](/docs/web-servers/apache/installation/centos-5) and a functional [MySQL database](/docs/databases/mysql/centos-5). With these prerequisites out of the way, we can begin installing tools for running Django applications on our server.
+As a prerequisite for this guide, we assume that you've completed the [getting started guide](/docs/getting-started/) and have a running and up to date CentOS 5 system. Furthermore, you will want to have a running [Apache web server](/docs/web-servers/apache/apache-2-web-server-on-centos-5/) and a functional [MySQL database](/docs/databases/mysql/use-mysql-relational-databases-on-centos-5/). With these prerequisites out of the way, we can begin installing tools for running Django applications on our server.
 
 # Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f
@@ -41,7 +41,7 @@ Before we begin to install packages we need to first install the EPEL repositori
 
 When you install your first package from EPEL, `yum` will ask you to import the PGP key for the EPEL repository. You should accept this request.
 
-Now we can install Django using the `yum` [package management](/docs/using-linux/package-management) interface. The following command will also install required dependencies on your system:
+Now we can install Django using the `yum` [package management](/docs/tools-reference/linux-package-management/) interface. The following command will also install required dependencies on your system:
 
     yum update
     yum install mod_python Django
@@ -77,7 +77,7 @@ You may choose to install additional Python-related tools for your specific appl
 
 # Configuring Apache
 
-With all of the dependencies installed, we must configure Apache for virtual hosting. If you're new to administering and configuring Apache web servers, please consider our documentation on [configuring and using the Apache HTTP server](/docs/web-servers/apache/). If you did not previously have Apache installed, it would have been installed when you installed the `mod_python` package. In these cases, [configure Apache for virtual hosting](/docs/web-servers/apache/apache-2-web-server-on-centos-5#configure-apache) before configuring Apache for Django.
+With all of the dependencies installed, we must configure Apache for virtual hosting. If you're new to administering and configuring Apache web servers, please consider our documentation on [configuring and using the Apache HTTP server](/docs/web-servers/apache/). If you did not previously have Apache installed, it would have been installed when you installed the `mod_python` package. In these cases, [configure Apache for virtual hosting](/docs/web-servers/apache/apache-2-web-server-on-centos-5/#configure-apache) before configuring Apache for Django.
 
 You will want to insert a `Location` block inside the virtual hosting block for the domain where you want the Django application to run. The location block looks like this:
 

--- a/docs/development/frameworks/django-apache-and-modpython-on-ubuntu-8-04-hardy.md
+++ b/docs/development/frameworks/django-apache-and-modpython-on-ubuntu-8-04-hardy.md
@@ -20,7 +20,7 @@ Django is a web development framework for the Python programing language. It ena
 
 This guide provides an introduction to getting started with the Django framework. Although Ubuntu Hardy includes Django packages, these contain a dated version of the Django framework, in the 0.9x series. We've decided to install the most recent stable release of Django instead. This provides the best possible balance between the stability and support of the Ubuntu-Hardy release, and the most current Django API. In general the Apache, plus mod\_python, plus Django is accepted as the idea setup for beginning Django deployments, although the framework is quite flexible with regards to how applications can be deployed. There are many base platforms that you may consider in the future as your needs grow and change.
 
-We assume that you've completed the [getting started guide](/docs/getting-started/) and have a running and up to date Ubuntu 8.04 (Hardy) system. Furthermore, you will want to have a running [Apache web server](/docs/web-servers/apache/installation/ubuntu-8-04-hardy) and a functional [MySQL database](/docs/databases/mysql/ubuntu-8-04-hardy) installed.
+We assume that you've completed the [getting started guide](/docs/getting-started/) and have a running and up to date Ubuntu 8.04 (Hardy) system. Furthermore, you will want to have a running [Apache web server](/docs/web-servers/apache/apache-2-web-server-on-ubuntu-8-04-lts-hardy/) and a functional [MySQL database](/docs/databases/mysql/use-mysql-relational-databases-on-ubuntu-8-04-hardy/) installed.
 
 # Installing Python Dependencies
 

--- a/docs/email/clients/install-squirrelmail-on-ubuntu-16-04-or-debian-8.md
+++ b/docs/email/clients/install-squirrelmail-on-ubuntu-16-04-or-debian-8.md
@@ -16,10 +16,10 @@ external_resources:
 
 ![Install SquirrelMail on Ubuntu or Debian](/docs/assets/install-squirrelmail-on-ubuntu/Install_SquirrelMail_smg.jpg)
 
-SquirrelMail is a webmail package, written in PHP, which supports both SMTP and IMAP protocols, and features cross-platform compatibility. SquirrelMail requires a web server with PHP to run properly. For this guide we'll be using Apache 2. If you don't already have Apache and PHP installed, you can check our [LAMP Server on Ubuntu 16.04](/docs/websites/lamp/install-lamp-on-ubuntu-16-04) or [LAMP Server on Debian 8](/docs/websites/lamp/lamp-on-debian-8-jessie) guide.
+SquirrelMail is a webmail package, written in PHP, which supports both SMTP and IMAP protocols, and features cross-platform compatibility. SquirrelMail requires a web server with PHP to run properly. For this guide we'll be using Apache 2. If you don't already have Apache and PHP installed, you can check our [LAMP Server on Ubuntu 16.04](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/) or [LAMP Server on Debian 8](/docs/web-servers/lamp/lamp-on-debian-8-jessie/) guide.
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Privileges](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Privileges](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Installation
@@ -125,7 +125,7 @@ Before using SquirrelMail for the first time, configure it to access your mail s
 3.  If your mail server is on the same Linode as your SquirrelMail installation, you may not need to make any adjustments to the default settings. Otherwise, adjust the **Domain**, **IMAP**, and **SMTP** settings to match the mail server you want to connect to. You can find additional configuration tips for this section from [SquirrelMail's official documentation](http://squirrelmail.org/docs/admin/admin-5.html#ss5.3).
 
     {{< note >}}
-If your email server uses `STARTTLS` encryption, as our [Email with Postfix, Dovecot, and MySQL](/docs/email/postfix/email-with-postfix-dovecot-and-mysql) guide does, You will not be able to authenticate using this version of Squirrelmail. Version 1.5.1 and higher can use `STARTTLS`, but are in development and not available in the main repositories. You can [download](https://squirrelmail.org/download.php) the latest build from Squirrelmail's website.
+If your email server uses `STARTTLS` encryption, as our [Email with Postfix, Dovecot, and MySQL](/docs/email/postfix/email-with-postfix-dovecot-and-mysql/) guide does, You will not be able to authenticate using this version of Squirrelmail. Version 1.5.1 and higher can use `STARTTLS`, but are in development and not available in the main repositories. You can [download](https://squirrelmail.org/download.php) the latest build from Squirrelmail's website.
 {{< /note >}}
 
 4.  When done, press `S` to save your changes, then press Q to quit.

--- a/docs/email/clients/installing-squirrelmail-on-debian-7.md
+++ b/docs/email/clients/installing-squirrelmail-on-debian-7.md
@@ -16,10 +16,10 @@ external_resources:
 deprecated: true
 ---
 
-SquirrelMail is a webmail package written in PHP. It supports both SMTP and IMAP protocols. SquirrelMail features cross-platform compatibility since all of its pages render in HTML 4.0. SquirrelMail requires a web server with PHP to run properly. For this guide we'll be using Apache 2. If you don't already have Apache and PHP installed, you can check our [LAMP Server on Ubuntu 12.04](/docs/lamp-guides/ubuntu-12-04-precise-pangolin) guide.
+SquirrelMail is a webmail package written in PHP. It supports both SMTP and IMAP protocols. SquirrelMail features cross-platform compatibility since all of its pages render in HTML 4.0. SquirrelMail requires a web server with PHP to run properly. For this guide we'll be using Apache 2. If you don't already have Apache and PHP installed, you can check our [LAMP Server on Ubuntu 12.04](/docs/web-servers/lamp/lamp-server-on-ubuntu-12-04-precise-pangolin/) guide.
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Privileges](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Privileges](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Installation
@@ -47,7 +47,7 @@ Since SquirrelMail is accessed through a web server (Apache in this example), we
 
         sudo nano /etc/apache2/sites-available/squirrelmail
 
-	{{< file "/etc/apache2/sites-available/squirrelmail" apache >}}
+    {{< file "/etc/apache2/sites-available/squirrelmail" apache >}}
 Alias /squirrelmail /usr/share/squirrelmail
 
 <Directory /usr/share/squirrelmail>
@@ -92,7 +92,7 @@ Alias /squirrelmail /usr/share/squirrelmail
 {{< /file >}}
 
 
-	{{< note >}}
+    {{< note >}}
 If Apache is serving other virtual hosts you may need to adjust them and/or this file to prevent any conflicts. If you're running Apache solely for SquirrelMail, you may still want to remove the default virtual host from `sites-enabled`.
 {{< /note >}}
 

--- a/docs/email/mailman/manage-email-lists-with-gnu-mailman-on-ubuntu-12-04-precise-pangolin.md
+++ b/docs/email/mailman/manage-email-lists-with-gnu-mailman-on-ubuntu-12-04-precise-pangolin.md
@@ -20,7 +20,7 @@ Be sure to review this guide in its entirety before beginning the procedure outl
 
 # Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f
@@ -44,7 +44,7 @@ During the Mailman installation, you will be required to specify the languages t
 
 # Configure Mailman
 
-Consider the [Configure Virtual Hosting](/docs/email/mailman/manage-email-lists-with-gnu-mailman-on-ubuntu-12-04-precise-pangolin#configure-virtual-hosting) section before preceding. In most cases where you will be hosting you will want to skip this section and continue with that procedure. Mailman requires a "base" list, from which it can send email to welcome new members to lists and send password reminders when needed. Create this list by issuing the following command:
+Consider the [Configure Virtual Hosting](/docs/email/mailman/manage-email-lists-with-gnu-mailman-on-ubuntu-12-04-precise-pangolin/#configure-virtual-hosting) section before preceding. In most cases where you will be hosting you will want to skip this section and continue with that procedure. Mailman requires a "base" list, from which it can send email to welcome new members to lists and send password reminders when needed. Create this list by issuing the following command:
 
     newlist mailman
 
@@ -101,7 +101,7 @@ mailman_destination_recipient_limit = 1
 {{< /file-excerpt >}}
 
 
-Replace `example.com` and `lists.example.com` with the relevant domains for your instance. Ensure that you have configured the [MX Records](/docs/dns-guides/introduction-to-dns#mx) for both domains that you want to receive email with. Additionally, ensure the following lines are included your `/etc/postfix/master.cf` file:
+Replace `example.com` and `lists.example.com` with the relevant domains for your instance. Ensure that you have configured the [MX Records](/docs/dns-guides/introduction-to-dns/#mx) for both domains that you want to receive email with. Additionally, ensure the following lines are included your `/etc/postfix/master.cf` file:
 
 {{< file-excerpt "/etc/postfix/master.cf" >}}
 mailman   unix  -       n       n       -       -       pipe
@@ -125,7 +125,7 @@ Finally, modify the `/etc/mailman/mm_cfg.py` file to set the following values. A
 
 This controls how Mailman processes the mail that it receives from postfix. Continue configuring Mailman by editing following file to update Mailman to interact properly with postfix:
 
-{{< file-excerpt "/etc/mailman/mm\\_cfg.py" >}}
+{{< file-excerpt "/etc/mailman/mm_cfg.py" >}}
 MTA = 'Postfix'
 POSTFIX_STYLE_VIRTUAL_DOMAINS = ['lists.example.com']
 # alias for postmaster, abuse and mailer-daemon
@@ -136,7 +136,7 @@ DEB_LISTMASTER = 'postmaster@example.com'
 
 Ensure that the fields `DEFAULT_EMAIL_HOST` and `DEFAULT_URL_HOST` match the sub-domain you are using for lists (e.g. `lists.example.com`) as follows:
 
-{{< file-excerpt "/etc/mailman/mm\\_cfg.py" >}}
+{{< file-excerpt "/etc/mailman/mm_cfg.py" >}}
 #-------------------------------------------------------------
 # Default domain for email addresses of newly created MLs
 DEFAULT_EMAIL_HOST = 'lists.example.com'
@@ -152,7 +152,7 @@ add_virtualhost(DEFAULT_URL_HOST, DEFAULT_EMAIL_HOST)
 
 If you need to configure additional domains for use, ensure that you've made the proper additions to the `relay_domains` field in the to the `POSTFIX_STYLE_VIRTUAL_DOMAINS` line and create additional `add_virtualhost` calls in the following form for every new domain:
 
-{{< file-excerpt "/etc/mailman/mm\\_cfg.py" >}}
+{{< file-excerpt "/etc/mailman/mm_cfg.py" >}}
 add_virtualhost('lists.example.org', 'lists.example.org')
 
 # Modify the following line
@@ -161,7 +161,7 @@ POSTFIX_STYLE_VIRTUAL_DOMAINS = ['lists.example.com', 'lists.example.org']
 {{< /file-excerpt >}}
 
 
-Ensure that your domains have valid MX and [A Records](/docs/dns-guides/introduction-to-dns#types-of-dns-records) that point to your Linode. When you've finished configuring Mailman, issue the following commands to create the default list (which will prompt you to enter an address for the list administrator and a password), restart Postfix, and start Mailman for the first time:
+Ensure that your domains have valid MX and [A Records](/docs/dns-guides/introduction-to-dns/#types-of-dns-records) that point to your Linode. When you've finished configuring Mailman, issue the following commands to create the default list (which will prompt you to enter an address for the list administrator and a password), restart Postfix, and start Mailman for the first time:
 
     newlist mailman
     /etc/init.d/postfix restart
@@ -176,7 +176,7 @@ From this point forward, you can create new lists by issuing `newlist` commands 
 
 # Configuring Mailman with Alternate Mail Configurations
 
-If you wish to deploy Mailman on a system that has an existing mail set up, such as the [Postfix with Dovecot and MySQL](/docs/email/postfix/dovecot-mysql-ubuntu-10-04-lucid) or the [Postfix with Dovecot and System Users](/docs/email/postfix/dovecot-system-users-ubuntu-10-04-lucid) configurations described in other documents, consider the following recommendations:
+If you wish to deploy Mailman on a system that has an existing mail set up, such as the [Postfix with Dovecot and MySQL](/docs/email/postfix/dovecot-mysql-ubuntu-10-04-lucid/) or the [Postfix with Dovecot and System Users](/docs/email/postfix/dovecot-system-users-ubuntu-10-04-lucid) configurations described in other documents, consider the following recommendations:
 
 Complete your basic mail configuration according to the appropriate guide before beginning to install and configure Mailman.
 

--- a/docs/email/postfix/basic-postfix-email-gateway-on-debian-5-lenny.md
+++ b/docs/email/postfix/basic-postfix-email-gateway-on-debian-5-lenny.md
@@ -18,11 +18,11 @@ title: 'Basic Postfix Email Gateway on Debian 5 (Lenny)'
 
 Postfix is an efficient, stable, and modern "Mail Transfer Agent" or MTA used for transmitting email messages between severs on the Internet. Most configurations involving Postfix combine the MTA with a server to allow users to download email using a protocol like IMAP or POP3. This document outlines a very simple configuration of Postfix that makes it possible to forward email, and deliver email to local mailboxes on your Linode instance. This guide *does not* provide any way to download this email or remotely access these mailboxes. In addition, this document provides instructions for sending email with this configuration. If you want to deploy a complete and fully featured email solution that includes the ability download locally delivered email, consider one of our other [postfix email guides](/docs/email/postfix/).
 
-Prior to beginning this document to install a basic Postfix email gateway, we assume that you have completed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/content/using-linux/administration-basics).
+Prior to beginning this document to install a basic Postfix email gateway, we assume that you have completed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/).
 
 # Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f
@@ -209,7 +209,7 @@ Edit this file to include your username and the location of your email gateway. 
     chmod +x /opt/smtp-tunnel
     /opt/smtp-tunnel start
 
-You may want to consider issuing the command to start the tunnel (`/opt/smtp-tunnel start`) as part of your boot script by including it in your `/etc/rc.local` file, or by creating a `@reboot` [cron job](/docs/linux-tools/utilities/cron). If your network configuration utility allows you to establish pre- and post-connection scripts, you may want to instantiate and destroy the tunnel during this process. To destroy the tunnel, issue the following command:
+You may want to consider issuing the command to start the tunnel (`/opt/smtp-tunnel start`) as part of your boot script by including it in your `/etc/rc.local` file, or by creating a `@reboot` [cron job](/docs/tools-reference/tools/schedule-tasks-with-cron/). If your network configuration utility allows you to establish pre- and post-connection scripts, you may want to instantiate and destroy the tunnel during this process. To destroy the tunnel, issue the following command:
 
     /opt/smtp-tunnel stop
 
@@ -239,8 +239,8 @@ You may wish to consult the following resources for additional information on th
 - [Postfix](http://postfix.org)
 - [Postfix Virtual Mail Handling](http://www.postfix.org/VIRTUAL_README.html)
 - [Introduction to the DNS System](/docs/dns-guides/introduction-to-dns)
-- [Host Email with Postfix, Courier and MySQL on Debian 5 (Lenny)](/docs/email/postfix/courier-mysql-debian-5-lenny)
-- [Host Email with Postfix, Dovecot and MySQL on Debian 5 (Lenny)](/docs/email/postfix/dovecot-mysql-debian-5-lenny)
+- [Host Email with Postfix, Courier and MySQL on Debian 5 (Lenny)](/docs/email/postfix/email-with-postfix-courier-and-mysql-on-debian-5-lenny/)
+- [Host Email with Postfix, Dovecot and MySQL on Debian 5 (Lenny)](/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-debian-5-lenny/)
 
 
 

--- a/docs/game-servers/how-to-set-up-minecraft-server-on-ubuntu-or-debian.md
+++ b/docs/game-servers/how-to-set-up-minecraft-server-on-ubuntu-or-debian.md
@@ -28,7 +28,7 @@ This guide shows you how to set up a personal [Minecraft](https://minecraft.net/
 
 1.  To use a Minecraft server you must also have a version of the game client from [Minecraft.net](https://minecraft.net/).
 
-2.  Complete our [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/securing-your-server) guides.
+2.  Complete our [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/securing-your-server/) guides.
 
 3.  Update your Linode's software:
 
@@ -36,7 +36,7 @@ This guide shows you how to set up a personal [Minecraft](https://minecraft.net/
 
 3.  Install *OpenJDK*, an open-source implementation of Java, and the GNU Screen package.
 
-	{{< note >}}
+    {{< note >}}
 Minecraft version 1.12 is only compatible with OpenJDK 8. If you are using OpenJDK 7 you must remove it using this command
 `sudo apt remove openjdk-7-\*` before continuing with this guide.
 {{< /note >}}
@@ -53,7 +53,7 @@ Minecraft version 1.12 is only compatible with OpenJDK 8. If you are using OpenJ
 
         sudo adduser minecraft
 
-    Assign a secure password, and configure any additional [SSH hardening](/docs/security/use-public-key-authentication-with-ssh) options at this time.
+    Assign a secure password, and configure any additional [SSH hardening](/docs/security/authentication/use-public-key-authentication-with-ssh/) options at this time.
 
 {{< note >}}
 If you have a firewall configured according to our [Securing Your Server](/docs/security/securing-your-server/) guide, add the following line to your `iptables.firewall.rules` file to add an exception for port 25565:
@@ -162,4 +162,4 @@ To disconnect from the screen session without stopping the game server, press **
 
     [![Minecraft Players.](/docs/assets/minecraft-gameplay_small.png)](/docs/assets/minecraft-gameplay.png)
 
-Congratulations! You can now play Minecraft in a persistent world with your friends. For more information on working with `screen`, check out our guide on [GNU Screen](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions).
+Congratulations! You can now play Minecraft in a persistent world with your friends. For more information on working with `screen`, check out our guide on [GNU Screen](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/).

--- a/docs/game-servers/minecraft-with-mcmyadmin-on-debian.md
+++ b/docs/game-servers/minecraft-with-mcmyadmin-on-debian.md
@@ -20,9 +20,9 @@ aliases: ['applications/game-servers/minecraft-with-mcmyadmin-on-debian/']
 
 ## Before You Begin
 
-1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) guide to create a standard user account, harden SSH access and remove unnecessary network services. Do **not** follow the *Configure a Firewall* section yet--this guide includes firewall rules specifically for a Minecraft server.
+2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) guide to create a standard user account, harden SSH access and remove unnecessary network services. Do **not** follow the *Configure a Firewall* section yet--this guide includes firewall rules specifically for a Minecraft server.
 
 3.  Update your system.
 

--- a/docs/game-servers/multicraft-on-debian.md
+++ b/docs/game-servers/multicraft-on-debian.md
@@ -20,7 +20,7 @@ aliases: ['applications/game-servers/multicraft-on-debian/']
 [Multicraft](http://www.multicraft.org/) is a control panel for single or multiple Minecraft servers Free and paid versions are available. This guide will help you install Multicraft on a Linode running Debian 7.
 
 {{< note >}}
-The steps required in this guide require root privileges. Be sure to run the steps below as `root` or with the **sudo** prefix. For more information on privileges see our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+The steps required in this guide require root privileges. Be sure to run the steps below as `root` or with the **sudo** prefix. For more information on privileges see our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Prerequisites
@@ -47,8 +47,8 @@ Multicraft for Linux depends on several software packages in order to run.
 
 {{< /file-excerpt >}}
 
-        {{< note >}}
-If you want a dedicated Apache virtual host for Multicraft, follow the instructions [here](/docs/websites/hosting-a-website#configure-name-based-virtual-hosts). Be sure to configure the `AllowOverride` option on your custom virtual host.
+    {{< note >}}
+If you want a dedicated Apache virtual host for Multicraft, follow the instructions [here](/docs/websites/hosting-a-website/#configure-name-based-virtual-hosts). Be sure to configure the `AllowOverride` option on your custom virtual host.
 {{< /note >}}
 
 4.  Reload the Apache configuration:
@@ -152,4 +152,4 @@ eula=true
 {{< /file >}}
 
 
-    You can now successfully start and manage your Minecraft server through Multicraft! For instructions on connecting to your Minecraft server, click [here](/docs/applications/game-servers/minecraft-on-debian-and-ubuntu#connect-to-your-minecraft-server).
+    You can now successfully start and manage your Minecraft server through Multicraft! For instructions on connecting to your Minecraft server, click [here](/docs/game-servers/how-to-set-up-minecraft-server-on-ubuntu-or-debian/#connect-to-your-minecraft-server).

--- a/docs/networking/dns/dns-manager-overview.md
+++ b/docs/networking/dns/dns-manager-overview.md
@@ -13,7 +13,7 @@ published: 2009-07-16
 title: DNS Manager Overview
 ---
 
-The *DNS Manager* is a comprehensive DNS management interface available within the [Linode Manager](https://manager.linode.com) that allows you to add DNS records for all of your domain names. This guide covers the use of Linode's DNS Manager and basic domain zone setup. For an introduction to DNS in general, please see our [Introduction to DNS Records](/docs/networking/dns/introduction-to-dns-records) guide.
+The *DNS Manager* is a comprehensive DNS management interface available within the [Linode Manager](https://manager.linode.com) that allows you to add DNS records for all of your domain names. This guide covers the use of Linode's DNS Manager and basic domain zone setup. For an introduction to DNS in general, please see our [Introduction to DNS Records](/docs/networking/dns/dns-records-an-introduction/) guide.
 
 ![DNS Manager Overview](/docs/assets/dns-manager-overview.png)
 
@@ -34,8 +34,8 @@ When setting up any domain name on your Linode, make sure you perform the follow
 1.  Register (purchase) a domain name, if you haven't already.
 2.  [Set your domain name to use Linode's name servers](#set-domain-names-to-use-linodes-name-servers). You'll need to do this on your domain registrar's website and then wait up to 24 hours for the change to take effect.
 3.  Use the DNS Manager to [Add a domain zone](#add-a-domain-zone), and then start [adding some basic DNS records](#add-records).
-4.  [Set reverse DNS](/docs/networking/dns/setting-reverse-dns).
-5.  If you have any special DNS needs, such as using a third-party email server, add additional DNS records to [create a custom configuration](/docs/networking/dns/common-dns-configurations).
+4.  [Set reverse DNS](/docs/networking/dns/configure-your-linode-for-reverse-dns/).
+5.  If you have any special DNS needs, such as using a third-party email server, add additional DNS records to [create a custom configuration](/docs/networking/dns/common-dns-configurations/).
 
 ## Set Domain Names to Use Linode's Name Servers
 
@@ -105,7 +105,7 @@ In order for Linode's DNS servers to function as slaves, your DNS master server 
 2a01:7e00::a
 {{< /note >}}
 
-If you selected the option to have the DNS Manager insert basic DNS records, those records will be visible, as shown above. If you elected to keep the zone empty, you can start adding DNS records now. Skip to the [Adding DNS Records](/docs/networking/dns/dns-manager-overview#add-records) section for instructions.
+If you selected the option to have the DNS Manager insert basic DNS records, those records will be visible, as shown above. If you elected to keep the zone empty, you can start adding DNS records now. Skip to the [Adding DNS Records](/docs/networking/dns/dns-manager-overview/#add-records) section for instructions.
 
 [![This page lets you add specific DNS records.](/docs/assets/1121-dns9.png)](/docs/assets/1121-dns9.png)
 
@@ -118,18 +118,18 @@ When you first create a domain zone, you'll need to add some DNS records. The DN
 
 1.  Select a domain zone from within your DNS Manager.
 
-	[![This page has seven sections showing seven different types of records: SOA, NS, MX, and A/AAAA, CNAME, TXT, and SRV. You can adjust the SOA record by clicking the "Settings" link in that section. The next six sections each have a corresponding link that lets you add a new record of that type. For example, to add an NS record, click the "Add a new NS record" link. There are similar links for MX, A, CNAME, TXT, and SRV records.](/docs/assets/1121-dns9.png)](/docs/assets/1121-dns9.png)
+    [![This page has seven sections showing seven different types of records: SOA, NS, MX, and A/AAAA, CNAME, TXT, and SRV. You can adjust the SOA record by clicking the "Settings" link in that section. The next six sections each have a corresponding link that lets you add a new record of that type. For example, to add an NS record, click the "Add a new NS record" link. There are similar links for MX, A, CNAME, TXT, and SRV records.](/docs/assets/1121-dns9.png)](/docs/assets/1121-dns9.png)
 
 2.  The page is divided into different sections for each type of DNS record. Locate the section for the type of DNS record you want to add, and then click the **Add new [DNS] record** link.
 
-	{{< note >}}
+    {{< note >}}
 The exact form fields will vary depending on the type of DNS record you select.
 {{< /note >}}
 
     ![This page allows you to create a new A/AAAA record.](/docs/assets/1122-dns10.png)
 
 3.  Enter a hostname in the **Hostname** field.
-4.  Enter the IP address of your server in the **IP Address** field. For instructions, see [Finding the IP Address](/docs/getting-started#find-the-ip-address-of-your-linode).
+4.  Enter the IP address of your server in the **IP Address** field. For instructions, see [Finding the IP Address](/docs/getting-started/#find-the-ip-address-of-your-linode).
 5.  From the **TTL** menu, select a time interval. *TTL*, which stands for "time to live," controls how long DNS records are cached by DNS resolvers before the resolver must query the authoritative name servers for new records.
 6.  Click **Save Changes**.
 
@@ -154,12 +154,12 @@ Here's how to import a zone file:
 
 1.  Select **Import a zone**, from the DNS Manager tab.
 
-	[![This page lets you import a domain zone.](/docs/assets/1658-axfr_sm.png)](/docs/assets/1659-axfr.png)
+    [![This page lets you import a domain zone.](/docs/assets/1658-axfr_sm.png)](/docs/assets/1659-axfr.png)
 
 2.  Enter the domain name in the **Domain** field, as shown in the example above.
 3.  Enter the name server in the **Remote Nameserver** field.
 
-	{{< note >}}
+    {{< note >}}
 The name server must allow zone transfers (AXFR) from: 96.126.114.97, 96.126.114.98, 2600:3c00::5e, and 2600:3c00::5f
 {{< /note >}}
 
@@ -235,7 +235,7 @@ Having problems with your DNS records? We recommend reviewing this section to he
 
 If you've just made a DNS change and aren't seeing it reflected yet, try waiting 48 hours. DNS updates will take effect, or *propagate*, within the time period set by your zone file's [TTL](#set-the-time-to-live-or-ttl). In some cases the new information may not be reflected for up to 48 hours.
 
-While you can't control DNS caching at every point on the Internet, you do have control over your web browser. Try holding down the *Shift* key or the *Control* key (depending on your browser) while you refresh the page to bypass your browser's cache of the old DNS data. You can also try bringing up your site in an alternate browser, or [Previewing Your Website Without DNS](/docs/networking/dns/previewing-websites-without-dns).
+While you can't control DNS caching at every point on the Internet, you do have control over your web browser. Try holding down the *Shift* key or the *Control* key (depending on your browser) while you refresh the page to bypass your browser's cache of the old DNS data. You can also try bringing up your site in an alternate browser, or [Previewing Your Website Without DNS](/docs/networking/dns/previewing-websites-without-dns/).
 
 ### Set the Time To Live or TTL
 
@@ -282,4 +282,4 @@ If you're on a Windows machine, or you're more comfortable using a web-based too
 
 ## Next Steps
 
-Now that you are familiar with Linode's DNS Manager, you should set up your [reverse DNS configuration](/docs/networking/dns/setting-reverse-dns), and consider looking at our [Common DNS Configurations](/docs/networking/dns/common-dns-configurations) guide.
+Now that you are familiar with Linode's DNS Manager, you should set up your [reverse DNS configuration](/docs/networking/dns/configure-your-linode-for-reverse-dns/), and consider looking at our [Common DNS Configurations](/docs/networking/dns/common-dns-configurations/) guide.

--- a/docs/networking/squid/squid-http-proxy-ubuntu-12-04.md
+++ b/docs/networking/squid/squid-http-proxy-ubuntu-12-04.md
@@ -20,10 +20,10 @@ external_resources:
 
 ![Creating an HTTP Proxy Using Squid on Ubuntu 12.04](/docs/assets/creating-an-http-proxy-with-squid-on-ubuntu-1204-title-graphic.jpg "Creating an HTTP Proxy Using Squid on Ubuntu 12.04")
 
-Squid is a proxy/cache application with a variety of configurations and uses. This guide will cover using Squid as an HTTP proxy. Please note that unless you follow the last section of the guide [Anonymizing Traffic](#anonymizing-traffic), this will not anonymize your traffic to the outside world, as your originating IP address will still be sent in the X-Forwarded-For header. Additionally, the traffic is not encrypted and will still be visible on your local network. If you are looking for a solution that offers greater security, you may want to look at our guide to [Setting up an SSH Tunnel](/docs/networking/ssh/setting-up-an-ssh-tunnel-with-your-linode-for-safe-browsing) or [Deploy VPN Services with OpenVPN](/docs/networking/vpn/secure-communications-with-openvpn-on-ubuntu-12-04-precise-and-debian-7).
+Squid is a proxy/cache application with a variety of configurations and uses. This guide will cover using Squid as an HTTP proxy. Please note that unless you follow the last section of the guide [Anonymizing Traffic](#anonymizing-traffic), this will not anonymize your traffic to the outside world, as your originating IP address will still be sent in the X-Forwarded-For header. Additionally, the traffic is not encrypted and will still be visible on your local network. If you are looking for a solution that offers greater security, you may want to look at our guide to [Setting up an SSH Tunnel](/docs/networking/ssh/setting-up-an-ssh-tunnel-with-your-linode-for-safe-browsing/) or [Deploy VPN Services with OpenVPN](/docs/networking/vpn/secure-communications-with-openvpn-on-ubuntu-12-04-precise-and-debian-7/).
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Installing Squid
@@ -48,7 +48,7 @@ This section covers the easiest way to use Squid as an HTTP proxy, using only th
 
 1.  Edit the Squid configuration file and add the following lines:
 
-	{{< file-excerpt "/etc/squid3/squid.conf" >}}
+    {{< file-excerpt "/etc/squid3/squid.conf" >}}
 acl client src 12.34.56.78 # Home IP
 http_access allow client
 
@@ -56,7 +56,7 @@ http_access allow client
 {{< /file-excerpt >}}
 
 
-	Be sure to replace **client** with a name identifying the connecting computer and **12.34.56.78** with your local IP address. The comment `# Home IP` isn't required, but comments can be used to help identify clients.
+    Be sure to replace **client** with a name identifying the connecting computer and **12.34.56.78** with your local IP address. The comment `# Home IP` isn't required, but comments can be used to help identify clients.
 
 2.  Once you've saved and exited the file, restart Squid:
 
@@ -82,17 +82,17 @@ The following configuration allows for authenticated access to the Squid proxy s
 
         sudo htpasswd /etc/squid3/squid_passwd user1
 
-	Replace **user1** with a username. You will be prompted to create a password for this user:
+    Replace **user1** with a username. You will be prompted to create a password for this user:
 
-		New password:
-    	Re-type new password:
-    	Adding password for user user1
+        New password:
+        Re-type new password:
+        Adding password for user user1
 
-	You can repeat this step at any time to create new users.
+    You can repeat this step at any time to create new users.
 
 4.  Edit the Squid configuration file and add the following lines:
 
-	{{< file-excerpt "/etc/squid3/squid.conf" >}}
+    {{< file-excerpt "/etc/squid3/squid.conf" >}}
 auth_param basic program /usr/lib/squid3/basic_ncsa_auth /etc/squid3/squid_passwd
 acl ncsa_users proxy_auth REQUIRED
 http_access allow ncsa_users
@@ -108,16 +108,16 @@ http_access allow ncsa_users
 6.  At this point, you can configure your local browser or operating system's network settings to use your Linode as an HTTP proxy. You will need to specify that the server requires authentication, and provide the username and password. How to do this will depend on your choice of OS and browser. Once you've changed the settings, test the connection by pointing your browser at a website that tells you your IP address, such as [ifconfig](http://ifconfig.me), [What is my IP](http://www.whatismyip.com/), or by Googling [What is my ip](https://www.google.com/search?q=what+is+my+ip).
 7.  To remove a user's access to the proxy, you must delete the entry in the `squid_passwd` file. Each user is represented in the file on a single line in the format of `user:passwordhash`:
 
-	{{< file "/etc/squid3/squid_passwd" >}}
+    {{< file "/etc/squid3/squid_passwd" >}}
 user1:\$p948w3nvq3489v6npq396g user2:\$q3cn478554387cq34n57vn
 
 
 {{< /file >}}
 
 
-	If you are using Nano, the command `Control+k` will remove the entire line where the cursor rests. Once you've saved and exited the file, restart Squid:
+    If you are using Nano, the command `Control+k` will remove the entire line where the cursor rests. Once you've saved and exited the file, restart Squid:
 
-		sudo service squid3 restart
+        sudo service squid3 restart
 
 ## Anonymizing Traffic
 

--- a/docs/networking/using-the-linode-graphical-shell-glish.md
+++ b/docs/networking/using-the-linode-graphical-shell-glish.md
@@ -13,10 +13,10 @@ published: 2015-08-28
 title: 'Using the Linode Graphical Shell (Glish)'
 ---
 
-Glish is the graphical version of the [Linode Shell](/docs/networking/using-the-linode-shell-lish) (Lish). It allows you to use a graphic environment running natively on your Linode's operating system.
+Glish is the graphical version of the [Linode Shell](/docs/networking/using-the-linode-shell-lish/) (Lish). It allows you to use a graphic environment running natively on your Linode's operating system.
 
 {{< note >}}
-Linode base distribution images do not have graphic environments installed. You will need to install one, or use a [Custom Distro](/docs/tools-reference/custom-kernels-distros/custom-distro-on-kvm-linode) with a graphic environment pre-installed.
+Linode base distribution images do not have graphic environments installed. You will need to install one, or use a [Custom Distro](/docs/tools-reference/custom-kernels-distros/custom-distro-on-kvm-linode/) with a graphic environment pre-installed.
 
 Glish is only available on KVM Linodes.
 {{< /note >}}

--- a/docs/networking/vpn/vpn-firewall-killswitch-for-linux-and-macos-clients.md
+++ b/docs/networking/vpn/vpn-firewall-killswitch-for-linux-and-macos-clients.md
@@ -24,11 +24,11 @@ For this reason, VPN clients often use firewall rules to ensure that internet tr
 
 This guide assumes that you already have an OpenVPN server running on your Linode, and have at least one client configured to connect to it. If you need help doing this, see our three-part series on setting up an OpenVPN environment:
 
-1.  [Set Up a Hardened OpenVPN Server with Debian](/docs/networking/vpn/set-up-a-hardened-openvpn-server)
+1.  [Set Up a Hardened OpenVPN Server with Debian](/docs/networking/vpn/set-up-a-hardened-openvpn-server/)
 
-2.  [Tunnel Your Internet Traffic Through an OpenVPN Server](/docs/assets/tunnel-traffic-through-openvpn.png)
+2.  [Tunnel Your Internet Traffic Through an OpenVPN Server](/docs/networking/vpn/tunnel-your-internet-traffic-through-an-openvpn-server/)
 
-3.  [Configuring OpenVPN Client Devices](/docs/networking/vpn/configuring-openvpn-client-devices)
+3.  [Configuring OpenVPN Client Devices](/docs/networking/vpn/configuring-openvpn-client-devices/)
 
 
 ## Gather Client Device Information
@@ -103,7 +103,7 @@ iptables -A OUTPUT -j ACCEPT -o tun0
 
 This ruleset replaces the pre-exiting iptables rules and instructs the firewall to drop every outgoing connection other than loopback traffic, the local network's subnet and UDP traffic to and from your OpenVPN server's IP on port 1194. In addition, all incoming and outgoing connections are allowed over the virtual network interface `tun0`.
 
-Your VPN firewall is now active, but this ruleset is only temporary and will be cleared when you reboot your Linode. To make the firewall permanent, you can install the `iptables-persistent` package for Debian or Ubuntu-based distributions, or you can see our [iptables](/docs/security/firewalls/control-network-traffic-with-iptables#deploy-your-iptables-rulesets) or [Firewalld](/docs/security/firewalls/introduction-to-firewalld-on-centos#constructing-a-ruleset-with-firewalld) guides to create permanent rulesets and/or profiles.
+Your VPN firewall is now active, but this ruleset is only temporary and will be cleared when you reboot your Linode. To make the firewall permanent, you can install the `iptables-persistent` package for Debian or Ubuntu-based distributions, or you can see our [iptables](/docs/security/firewalls/control-network-traffic-with-iptables/#deploy-your-iptables-rulesets) or [Firewalld](/docs/security/firewalls/introduction-to-firewalld-on-centos/#constructing-a-ruleset-with-firewalld) guides to create permanent rulesets and/or profiles.
 
 ### VPN Firewall using ufw
 

--- a/docs/platform/disk-images/disk-images-and-configuration-profiles.md
+++ b/docs/platform/disk-images/disk-images-and-configuration-profiles.md
@@ -127,7 +127,7 @@ You can delete a disk to remove it from your Linode and reallocate its storage s
 4.  Click **Shut down** to turn your Linode off. Watch the *Host Job Queue* for confirmation that the Linode has shut down.
 5.  Select the **Remove** link next to the Linode you want to delete, as shown below. The disk will be deleted. Watch the *Host Job Queue* for confirmation that the disk has been duplicated.
 
-	[![Deleting a disk](/docs/assets/987-disk5-1-small.png)](/docs/assets/986-disk5-1.png)
+    [![Deleting a disk](/docs/assets/987-disk5-1-small.png)](/docs/assets/986-disk5-1.png)
 
 6.  Click **Boot** to turn on the Linode.
 
@@ -146,7 +146,7 @@ Making a new configuration profile allows you to create a new and separate boot 
 3.  Select a Linode. The Linode's dashboard appears.
 4.  Select the **Create a new Configuration Profile** link. The *Configuration Profile* webpage appears, as shown below.
 
-	[![Creating a configuration profile](/docs/assets/createconfprofile-small.png)](/docs/assets/createconfprofile.png)
+    [![Creating a configuration profile](/docs/assets/createconfprofile-small.png)](/docs/assets/createconfprofile.png)
 
 5.  Enter a descriptive name for the configuration profile in the **Label** field. This name appears on the dashboard and will help you differentiate it from other configuration profiles.
 6.  You can enter comments or notes about this configuration profile in the **Notes** field.
@@ -180,7 +180,7 @@ You can create and store many different configuration profiles in the Linode Man
 3.  Select a Linode. The Linode's dashboard appears.
 4.  Click the button to select a configuration profile, as shown below.
 
-	[![Selecting a configuration profile](/docs/assets/993-disk7-1.png)](/docs/assets/993-disk7-1.png)
+    [![Selecting a configuration profile](/docs/assets/993-disk7-1.png)](/docs/assets/993-disk7-1.png)
 
 5.  Click **Reboot** to restart your Linode using the selected configuration profile.
 
@@ -199,14 +199,14 @@ The configuration profile is removed from the dashboard.
 
 ## Cloning Disks and Configuration Profiles
 
-You can *clone* disks and configuration profiles from one Linode to another, as long as both of the Linodes are on your account. This is an easy way to transfer your configuration between Linodes, or migrate your Linode to a different data center. See our guide on [cloning your Linode](/docs/migrate-to-linode/disk-images/clone-your-linode) for more information.
+You can *clone* disks and configuration profiles from one Linode to another, as long as both of the Linodes are on your account. This is an easy way to transfer your configuration between Linodes, or migrate your Linode to a different data center. See our guide on [cloning your Linode](/docs/platform/disk-images/clone-your-linode/) for more information.
 
 ## Potential Uses
 
 If you're wondering how you could use disks and configuration profiles, here are some ideas to get you started:
 
 -   **Duplicate Server Configurations:** It takes time to configure your Linode. Preserve that hard work by [duplicating the disk](#duplicating-a-disk) to preserve all of your settings and applications in their current state. If you decide to create another Linode later, you could [clone a saved disk](#cloning-disks-and-configuration-profiles) to the new Linode in a matter of minutes, saving yourself hours of work.
--   **Automate Server Builds:** If you run a large website that requires multiple servers, or if you just love automating things, you'll want to [automate your server builds](/docs/platform/automating-server-builds). You can rapidly spin up multiple servers with exactly the same configuration by creating a *golden disk* that can be cloned to multiple Linodes.
+-   **Automate Server Builds:** If you run a large website that requires multiple servers, or if you just love automating things, you'll want to [automate your server builds](/docs/platform/automating-server-builds/). You can rapidly spin up multiple servers with exactly the same configuration by creating a *golden disk* that can be cloned to multiple Linodes.
 -   **Experiment with Distributions:** New to Linux? Take different distributions out for a spin by creating a separate disk for each flavor of Linux. Once you find a distribution you like, you can delete all of the disks except the one with your favorite distribution.
 -   **Create a Software Testing Environment:** If you're a developer, you can create different disks for testing purposes. Every disk can hold a different 32- or 64-bit distribution, and every configuration profile can be set to use a different kernel. Even if you're not a developer, this is ideal for testing open source or proprietary software on different distributions.
 

--- a/docs/platform/disk-images/switch-to-a-64-bit-linux-kernel.md
+++ b/docs/platform/disk-images/switch-to-a-64-bit-linux-kernel.md
@@ -53,7 +53,7 @@ For Ubuntu and Debian users, the Apt package management system will continue to 
 
 ### CentOS and Fedora
 
-When switching a 32-bit CentOS or Fedora build to use a 64-bit kernel, you need to configure the distro's package manager (Yum) to explicitly download x86 architecture builds of updates to existing and new packages. If you haven't already, we recommend CentOS users switch to the package mirrors Linode provides. The instructions to switch to Linode's package mirrors are in the [package mirrors](/docs/platform/package-mirrors) guide. Regardless of your decision to use our mirrors, you will want to run this command to ensure that only 32-bit packages are selected:
+When switching a 32-bit CentOS or Fedora build to use a 64-bit kernel, you need to configure the distro's package manager (Yum) to explicitly download x86 architecture builds of updates to existing and new packages. If you haven't already, we recommend CentOS users switch to the package mirrors Linode provides. The instructions to switch to Linode's package mirrors are in the [package mirrors](/docs/platform/package-mirrors/) guide. Regardless of your decision to use our mirrors, you will want to run this command to ensure that only 32-bit packages are selected:
 
     sed -i 's/$basearch/i386/g' /etc/yum.repos.d/*
 

--- a/docs/platform/linode-images.md
+++ b/docs/platform/linode-images.md
@@ -13,7 +13,7 @@ published: 2014-09-25
 title: Linode Images
 ---
 
-![Linode Images](/docs/assets/linode-images/Linode_Images_smg.jpg)
+![Linode Images](/docs/assets/linode-images/linode-images.jpg)
 
 *Linode Images* allows you to take snapshots of your disks, and then deploy them to any Linode under your account. This can be useful for bootstrapping a master image for a large deployment, or retaining a disk for a configuration that you may not need running, but wish to return to in the future. Linode Images will be retained whether or not you have an active Linode on your account, which also makes them useful for long term storage of a private template that you may need in the future. There is no additional charge to store Images for Linode users, with a limit of 2GB per Image and 3 Images per account.
 

--- a/docs/platform/longview/longview-app-for-nginx.md
+++ b/docs/platform/longview/longview-app-for-nginx.md
@@ -19,7 +19,7 @@ Longview for NGINX is a Longview App. The Longview NGINX tab appears in the Lino
 
 Prerequisites:
 
--   Install and start [NGINX](/docs/websites/nginx)
+-   Install and start [NGINX](/docs/web-servers/nginx/)
 -   Install the [Longview client](/docs/platform/longview/longview/#installing-the-client)
 
 ### Debian and Ubuntu Automatic Configuration
@@ -119,7 +119,7 @@ Click the image for a full-size view.
 
 You'll see the current version of NGINX listed on the upper right.
 
-Mouse over a data point to see the exact numbers for that time. You can also zoom in on data points, or view older time periods with Longview Pro. For details, jump to this section in the main article about [navigating the Longview interface](/docs/platform/longview/longview#using-the-interface). The next sections cover the Longview Nginx App in detail.
+Mouse over a data point to see the exact numbers for that time. You can also zoom in on data points, or view older time periods with Longview Pro. For details, jump to this section in the main article about [navigating the Longview interface](/docs/platform/longview/longview/#using-the-interface). The next sections cover the Longview Nginx App in detail.
 
 ### Requests
 
@@ -139,19 +139,19 @@ The **Workers** graph shows all of the NGINX workers at the selected time. The w
 
 ### CPU
 
-The **CPU** graph shows the percentage of your Linode's CPU being used by NGINX at the selected time. If you want to see the total CPU use instead, check the [Overview tab](/docs/platform/longview/longview#overview-tab).
+The **CPU** graph shows the percentage of your Linode's CPU being used by NGINX at the selected time. If you want to see the total CPU use instead, check the [Overview tab](/docs/platform/longview/longview/#overview-tab).
 
 ### Memory
 
-The **Memory** graph shows the amount of RAM being used by NGINX at the selected time. If you want to see your Linode's total memory use instead, check the [Overview tab](/docs/platform/longview/longview#overview-tab).
+The **Memory** graph shows the amount of RAM being used by NGINX at the selected time. If you want to see your Linode's total memory use instead, check the [Overview tab](/docs/platform/longview/longview/#overview-tab).
 
 ### Disk IO
 
-The **Disk IO** graph shows the amount of input to and output from the disk caused by NGINX at the selected time. To see the total IO instead, visit the [Disks tab](/docs/platform/longview/longview#disks-tab).
+The **Disk IO** graph shows the amount of input to and output from the disk caused by NGINX at the selected time. To see the total IO instead, visit the [Disks tab](/docs/platform/longview/longview/#disks-tab).
 
 ### Process Count
 
-The **Process Count** graph shows the total number of processes on your Linode spawned by NGINX at the selected time. If you want to see more details, and how this stacks up against the total number of processes on your Linode, see the [Process Explorer tab](/docs/platform/longview/longview#process-explorer-tab).
+The **Process Count** graph shows the total number of processes on your Linode spawned by NGINX at the selected time. If you want to see more details, and how this stacks up against the total number of processes on your Linode, see the [Process Explorer tab](/docs/platform/longview/longview/#process-explorer-tab).
 
 ## Troubleshooting
 

--- a/docs/quick-answers/linode-platform/enable-backups-on-a-linode.md
+++ b/docs/quick-answers/linode-platform/enable-backups-on-a-linode.md
@@ -12,7 +12,7 @@ published: 2017-05-08
 title: Enable Backups on a Linode
 ---
 
-This QuickAnswer will show you how to enable the [Linode Backup Service](https://www.linode.com/backups) on your Linode. See our full [Backup Service](/docs/platform/linode-backup-service) guide for additional information.
+This QuickAnswer will show you how to enable the [Linode Backup Service](https://www.linode.com/backups) on your Linode. See our full [Backup Service](/docs/platform/linode-backup-service/) guide for additional information.
 
 1.  Log in to the [Linode Manager](https://manager.linode.com).
 2.  From the **Linodes** tab, select the Linode you want to back up.

--- a/docs/quick-answers/linode-platform/reset-the-root-password-on-your-linode.md
+++ b/docs/quick-answers/linode-platform/reset-the-root-password-on-your-linode.md
@@ -12,7 +12,7 @@ published: 2017-05-08
 title: Reset the Root Password on your Linode
 ---
 
-This QuickAnswer will show you how to reset the root password for the Linux distribution running on your Linode. See our [Accounts and Passwords](/docs/platform/accounts-and-passwords#resetting-the-root-password) guide for additional information.
+This QuickAnswer will show you how to reset the root password for the Linux distribution running on your Linode. See our [Accounts and Passwords](/docs/platform/accounts-and-passwords/#resetting-the-root-password) guide for additional information.
 
 1.  Click the **Linodes** tab in the Linode Manager.
 2.  Select a Linode to pull up its Dashboard.

--- a/docs/quick-answers/linode-platform/resize-a-linode-disk.md
+++ b/docs/quick-answers/linode-platform/resize-a-linode-disk.md
@@ -12,7 +12,7 @@ published: 2017-05-08
 title: Resize a Linode Disk
 ---
 
-This QuickAnswer will show you how to resize a disk on your Linode. See our [Disks and Configuration Profiles](/docs/platform/disk-images/disk-images-and-configuration-profiles) guide for additional information.
+This QuickAnswer will show you how to resize a disk on your Linode. See our [Disks and Configuration Profiles](/docs/platform/disk-images/disk-images-and-configuration-profiles/) guide for additional information.
 
 1.  Log in to the [Linode Manager](https://manager.linode.com).
 2.  Click the **Linodes** tab.

--- a/docs/quick-answers/linux/how-to-use-git.md
+++ b/docs/quick-answers/linux/how-to-use-git.md
@@ -17,7 +17,7 @@ external_resources:
 - '[Github Guides](https://guides.github.com/)'
 ---
 
-Git is a [version control system](https://en.wikipedia.org/wiki/Version_control) that can be used to manage software projects. This guide's six steps will show you how to initialize a Git repository, stage files for a commit, and commit these files to a local Git repository. For fuller instruction, refer to our more robust guide on [Git Source Control Management](/docs/development/version-control/how-to-install-git-on-mac-and-windows).
+Git is a [version control system](https://en.wikipedia.org/wiki/Version_control) that can be used to manage software projects. This guide's six steps will show you how to initialize a Git repository, stage files for a commit, and commit these files to a local Git repository. For fuller instruction, refer to our more robust guide on [Git Source Control Management](/docs/development/version-control/how-to-install-git-on-mac-and-windows/).
 
 1.  Create a folder in which to store your files, then initialize a Git repository in that folder:
 

--- a/docs/quick-answers/linux/how-to-use-grep.md
+++ b/docs/quick-answers/linux/how-to-use-grep.md
@@ -34,4 +34,4 @@ In this guide, you'll learn how to use the `grep` command. When performing admin
 
     This example will search the `/etc/ssh/sshd_config` file for strings of alphabetic characters that are 16-20 characters long, but you can use any regex pattern you like.
 
-These are simply a few basic ways to use `grep`. Many other options exist, and in combination with other tools, it serves as an invaluable utility for performing administrative tasks on your Linode. For more information on some of `grep`'s advanced features, check out our guide on how to [search and filter text with grep](/docs/tools-reference/search-and-filter-text-with-grep).
+These are simply a few basic ways to use `grep`. Many other options exist, and in combination with other tools, it serves as an invaluable utility for performing administrative tasks on your Linode. For more information on some of `grep`'s advanced features, check out our guide on how to [search and filter text with grep](/docs/tools-reference/tools/how-to-grep-for-text-in-files/).

--- a/docs/quick-answers/linux/log-in-to-coreos-container-linux.md
+++ b/docs/quick-answers/linux/log-in-to-coreos-container-linux.md
@@ -36,5 +36,5 @@ The `root` user is not active by default in Container Linux, so root login is no
 2.  At the `password:` prompt, enter the `core` user's password you assigned when first having deployed Container Linux.
 
 {{< note >}}
-If you are not already familiar with the serial and graphical Linode shells, see the [Using the Linode Shell (/docs/networking/using-the-linode-shell-lish/)](/docs/networking/using-the-linode-shell-lish) and [Use the Graphic Shell, Glish, to Manage Graphic Environments on Your Linode](/docs/networking/use-the-graphic-shell-glish/) guides.
+If you are not already familiar with the serial and graphical Linode shells, see the [Using the Linode Shell](/docs/networking/using-the-linode-shell-lish/) and [Use the Graphic Shell, Glish, to Manage Graphic Environments on Your Linode](/docs/networking/use-the-graphic-shell-glish/) guides.
 {{< /note >}}

--- a/docs/quick-answers/linux/use-nano-to-edit-files-in-linux.md
+++ b/docs/quick-answers/linux/use-nano-to-edit-files-in-linux.md
@@ -19,7 +19,7 @@ external_resources:
 
 GNU nano, or more commonly, nano is the basic, built-in editor for most Linux distributions. In this QuickAnswer, we'll cover some of the essentials to help you get started.
 
-To learn more, visit our full guide on [using nano](/docs/tools-reference/tools/using-nano).
+To learn more, visit our full guide on [using nano](/docs/tools-reference/tools/use-nano-text-editor-commands/).
 
 ## Use nano to Open a System File
 

--- a/docs/security/encryption/full-disk-encryption-xen.md
+++ b/docs/security/encryption/full-disk-encryption-xen.md
@@ -23,7 +23,7 @@ Full disk encryption protects the information stored on your Linode's disks by c
 
 ## Potential Drawbacks
 
-Full disk encryption does a great job of keeping your data secure, but there are a few caveats. To decrypt and mount the disk, you'll need to enter the encryption passphrase in the console every time your Linode boots. And some Linode Manager tools may not work as expected if your disks are encrypted. You'll need to manually resize your filesystem if you want to resize your disk. You'll also need to implement your own backup solution since the [Linode Backup Service](/docs/backup-service) can't mount encrypted disks.
+Full disk encryption does a great job of keeping your data secure, but there are a few caveats. To decrypt and mount the disk, you'll need to enter the encryption passphrase in the console every time your Linode boots. And some Linode Manager tools may not work as expected if your disks are encrypted. You'll need to manually resize your filesystem if you want to resize your disk. You'll also need to implement your own backup solution since the [Linode Backup Service](/docs/platform/linode-backup-service/) can't mount encrypted disks.
 
 ## Getting Started
 
@@ -66,11 +66,11 @@ Now you're ready to enable full disk encryption on your Linode running Debian 7 
 
         cryptsetup luksFormat /dev/xvdc
 
-	{{< caution >}}
+    {{< caution >}}
 If you lose this passphrase your data will be irretrievable!
 {{< /caution >}}
 
-	{{< note >}}
+    {{< note >}}
 You may receive a FATAL notice about loading a kernel module used for hardware crypto acceleration. This message can be safely ignored.
 {{< /note >}}
 
@@ -89,7 +89,7 @@ You may receive a FATAL notice about loading a kernel module used for hardware c
         mkswap /dev/mapper/crypt-swap
         swapon /dev/mapper/crypt-swap
 
-	{{< note >}}
+    {{< note >}}
 Swap will not persist through reboots, so a random key will be used to encrypt swap data.
 {{< /note >}}
 
@@ -196,4 +196,4 @@ You're almost finished! Just a couple more steps and you'll have a Linode with e
         ^a^d
         reboot 1
 
-If everything is configured properly your Linode will boot and prompt you for the encryption passphrase. Enter the passphrase on your console to mount your encrypted disk and boot your Linode. Now you'll want to follow the steps in our [Getting Started](/docs/getting-started) guide.
+If everything is configured properly your Linode will boot and prompt you for the encryption passphrase. Enter the passphrase on your console to mount your encrypted disk and boot your Linode. Now you'll want to follow the steps in our [Getting Started](/docs/getting-started/) guide.

--- a/docs/security/security-patches/disabling-sslv3-for-poodle.md
+++ b/docs/security/security-patches/disabling-sslv3-for-poodle.md
@@ -12,7 +12,7 @@ published: 2014-10-15
 title: Disabling SSLv3 for POODLE
 ---
 
-Padding Oracle On Downgraded Legacy Encryption (POODLE) was released with the CVE identifier of [CVE-2014-3566](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3566). The vulnerability was found in SSL protocol 3.0, unlike [Heartbleed](/docs/security/security-patches/patching-openssl-for-the-heartbleed-vulnerability) which was found in OpenSSL.
+Padding Oracle On Downgraded Legacy Encryption (POODLE) was released with the CVE identifier of [CVE-2014-3566](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3566). The vulnerability was found in SSL protocol 3.0, unlike [Heartbleed](/docs/security/security-patches/patching-openssl-for-the-heartbleed-vulnerability/) which was found in OpenSSL.
 
 SSL protocol 3.0 makes use of CBC-mode ciphers that allow for man-in-the-middle attacks using padding-oracle stacks. These attacks target the CBC ciphers to retrieve plain-text output from otherwise encrypted information.
 
@@ -51,7 +51,7 @@ The POODLE vulnerability only works if the browser of the client and the server'
 
 If you're running an Apache web server that currently allows SSLv3, you will need to edit the Apache configuration. On Debian and Ubuntu systems the file is `/etc/apache2/mods-available/ssl.conf`. On CentOS and Fedora the file is `/etc/httpd/conf.d/ssl.conf`. You will need to add the following line to your Apache configuration with other SSL directives.
 
-	SSLProtocol All -SSLv2 -SSLv3
+    SSLProtocol All -SSLv2 -SSLv3
 
 This will allow all protocols except SSLv2 and SSLv3. You can test your configuration change with the command:
 
@@ -59,7 +59,7 @@ This will allow all protocols except SSLv2 and SSLv3. You can test your configur
 
  You will then need to restart your Apache instance. On Ubuntu and Debian:
 
-	sudo service apache2 restart
+    sudo service apache2 restart
 
 On CentOS and Fedora:
 
@@ -77,7 +77,7 @@ In order to change the Apache cipher suites, follow these steps:
 
 2.  The first option is `SSL Cipher Suite`, and you will need to modify the current SSL Cipher Suite to include `-SSLv3`. An example of this is shown below.
 
-	ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-SSLv3:-EXP:!kEDH
+        ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-SSLv3:-EXP:!kEDH
 
 3.  After saving the page, you will be asked to rebuild and restart Apache. Your changes should take effect after Apache has been rebuilt and restarted.
 
@@ -85,13 +85,13 @@ In order to change the Apache cipher suites, follow these steps:
 
 If you're running an NGINX web server that currently uses SSLv3, you need to edit the NGINX configuration (`nginx.conf`). You will need to add the following line to your `server` directive:
 
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
 This will deactivate SSLv3 from being used on NGINX. If you're unable to find the server directive in `nginx.conf`, you may need to locate your VirtualHost configuration file.
 
 You will also need to restart your NGINX server:
 
-	sudo service nginx restart
+    sudo service nginx restart
 
 For more information about NGINX's SSL protocol setting, please see their [NGX HTTP SSL Module Documentation](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols).
 
@@ -99,12 +99,12 @@ For more information about NGINX's SSL protocol setting, please see their [NGX H
 
 If you're using the security-focused [Hiawatha web server](https://www.hiawatha-webserver.org/), it's likely that SSLv3 is already disabled by default. But if for some reason you're running an older version that does allow SSLv3, you can use the `MinSSLversion` setting in `hiawatha.conf`:
 
-	MinSSLversion = TLS1.0
-	# or TLS1.1 or TLS1.2
+    MinSSLversion = TLS1.0
+    # or TLS1.1 or TLS1.2
 
 Then restart Hiawatha. For example, in Debian or Ubuntu:
 
-	sudo service hiawatha restart
+    sudo service hiawatha restart
 
 For more information on Hiawatha's configuration settings, see the [manual page](https://www.hiawatha-webserver.org/manpages).
 
@@ -112,11 +112,11 @@ For more information on Hiawatha's configuration settings, see the [manual page]
 
 If your Postfix installation is set up for `opportunistic SSL`, which means that encryption is not enforced and plain text is accepted, you do not need to change anything. However, if you are running Postfix in `mandatory SSL` mode, you will need to adjust your configuration to reflect the following change:
 
-	smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
+    smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
 
 You'll want to look in the `# TLS parameters` section of `/etc/postfix/main.cf`. This will force Postfix SMTP to not use SSLv3 or SSLv2. You will also need to restart Postfix:
 
-	sudo service postfix restart
+    sudo service postfix restart
 
 For more information about Postfix's `smtpd_tls_mandatory_protocols` setting, please see their [Postfix Configuration Parameters](http://www.postfix.org/postconf.5.html#smtpd_tls_mandatory_protocols) documentation.
 
@@ -128,11 +128,11 @@ The Postfix documentation has not yet been adjusted to disallow SSLv3.
 
 This will only work in Dovecot versions 2.1 and above. Add the following line to `/etc/dovecot/local.conf` or a new file in `/etc/dovecot/conf.d/10-ssl.conf`:
 
-	ssl_protocols = !SSLv2 !SSLv3
+    ssl_protocols = !SSLv2 !SSLv3
 
 Then restart Dovecot:
 
-	sudo service dovecot restart
+    sudo service dovecot restart
 
 If you are running a version of Dovecot before 2.1, you will need to edit the source code of Dovecot.
 
@@ -142,7 +142,7 @@ In order to disable SSLv3 in HAProxy, you must be using HAProxy 1.5+, as SSL is 
 
 An example of this line would be:
 
-	bind :443 ssl crt <crt> ciphers <ciphers> no-sslv3
+    bind :443 ssl crt <crt> ciphers <ciphers> no-sslv3
 
 You can learn more about HAProxy's `no-sslv3` cipher in their [HAProxy Configuration Manual](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.1-no-sslv3).
 

--- a/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub.md
+++ b/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub.md
@@ -15,14 +15,14 @@ deprecated: true
 ---
 
 {{< caution >}}
-This guide is for legacy Xen Linodes. For newer Linodes, consult our guide on how to [Run a Distribution-Supplied Kernel](/docs/tools-reference/custom-kernels-distros/run-a-distribution-supplied-kernel).
+This guide is for legacy Xen Linodes. For newer Linodes, consult our guide on how to [Run a Distribution-Supplied Kernel](/docs/tools-reference/custom-kernels-distros/run-a-distribution-supplied-kernel/).
 {{< /caution >}}
 
 PV-GRUB makes it possible to run your own kernel on your Linode, instead of using a host-supplied kernel. This is useful in cases where you'd like to enable specific kernel features, or you'd prefer to handle kernel upgrades directly.
 
 If you'd like to run a custom distro on your Linode in combination with PV-GRUB, please follow our [Custom Distro](/docs/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/) guide before taking these steps.
 
-Before you get started, make sure you follow the steps outlined in our [Getting Started](/docs/getting-started) guide. Your Linode needs to be in a functional state. These steps should be performed as `root` on your Linode, via an SSH session.
+Before you get started, make sure you follow the steps outlined in our [Getting Started](/docs/getting-started/) guide. Your Linode needs to be in a functional state. These steps should be performed as `root` on your Linode, via an SSH session.
 
 ## Ubuntu 13.04 (Raring)
 

--- a/docs/uptime/monitoring/monitoring-servers-with-zabbix.md
+++ b/docs/uptime/monitoring/monitoring-servers-with-zabbix.md
@@ -78,7 +78,7 @@ You have successfully added the `zabbix` user.
 
 You'll first want to install MySQL on your Linode and create a MySQL user for Zabbix. Here's how:
 
-1.  If you haven't already, install and configure MySQL on your Linode. See the [MySQL reference manuals](/docs/databases/mysql) for more information.
+1.  If you haven't already, install and configure MySQL on your Linode. See the [MySQL reference manuals](/docs/databases/mysql/) for more information.
 2.  Log in to MySQL by entering the following command:
 
         mysql -uroot -p
@@ -114,7 +114,7 @@ Zabbix requires Apache and PHP to be installed. Here's how to install them:
 
         sudo apt-get install libmysqlclient-dev libcurl3-gnutls libcurl3-gnutls-dev
 
-4.  Verify that you have configured a name-based virtual host for Apache. This is required for the Zabbix web interface. For instructions, see [Configuring Name-based Virtual Hosts](/docs/websites/hosting-a-website#configure-name-based-virtual-hosts).
+4.  Verify that you have configured a name-based virtual host for Apache. This is required for the Zabbix web interface. For instructions, see [Configuring Name-based Virtual Hosts](/docs/websites/hosting-a-website/#configure-name-based-virtual-hosts).
 
 The required applications, modules, and libraries have been installed on your Linode.
 
@@ -405,32 +405,32 @@ You'll need to complete the installation of the Zabbix web interface with your w
 1.  Open up a browser and point it to <http://YourLinodeIP/zabbix> to continue with the installation, where `YourLinodeIP` is the IP address of your Linode.
 2.  The introduction page appears, as shown below. Click **Next** to continue.
 
-[![Zabbix installer.](/docs/assets/1086-new_zabbix_1.png)](/docs/assets/1086-new_zabbix_1.png)
+    [![Zabbix installer.](/docs/assets/1086-new_zabbix_1.png)](/docs/assets/1086-new_zabbix_1.png)
 
 3.  Correct any prerequisite errors, as shown below. Click **Next** to continue.
 
-[![Zabbix installer.](/docs/assets/1087-new_zabbix_2.png)](/docs/assets/1087-new_zabbix_2.png)
+    [![Zabbix installer.](/docs/assets/1087-new_zabbix_2.png)](/docs/assets/1087-new_zabbix_2.png)
 
 4.  Configure the connection to your Zabbix database, as shown below. After you've entered the information for the MySQL database, click **Next** to continue.
 
-[![Zabbix installer.](/docs/assets/1088-new_zabbix_3.png)](/docs/assets/1088-new_zabbix_3.png)
+    [![Zabbix installer.](/docs/assets/1088-new_zabbix_3.png)](/docs/assets/1088-new_zabbix_3.png)
 
 5.  Enter the details for your Zabbix server, as shown below. Click **Next** to continue.
 
-[![Zabbix installer.](/docs/assets/1090-new_zabbix_5.png)](/docs/assets/1090-new_zabbix_5.png)
+    [![Zabbix installer.](/docs/assets/1090-new_zabbix_5.png)](/docs/assets/1090-new_zabbix_5.png)
 
 6.  Check your pre-install summary, as shown below. Click **Next** to continue.
 
-[![Zabbix installer.](/docs/assets/1091-new_zabbix_6.png)](/docs/assets/1091-new_zabbix_6.png)
+    [![Zabbix installer.](/docs/assets/1091-new_zabbix_6.png)](/docs/assets/1091-new_zabbix_6.png)
 
 7.  Download your Zabbix configuration file, as shown below. Click **Next** to continue.
 
-[![Zabbix installer.](/docs/assets/1092-new_zabbix_7.png)](/docs/assets/1092-new_zabbix_7.png)
+    [![Zabbix installer.](/docs/assets/1092-new_zabbix_7.png)](/docs/assets/1092-new_zabbix_7.png)
 
 8.  Once you've updated your Zabbix configuration file to the specified location, click **Retry**.
 9.  If the configuration file is found, click **Finish**.
 
-[![Zabbix installer.](/docs/assets/1093-new_zabbix_8.png)](/docs/assets/1093-new_zabbix_8.png)
+    [![Zabbix installer.](/docs/assets/1093-new_zabbix_8.png)](/docs/assets/1093-new_zabbix_8.png)
 
 After you've finished the front-end installation, you'll be forwarded to the Zabbix login page. The default username is `Admin`, the default password is `zabbix`.
 
@@ -444,7 +444,7 @@ Now you have the Zabbix server and web admin installed, and you just set up the 
 
 2.  Click the **Configuration** tab, then the **Hosts** menu item, then the **Create Host** button. The screen shown below appears.
 
-[![Zabbix add host screen.](/docs/assets/1073-zabbix-9-small.png)](/docs/assets/859-AddHost.png)
+    [![Zabbix add host screen.](/docs/assets/1073-zabbix-9-small.png)](/docs/assets/859-AddHost.png)
 
 3.  Enter a name for the host in the **Name** field. This will be displayed on your server list.
 4.  Add the IP address of your monitored host to the **IP Address** field.
@@ -462,7 +462,7 @@ If you would like the base graphs for your new monitored host, you can copy thos
 2.  Select the graphs you'd like to copy over and click **Go** button.
 3.  On the next screen, you'll be able to select where to copy those graphs, whether to a Host Group or just a single Host, as shown below.
 
-[![Zabbix copy graphs screen.](/docs/assets/860-CopyGraphs.png)](/docs/assets/860-CopyGraphs.png)
+    [![Zabbix copy graphs screen.](/docs/assets/860-CopyGraphs.png)](/docs/assets/860-CopyGraphs.png)
 
 Note that the [Zabbix manual](http://www.zabbix.com/documentation/2.0) has complete documentation on setting up the various actions and operations Zabbix can perform.
 

--- a/docs/web-servers/apache/apache-2-web-server-on-debian-6-squeeze.md
+++ b/docs/web-servers/apache/apache-2-web-server-on-debian-6-squeeze.md
@@ -18,12 +18,12 @@ title: 'Apache 2 Web Server on Debian 6 (Squeeze)'
 
 This tutorial explains how to install and configure the Apache web server on Debian 6 (Squeeze).
 
-Note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Debian 6](/docs/lamp-guides/debian-6-squeeze).
+Note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Debian 6](/docs/web-servers/lamp/lamp-server-on-debian-6-squeeze/).
 
 # Before You Begin
 
 -   Make sure you've followed the [Getting Started](/docs/getting-started/) guide.
--   As part of the Getting Started guide, make sure you [set the hostname](/docs/web-servers/apache/apache-2-web-server-on-debian-6-squeeze) for your server.
+-   As part of the Getting Started guide, make sure you [set the hostname](/docs/getting-started/#setting-the-hostname) for your server.
 
 Issue the following commands to make sure your hostname is set properly:
 
@@ -211,7 +211,7 @@ Later files take precedence over earlier ones. Within a directory, files are rea
 
 Apache will follow symbolic links to read configuration files, so it's possible to put files in other locations as well.
 
-Generally, as specified in our [LAMP Guide for Debian 6 (Squeeze)](/docs/lamp-guides/debian-6-squeeze) and elsewhere, you should create configuration files for your virtual hosts in the `/etc/apache2/sites-available/` directory, then use the `a2ensite` tool to symbolically link to files in the `sites-enabled/` directory. This allows for a clear and specific per-site configuration.
+Generally, as specified in our [LAMP Guide for Debian 6 (Squeeze)](/docs/web-servers/lamp/lamp-server-on-debian-6-squeeze/) and elsewhere, you should create configuration files for your virtual hosts in the `/etc/apache2/sites-available/` directory, then use the `a2ensite` tool to symbolically link to files in the `sites-enabled/` directory. This allows for a clear and specific per-site configuration.
 
 We recommend that you *not* modify these files:
 

--- a/docs/web-servers/apache/apache-2-web-server-on-fedora-12.md
+++ b/docs/web-servers/apache/apache-2-web-server-on-fedora-12.md
@@ -16,7 +16,7 @@ title: Apache 2 Web Server on Fedora 12
 
 
 
-This tutorial explains how to install and configure the Apache web server on Fedora 12. All configuration will be done through the terminal; make sure you are logged in as root via SSH. If you have not followed the [getting started](/docs/getting-started/) guide, it is recommended that you do so prior to beginning this guide. Also note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Fedora 12](/docs/lamp-guides/fedora-12).
+This tutorial explains how to install and configure the Apache web server on Fedora 12. All configuration will be done through the terminal; make sure you are logged in as root via SSH. If you have not followed the [getting started](/docs/getting-started/) guide, it is recommended that you do so prior to beginning this guide. Also note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Fedora 12](/docs/web-servers/lamp/lamp-server-on-fedora-12/).
 
 # Install Apache HTTP Server
 

--- a/docs/web-servers/apache/apache-2-web-server-on-fedora-13.md
+++ b/docs/web-servers/apache/apache-2-web-server-on-fedora-13.md
@@ -16,7 +16,7 @@ title: Apache 2 Web Server on Fedora 13
 
 
 
-This tutorial explains how to install and configure the Apache web server on Fedora 13. All configuration will be done through the terminal; make sure you are logged in as root via SSH. If you have not followed the [getting started](/docs/getting-started/) guide, it is recommended that you do so prior to beginning this guide. Also note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Fedora 13](/docs/lamp-guides/fedora-13).
+This tutorial explains how to install and configure the Apache web server on Fedora 13. All configuration will be done through the terminal; make sure you are logged in as root via SSH. If you have not followed the [getting started](/docs/getting-started/) guide, it is recommended that you do so prior to beginning this guide. Also note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Fedora 13](/docs/web-servers/lamp/lamp-server-on-fedora-13/).
 
 # Install Apache HTTP Server
 

--- a/docs/web-servers/apache/apache-2-web-server-on-ubuntu-10-10-maverick.md
+++ b/docs/web-servers/apache/apache-2-web-server-on-ubuntu-10-10-maverick.md
@@ -16,11 +16,11 @@ title: 'Apache 2 Web Server on Ubuntu 10.10 (Maverick)'
 
 
 
-This tutorial explains how to install and configure the Apache web server on Ubuntu 10.10 (Maverick). All configuration will be done through the terminal; make sure you are logged in as root via SSH. If you have not followed the [getting started](/docs/getting-started/) guide, it is recommended that you do so prior to beginning this guide. Also note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Ubuntu 10.10](/docs/lamp-guides/ubuntu-10-10-maverick).
+This tutorial explains how to install and configure the Apache web server on Ubuntu 10.10 (Maverick). All configuration will be done through the terminal; make sure you are logged in as root via SSH. If you have not followed the [getting started](/docs/getting-started/) guide, it is recommended that you do so prior to beginning this guide. Also note that if you're looking to install a full LAMP stack, you may want to consider using our [LAMP guide for Ubuntu 10.10](/docs/web-servers/lamp/lamp-server-on-ubuntu-10-10-maverick/).
 
 # Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f

--- a/docs/web-servers/apache/apache-access-control.md
+++ b/docs/web-servers/apache/apache-access-control.md
@@ -13,7 +13,7 @@ published: 2009-12-07
 title: 'Apache Access Control'
 external_resources:
  - '[Installation of the Apache web server](/docs/web-servers/apache/)'
- - '[LAMP stack guides](/docs/lamp-guides/)'
+ - '[LAMP stack guides](/docs/web-servers/lamp/)'
  - '[Authentication and Access Control](http://httpd.apache.org/docs/2.2/howto/auth.html)'
  - '[Basic Authentication Module](http://httpd.apache.org/docs/2.2/mod/mod_auth_basic.html)'
 ---
@@ -24,18 +24,18 @@ This guide provides an overview of both credential-based and rule-based access c
 
 ## Before You Begin
 
-1.  Ensure that you have followed the [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/security/securing-your-server) guides, and the Linode’s hostname is set.
+1.  Ensure that you have followed the [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/security/securing-your-server/) guides, and the Linode’s hostname is set.
 
-2.  Have a working installation of Apache. If you have not installed Apache, you might want to follow one of our [Apache installation guides](/docs/websites/apache/) or [LAMP stack installation guides](/docs/websites/lamp).
+2.  Have a working installation of Apache. If you have not installed Apache, you might want to follow one of our [Apache installation guides](/docs/web-servers/apache/) or [LAMP stack installation guides](/docs/web-servers/lamp/).
 
 3.  Update your system:
 
         sudo apt-get update && sudo apt-get upgrade
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 
-This guide uses the same example file paths as our [Apache on Debian 8](/docs/websites/apache/apache-web-server-debian-8) guide. Be sure to adjust for your distribution.
+This guide uses the same example file paths as our [Apache on Debian 8](/docs/web-servers/apache/apache-web-server-debian-8/) guide. Be sure to adjust for your distribution.
 {{< /note >}}
 
 ## Apache Access Control

--- a/docs/web-servers/apache/run-php-cgi-apache-centos-6.md
+++ b/docs/web-servers/apache/run-php-cgi-apache-centos-6.md
@@ -20,12 +20,12 @@ external_resources:
 In instances where running the `mod_php` module to run PHP scripts on Apache is not sufficient, PHP can be run as a CGI binary. Combined with the `itk` multi-processing module (MPM), PHP scripts can be run as user processes in a per-virtual host setup. This guide will walk users through the process of setting up Apache and PHP CGI.
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Before You Begin
 
-1.  Ensure that you have followed the [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/security/securing-your-server) guides, and the Linode's [hostname is set](/docs/getting-started#setting-the-hostname).
+1.  Ensure that you have followed the [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/security/securing-your-server/) guides, and the Linode's [hostname is set](/docs/getting-started/#setting-the-hostname).
 
     To check your hostname run:
 
@@ -59,7 +59,7 @@ This guide is written for a non-root user. Commands that require elevated privil
 
 ### Configure Apache for PHP CGI
 
-The directives required to enable PHP CGI may be set anywhere in Apache's [configuration tree](/docs/web-servers/apache/configuration/configuration-basics). We recommend creating the `php-cgi.conf` file in Apache's `conf.d/` directory and setting these variables there. For CentOS systems, this is located at `/etc/httpd/conf.d/`. Regardless of their location, the relevant settings are:
+The directives required to enable PHP CGI may be set anywhere in Apache's [configuration tree](/docs/web-servers/apache-tips-and-tricks/apache-configuration-basics/). We recommend creating the `php-cgi.conf` file in Apache's `conf.d/` directory and setting these variables there. For CentOS systems, this is located at `/etc/httpd/conf.d/`. Regardless of their location, the relevant settings are:
 
 {{< file-excerpt "Apache Configuration Block" apache >}}
 ScriptAlias /local-bin /usr/bin

--- a/docs/web-servers/apache/run-php-cgi-apache-ubuntu-12-04.md
+++ b/docs/web-servers/apache/run-php-cgi-apache-ubuntu-12-04.md
@@ -20,12 +20,12 @@ external_resources:
 In instances where running the `mod_php` module to run PHP scripts on Apache is not sufficient, PHP can be run as a CGI binary. Combined with the `itk` multi-processing module (MPM), PHP scripts can be run as user processes in a per-virtual host setup. This guide will walk users through the process of setting up Apache and PHP CGI.
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Before You Begin
 
-1.  Ensure that you have followed the [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/security/securing-your-server) guides, and the Linode's [hostname is set](/docs/getting-started#setting-the-hostname).
+1.  Ensure that you have followed the [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/security/securing-your-server/) guides, and the Linode's [hostname is set](/docs/getting-started/#setting-the-hostname).
 
     To check your hostname, run:
 
@@ -44,7 +44,7 @@ This guide is written for a non-root user. Commands that require elevated privil
 
         sudo apt-get install apache2
 
-    You can now [configure virtual hosting](/docs/web-servers/apache/apache-web-server-ubuntu-12-04#configure-virtual-hosting) in accordance with the needs of your server.
+    You can now [configure virtual hosting](/docs/web-servers/apache/apache-web-server-ubuntu-12-04/#configure-virtual-hosting) in accordance with the needs of your server.
 
 2.  Install the PHP CGI binaries:
 
@@ -58,7 +58,7 @@ In order to set up Apache to use PHP-CGI on Ubuntu systems, you must enable the 
 
     sudo a2enmod actions
 
-The required directives can be set anywhere in Apache's [configuration tree](/docs/web-servers/apache/configuration/configuration-basics). We recommend creating the `php-cgi.conf` file in Apache's `conf.d/` directory and setting these variables there. For Ubuntu systems, this is located at `/etc/apache2/conf.d/`. You may also choose to place these settings in your `/etc/apache2/httpd.conf` file. Regardless of their location, the relevant settings are:
+The required directives can be set anywhere in Apache's [configuration tree](/docs/web-servers/apache-tips-and-tricks/apache-configuration-basics/). We recommend creating the `php-cgi.conf` file in Apache's `conf.d/` directory and setting these variables there. For Ubuntu systems, this is located at `/etc/apache2/conf.d/`. You may also choose to place these settings in your `/etc/apache2/httpd.conf` file. Regardless of their location, the relevant settings are:
 
 {{< file-excerpt "Apache Configuration Block" apache >}}
 ScriptAlias /local-bin /usr/bin
@@ -114,4 +114,4 @@ This may not be ideal if you have multiple users running publicly accessible scr
 {{< /file-excerpt >}}
 
 
-In this example, `webeditor` is the name of the user of the specific site in question, and `webgroup` is the name of the user group that "owns" the web server related files and processes for this host. Remember that you must create the user accounts and groups using the `useradd` command. Consider our documentation of [user groups and permissions](/docs/tools-reference/linux-users-and-groups) for more information about creating the necessary users and groups.
+In this example, `webeditor` is the name of the user of the specific site in question, and `webgroup` is the name of the user group that "owns" the web server related files and processes for this host. Remember that you must create the user accounts and groups using the `useradd` command. Consider our documentation of [user groups and permissions](/docs/tools-reference/linux-users-and-groups/) for more information about creating the necessary users and groups.

--- a/docs/web-servers/cherokee/use-cherokee-web-server-on-ubuntu-12-04.md
+++ b/docs/web-servers/cherokee/use-cherokee-web-server-on-ubuntu-12-04.md
@@ -14,7 +14,7 @@ published: 2012-10-10
 title: 'Use Cherokee Web Server on Ubuntu 12.04'
 external_resources:
  - '[Cherokee Web Server Documentation](http://www.cherokee-project.com/doc/)'
- - '[Host Web Apps with Cherokee and PHP-FastCGI on Ubuntu 10.04 LTS (Lucid)](/docs/web-servers/cherokee/php-fastcgi-ubuntu-10-04-lucid)'
+ - '[Host Web Apps with Cherokee and PHP-FastCGI on Ubuntu 10.04 LTS (Lucid)](/docs/web-servers/cherokee/web-apps-with-cherokee-and-phpfastcgi-on-ubuntu-10-04-lts-lucid/)'
 ---
 
 Cherokee is a fast, flexible web server for POSIX-compliant operating systems such as Linux. It's designed to be easy to administer, and includes support for a wide range of common web server functions.
@@ -25,7 +25,7 @@ This document assumes that you already have a working and up to date Ubuntu 12.0
 
 ## Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f

--- a/docs/web-servers/lamp/lamp-server-on-debian-6-squeeze.md
+++ b/docs/web-servers/lamp/lamp-server-on-debian-6-squeeze.md
@@ -25,7 +25,7 @@ This guide provides step-by-step instructions for installing a full-featured LAM
 
 ## Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f

--- a/docs/web-servers/lemp/lemp-server-on-debian-6-squeeze.md
+++ b/docs/web-servers/lemp/lemp-server-on-debian-6-squeeze.md
@@ -16,11 +16,11 @@ title: 'LEMP Server on Debian 6 (Squeeze)'
 
 This document describes a compatible alternative to the "LAMP" (Linux, Apache, MySQL, and PHP) stack, known as "LEMP." The LEMP stack replaces the Apache web server component with nginx (pronounced "engine x", providing the "E" in LEMP) which can increase the ability of the server to scale in response to demand.
 
-Prior to beginning this guide, please complete the [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/docs/using-linux/administration-basics).
+Prior to beginning this guide, please complete the [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/).
 
 # Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f
@@ -40,7 +40,7 @@ There are several viable and popular options for installing the nginx software. 
 
 The final option requires downloading the source for nginx from the upstream provider and compiling the software manually. Manual compilation makes it possible to run the most current version of the software at the expense of the testing and automatic updates from the Debian or the Backports project. All options are compatible, but in most cases we recommend using the packages from the Debian Project or Backports unless your needs require a version newer than the one provided by the Debian packages. Possible reasons for compiling nginx yourself include access to optional compile-time modules and features added in more recent versions.
 
-For more in-depth installation instructions consider our [guide to installing nginx](/docs/web-servers/nginx/installation/debian-6-squeeze).
+For more in-depth installation instructions consider our [guide to installing nginx](/docs/web-servers/nginx/websites-with-nginx-on-debian-6-squeeze/).
 
 ### Deploy from Stable Debian Packages
 
@@ -159,7 +159,7 @@ http {
 }
 {{< /file-excerpt >}}
 
-Then, depending on the size and nature of your deployment, place your virtual host configurations either directly in the `/opt/nginx-sites.conf` file or include statements for server-specific configuration files in the `nginx-sites.file`. For more information regarding nginx configuration options, consider our [overview of nginx configuration](/docs/websites/nginx/basic-nginx-configuration).
+Then, depending on the size and nature of your deployment, place your virtual host configurations either directly in the `/opt/nginx-sites.conf` file or include statements for server-specific configuration files in the `nginx-sites.file`. For more information regarding nginx configuration options, consider our [overview of nginx configuration](/docs/web-servers/nginx/how-to-configure-nginx/).
 
 Once you've configured and loaded the nginx configuration, restart the web server to implement the new configuration by issuing the following command:
 
@@ -169,7 +169,7 @@ Make sure that the directories referenced in your configuration exist on your fi
 
 # Deploy PHP with FastCGI
 
-In order to deploy PHP applications, you will need to implement the following "PHP-FastCGI" solution to allow nginx to properly handle and serve pages that contain PHP code. For a more complete introduction to this subject, consider our dedicated guide to [PHP FastCGI with Nginx](/docs/web-servers/nginx/php-fastcgi/debian-6-squeeze). Begin the deployment process by issuing the following command to install the required dependencies:
+In order to deploy PHP applications, you will need to implement the following "PHP-FastCGI" solution to allow nginx to properly handle and serve pages that contain PHP code. For a more complete introduction to this subject, consider our dedicated guide to [PHP FastCGI with Nginx](/docs/web-servers/nginx/nginx-and-phpfastcgi-on-debian-6-squeeze/). Begin the deployment process by issuing the following command to install the required dependencies:
 
     apt-get install php5-cli php5-cgi build-essential wget psmisc spawn-fcgi
 
@@ -303,8 +303,8 @@ When upstream sources offer new releases, repeat the instructions for installing
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 
-- [Basic nginx Configuration](/docs/websites/nginx/basic-nginx-configuration)
-- [Clustered Web Servers and Software Load Balancing with nginx](/docs/uptime/loadbalancing/how-to-use-nginx-as-a-front-end-proxy-server-and-software-load-balancer)
-- [Deploy CGI and Perl Scripts with Perl-FastCGI and nginx](/docs/web-servers/nginx/perl-fastcgi/debian-6-squeeze)
-- [Use PostgreSQL as an Alternative to MySQL for data storage](/docs/databases/postgresql/debian-6-squeeze)
-- [Deploy Python Applications with uWSGI and nginx](/docs/web-servers/nginx/python-uwsgi/debian-6-squeeze)
+- [Basic nginx Configuration](/docs/web-servers/nginx/how-to-configure-nginx/)
+- [Clustered Web Servers and Software Load Balancing with nginx](/docs/uptime/loadbalancing/use-nginx-as-a-front-end-proxy-and-software-load-balancer/)
+- [Deploy CGI and Perl Scripts with Perl-FastCGI and nginx](/docs/web-servers/nginx/nginx-and-perlfastcgi-on-debian-6-squeeze/)
+- [Use PostgreSQL as an Alternative to MySQL for data storage](/docs/databases/postgresql/debian-6-squeeze/)
+- [Deploy Python Applications with uWSGI and nginx](/docs/web-servers/nginx/wsgi-using-uwsgi-and-nginx-on-debian-6-squeeze/)

--- a/docs/web-servers/nginx/installing-nginx-on-ubuntu-12-04-lts-precise-pangolin.md
+++ b/docs/web-servers/nginx/installing-nginx-on-ubuntu-12-04-lts-precise-pangolin.md
@@ -15,19 +15,19 @@ title: 'Installing Nginx on Ubuntu 12.04 LTS (Precise Pangolin)'
 external_resources:
  - '[Linode nginx Documentation](/docs/web-servers/nginx/)'
  - '[nginx Community Documentation](http://wiki.nginx.org)'
- - '[Configure Perl and FastCGI with nginx](/docs/web-servers/nginx/perl-fastcgi/ubuntu-10-04-lucid)'
- - '[Configure PHP and FastCGI with nginx](/docs/web-servers/nginx/php-fastcgi/ubuntu-10-04-lucid)'
+ - '[Configure Perl and FastCGI with nginx](/docs/web-servers/nginx/nginx-and-perlfastcgi-on-ubuntu-10-04-lts-lucid/)'
+ - '[Configure PHP and FastCGI with nginx](/docs/web-servers/nginx/nginx-and-phpfastcgi-on-ubuntu-10-04-lts-lucid/)'
 ---
 
 Nginx is a lightweight, high performance web server designed to deliver large amounts of static content quickly and with efficient use of system resources. In contrast to the [Apache server](/docs/web-servers/apache/), Nginx uses an asynchronous event-driven model which provides more predictable performance under load.
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Before You Begin
 
-1.  Ensure that you have followed the [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/security/securing-your-server) guides, and the Linode's [hostname is set](/docs/getting-started#setting-the-hostname).
+1.  Ensure that you have followed the [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/security/securing-your-server/) guides, and the Linode's [hostname is set](/docs/getting-started/#setting-the-hostname).
 
     To check your hostname run:
 
@@ -254,4 +254,4 @@ Regardless of installation source or method, Nginx can be tested by navigating t
 
 ![Nginx welcome](/docs/assets/nginx-welcome.png)
 
-Continue reading our introduction to [Basic NGINX Configuration](/docs/websites/nginx/basic-nginx-configuration) for more information about using and setting up a web server.
+Continue reading our introduction to [Basic NGINX Configuration](/docs/web-servers/nginx/how-to-configure-nginx/) for more information about using and setting up a web server.

--- a/docs/web-servers/nginx/nginx-and-perlfastcgi-on-ubuntu-9-10-karmic.md
+++ b/docs/web-servers/nginx/nginx-and-perlfastcgi-on-ubuntu-9-10-karmic.md
@@ -109,11 +109,11 @@ Issue the following commands to enable the site:
     ln -s /etc/nginx/sites-available/www.example.com
     /etc/init.d/nginx restart
 
-You may wish to create a test HTML page under `/srv/www/www.example.com/public_html/` and view it in your browser to verify that nginx is properly serving your site (Perl will not work yet). Please note that this will require an [entry in DNS](/docs/dns-guides/configuring-dns-with-the-linode-manager) pointing your domain name to your Linode's IP address (found on the "Remote Access" tab in the [Linode Manager](http://manager.linode.com//)).
+You may wish to create a test HTML page under `/srv/www/www.example.com/public_html/` and view it in your browser to verify that nginx is properly serving your site (Perl will not work yet). Please note that this will require an [entry in DNS](/docs/networking/dns/dns-manager-overview/) pointing your domain name to your Linode's IP address (found on the "Remote Access" tab in the [Linode Manager](http://manager.linode.com//)).
 
 # Configure spawn-fcgi
 
-Install the Perl module for FastCGI using the [CPAN Minus](/docs/linux-tools/utilities/cpanm) interface for CPAN. Install CPAN Minus and FCGI by issuing the following sequence of commands:
+Install the Perl module for FastCGI using the [CPAN Minus](/docs/development/perl/manage-cpan-modules-with-cpan-minus/) interface for CPAN. Install CPAN Minus and FCGI by issuing the following sequence of commands:
 
     cd /opt/
     curl https://github.com/miyagawa/cpanminus/raw/master/cpanm > cpanm
@@ -171,4 +171,4 @@ You may wish to consult the following resources for additional information on th
 - [FastCGI Project Homepage](http://www.fastcgi.com/)
 - [Perl Documentation](http://perldoc.perl.org/)
 - [Installing NGINX on Ubuntu 9.10 (Karmic)](/docs/web-servers/nginx/installation/ubuntu-9-10-karmic)
-- [Basic NGINX Configuration](/docs/websites/nginx/basic-nginx-configuration)
+- [Basic NGINX Configuration](/docs/web-servers/nginx/how-to-configure-nginx/)

--- a/docs/web-servers/nginx/websites-with-nginx-on-centos-5.md
+++ b/docs/web-servers/nginx/websites-with-nginx-on-centos-5.md
@@ -20,7 +20,7 @@ Although nginx is a relatively new entrant in the web server field, it has achie
 
 Before we begin installing the nginx web server, we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/).
 
-# Set the Hostname
+## Set the Hostname
 
 Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
@@ -132,6 +132,6 @@ You may wish to consult the following resources for additional information on th
 
 - [Linode Docs nginx Documentation](/docs/web-servers/nginx/)
 - [nginx Community Documentation](http://wiki.nginx.org)
-- [Configure Perl and FastCGI with nginx](/docs/web-servers/nginx/perl-fastcgi/centos-5)
-- [Configure PHP and FastCGI with nginx](/docs/web-servers/nginx/php-fastcgi/centos-5)
-- [Configure Ruby on Rails with nginx](/docs/frameworks/ruby-on-rails-nginx/centos-5)
+- [Configure Perl and FastCGI with nginx](/docs/web-servers/nginx/nginx-and-perlfastcgi-on-centos-5/)
+- [Configure PHP and FastCGI with nginx](/docs/web-servers/nginx/nginx-and-phpfastcgi-on-centos-5/)
+- [Configure Ruby on Rails with nginx](/docs/development/ror/ruby-on-rails-with-nginx-on-centos-5/)

--- a/docs/web-servers/nginx/websites-with-nginx-on-ubuntu-10-10-maverick.md
+++ b/docs/web-servers/nginx/websites-with-nginx-on-ubuntu-10-10-maverick.md
@@ -18,11 +18,11 @@ title: 'Websites with nginx on Ubuntu 10.10 (Maverick)'
 
 Nginx is a lightweight and high performance web server designed with the purpose of delivering large amounts of static content quickly and with efficient use of system resources. In contrast to the [Apache HTTP server](/docs/web-servers/apache/) that uses a threaded or process-oriented approach to handling requests, nginx uses an asynchronous event-driven model which provides more predictable performance under load.
 
-Before we begin installing the nginx web server, we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/content/using-linux/administration-basics).
+Before we begin installing the nginx web server, we assume that you have followed our [getting started guide](/docs/getting-started/). If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/).
 
 # Set the Hostname
 
-Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started#setting-the-hostname). Issue the following commands to make sure it is set properly:
+Before you begin installing and configuring the components described in this guide, please make sure you've followed our instructions for [setting your hostname](/docs/getting-started/#setting-the-hostname). Issue the following commands to make sure it is set properly:
 
     hostname
     hostname -f
@@ -131,7 +131,7 @@ You can now start, stop, and restart nginx just like any other server daemon. Fo
 
     /etc/init.d/nginx start
 
-Congratulations! You now have a running and fully functional HTTP server powered by nginx. Continue reading our introduction to [basic nginx configuration](/docs/websites/nginx/basic-nginx-configuration) for more information about using and setting up the web server.
+Congratulations! You now have a running and fully functional HTTP server powered by nginx. Continue reading our introduction to [basic nginx configuration](/docs/web-servers/nginx/how-to-configure-nginx/) for more information about using and setting up the web server.
 
 # More Information
 
@@ -139,5 +139,5 @@ You may wish to consult the following resources for additional information on th
 
 - [Linode Docs nginx Documentation](/docs/web-servers/nginx/)
 - [nginx Community Documentation](http://wiki.nginx.org)
-- [Configure Perl and FastCGI with nginx](/docs/web-servers/nginx/perl-fastcgi/ubuntu-10-10-maverick)
-- [Configure PHP and FastCGI with nginx](/docs/web-servers/nginx/php-fastcgi/ubuntu-10-10-maverick)
+- [Configure Perl and FastCGI with nginx](/docs/web-servers/nginx/nginx-and-perlfastcgi-on-ubuntu-10-10-maverick/)
+- [Configure PHP and FastCGI with nginx](/docs/web-servers/nginx/nginx-and-phpfastcgi-on-ubuntu-10-10-maverick/)

--- a/docs/websites/cms/high-availability-wordpress.md
+++ b/docs/websites/cms/high-availability-wordpress.md
@@ -16,11 +16,11 @@ This guide configures a high availability WordPress site with a two-Linode clust
 
 ## Prerequisites
 
-This guide is written for Debian 7 or Ubuntu 14.04. To complete this guide, ensure that there are two Linodes and a NodeBalancer present on your account.  Both Linodes need a [Private IP address](/docs/networking/remote-access#adding-private-ip-addresses). Also ensure that both of your Linodes have been configured with SSH keys, and place the opposing Linode's SSH key in the other's `/.ssh/authorized_keys` file.
+This guide is written for Debian 7 or Ubuntu 14.04. To complete this guide, ensure that there are two Linodes and a NodeBalancer present on your account.  Both Linodes need a [Private IP address](/docs/networking/remote-access/#adding-private-ip-addresses). Also ensure that both of your Linodes have been configured with SSH keys, and place the opposing Linode's SSH key in the other's `/.ssh/authorized_keys` file.
 
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with ``sudo``. If you're not familiar with the ``sudo`` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with ``sudo``. If you're not familiar with the ``sudo`` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Install Required Software Packages

--- a/docs/websites/cms/install-wordpress-on-ubuntu-16-04.md
+++ b/docs/websites/cms/install-wordpress-on-ubuntu-16-04.md
@@ -21,7 +21,7 @@ In this guide, you'll learn to how to install WordPress on a Linode running Ubun
 ![Install WordPress on Ubuntu 16.04](/docs/assets/wordpress-ubuntu-16-04-title.png "Install WordPress on Ubuntu 16.04")
 
 {{< note >}}
-This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 
 All configuration files should be edited with elevated privileges. Remember to include `sudo` before running your text editor.
 
@@ -30,7 +30,7 @@ Replace each instance of `example.com` in this guide with your site's domain nam
 
 ## Before You Begin
 
--   This guide assumes you have followed the [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/security/securing-your-server) guides, and that your Linode's [hostname is set](/docs/getting-started#setting-the-hostname).
+-   This guide assumes you have followed the [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/security/securing-your-server/) guides, and that your Linode's [hostname is set](/docs/getting-started/#setting-the-hostname).
 
     To check your hostname run:
 
@@ -39,7 +39,7 @@ Replace each instance of `example.com` in this guide with your site's domain nam
 
     The first command will output your short hostname; the second, your fully-qualified domain name (FQDN).
 
--   Configure a [LAMP](/docs/websites/lamp/install-lamp-on-ubuntu-16-04) or [LEMP](/docs/websites/lemp/lemp-server-on-ubuntu-16-04) web stack.
+-   Configure a [LAMP](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/) or [LEMP](/docs/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-16-04/) web stack.
 
 -   Make sure MySQL has a database set up for WordPress. If you do not have a WordPress database, create one:
 

--- a/docs/websites/cms/manage-an-ubuntu-10-04-lucid-vps-with-ispconfig.md
+++ b/docs/websites/cms/manage-an-ubuntu-10-04-lucid-vps-with-ispconfig.md
@@ -16,7 +16,7 @@ title: 'Manage an Ubuntu 10.04 (Lucid) Linode with ISPConfig'
 
 ISPConfig is an open-source control panel similar to proprietary software like CPanel or Plesk. It features a wide variety of options to help you control your server and allow other users to maintain their websites.
 
-Before beginning to follow this guide we assume that you have completed the [getting started guide](/docs/getting-started/).If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/beginners-guide/) and [administration basics guide](/content/using-linux/administration-basics).
+Before beginning to follow this guide we assume that you have completed the [getting started guide](/docs/getting-started/).If you are new to Linux server administration, you may be interested in our [introduction to Linux concepts guide](/docs/tools-reference/introduction-to-linux-concepts/), [beginner's guide](/docs/platform/linode-beginners-guide/) and [administration basics guide](/docs/tools-reference/linux-system-administration-basics/).
 
 This guide assumes you are installing this on a clean system. If you feel that you will not need certain features that are mentioned in this document, please feel free to exclude them from your setup.
 
@@ -29,13 +29,13 @@ When you have saved this file, issue the following commands to refresh your syst
 
 # Install Postfix, Courier, MySQL, and Dependencies
 
-In order to use the email capabilities in ISPConfig, you will need to install the email applications it depends on in order to function. More information on Postfix and Courier can be found in [our documentation](/docs/email/postfix/dovecot-mysql-ubuntu-10-04-lucid), and you are encouraged to read it to gain a better understanding of this software. MySQL is a relational database management system (RDBMS) that is commonly used for dynamic web pages and email. If you have already installed this, you will not need to install is as part of the ISPConfig installation process. You are encouraged to read the [MySQL documentation](/docs/databases/mysql/). You will need to read the documentation for detailed installation instructions.
+In order to use the email capabilities in ISPConfig, you will need to install the email applications it depends on in order to function. More information on Postfix and Courier can be found in [our documentation](/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-ubuntu-10-04-lts-lucid/), and you are encouraged to read it to gain a better understanding of this software. MySQL is a relational database management system (RDBMS) that is commonly used for dynamic web pages and email. If you have already installed this, you will not need to install is as part of the ISPConfig installation process. You are encouraged to read the [MySQL documentation](/docs/databases/mysql/). You will need to read the documentation for detailed installation instructions.
 
 Issue the following command (all one line):
 
     apt-get install postfix postfix-mysql postfix-doc mysql-client mysql-server courier-authdaemon courier-authlib-mysql courier-pop courier-pop-ssl courier-imap courier-imap-ssl libsasl2-2 libsasl2-modules libsasl2-modules-sql sasl2-bin libpam-mysql openssl maildrop getmail4 binutils
 
-You will be asked a series of questions during the installation; please refer to the [Postfix guide](/docs/email/postfix/dovecot-mysql-ubuntu-10-04-lucid) to determine what the needs of your system will be. In most cases, the defaults are fine.
+You will be asked a series of questions during the installation; please refer to the [Postfix guide](/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-ubuntu-10-04-lts-lucid/) to determine what the needs of your system will be. In most cases, the defaults are fine.
 
 # Install Amavisd-new and SpamAssassin
 
@@ -60,7 +60,7 @@ Vlogger is a tool that logs information regarding Apache. Webalizer can then be 
 
     apt-get install vlogger webalizer
 
-More information on Webalizer can be found in our [Webalizer documentation](/docs/uptime/analytics/webalizer-on-debian-5-lenny).
+More information on Webalizer can be found in our [Webalizer documentation](/docs/uptime/analytics/webalizer-on-debian-5-lenny/).
 
 # Install fail2ban
 
@@ -87,7 +87,7 @@ This script will configure services that you installed above to be monitored and
 
 Once it has completed, you may login to the control panel. By default, ISPConfig runs on port 8080, so you may find it at `http://12.34.56.78:8080/`. Replace `12.34.56.78` with your Linode's IP. The default login uses "admin" as the username and "admin" as the password. You will want to change these to prevent someone from accessing your system.
 
-Congratulations! You now have ISPConfig installed on your Ubuntu 10.04 (Lucid) Linode. You are highly encouraged to see the links in the "More Information" section to help you install extra applications that may help you manage your system better. Additionally, we highly recommend becoming familiar with our [SFTP guides](/docs/networking/file-transfer), as you'll need to use this method for uploading files to your Linode.
+Congratulations! You now have ISPConfig installed on your Ubuntu 10.04 (Lucid) Linode. You are highly encouraged to see the links in the "More Information" section to help you install extra applications that may help you manage your system better. Additionally, we highly recommend becoming familiar with our [SFTP guides](/docs/tools-reference/file-transfer/), as you'll need to use this method for uploading files to your Linode.
 
 # Monitor for Software Updates and Security Notices
 
@@ -107,7 +107,7 @@ You may wish to consult the following resources for additional information on th
 - [ISPConfig Home Page](http://www.ispconfig.org/)
 - [ISPConfig Support](http://www.ispconfig.org/page/en/support.html)
 - [ISPConfig Community](http://www.ispconfig.org/page/en/community.html)
-- [Limit User Access with SFTP Jails](/docs/security/sftp-jails)
+- [Limit User Access with SFTP Jails](/docs/tools-reference/tools/limiting-access-with-sftp-jails-on-debian-and-ubuntu/)
 
 
 

--- a/docs/websites/cms/update-and-secure-drupal-8-on-ubuntu.md
+++ b/docs/websites/cms/update-and-secure-drupal-8-on-ubuntu.md
@@ -21,10 +21,10 @@ Drupal 8 is the latest version of the popular [Drupal](https://www.drupal.org/) 
 
 1.  Ensure that you have completed the following guides:
 
-    -   [Getting Started](/docs/getting-started)
-    -   [Securing Your Server](/docs/security/securing-your-server)
-    -   [Install a LAMP stack](/docs/websites/lamp/lamp-on-ubuntu-14-04)
-    -   [Install and Configure Drupal 8](/docs/websites/cms/install-and-configure-drupal-8)
+    -   [Getting Started](/docs/getting-started/)
+    -   [Securing Your Server](/docs/security/securing-your-server/)
+    -   [Install a LAMP stack](/docs/web-servers/lamp/lamp-on-ubuntu-14-04/)
+    -   [Install and Configure Drupal 8](/docs/websites/cms/install-and-configure-drupal-8/)
 
 2.  Confirm the name of your site's Document Root folder by running the following command on your Linode:
 
@@ -42,7 +42,7 @@ Drupal 8 is the latest version of the popular [Drupal](https://www.drupal.org/) 
 
 ## Create Backups
 
-Back up existing files and move the archive into the backups directory. This process can also be scripted and run on a regular basis using [cron](/docs/tools-reference/tools/schedule-tasks-with-cron):
+Back up existing files and move the archive into the backups directory. This process can also be scripted and run on a regular basis using [cron](/docs/tools-reference/tools/schedule-tasks-with-cron/):
 
     cd /var/www/html/example.com/public_html
     sudo tar -cvzf example.com-BCKP-$(date +%Y%m%d).tar.gz ./
@@ -104,7 +104,7 @@ If `update.php` does not load or returns a 403 Forbidden error, you can try to c
 
 4.  Follow the prompts to continue the update.
 
-5.  If installing additional modules or configuring additional security settings, proceed to the *[Additional Security](/docs/websites/cms/update-and-secure-drupal-8-on-ubuntu#additional-security)* section below. Return to Step 6 once those configurations are complete.
+5.  If installing additional modules or configuring additional security settings, proceed to the *[Additional Security](/docs/websites/cms/update-and-secure-drupal-8-on-ubuntu/#additional-security)* section below. Return to Step 6 once those configurations are complete.
 
 6.  Rebuild the site's cache by clicking **Configuration** in the Admin Toolbar, then **Performance** under Development. Click **Clear all caches**.
 
@@ -112,7 +112,7 @@ If `update.php` does not load or returns a 403 Forbidden error, you can try to c
 
 8.  From your Linode, open `/var/www/html/example.com/public_html/sites/default/settings.php` and confirm that `$update_free_access = FALSE`.
 
-9.  If everything looks good, take the site out of maintenance mode *[described above](/docs/websites/cms/update-and-secure-drupal-8-on-ubuntu#put-the-site-into-maintenance-mode)* by unchecking the box next to "Put site into maintenance mode."
+9.  If everything looks good, take the site out of maintenance mode *[described above](/docs/websites/cms/update-and-secure-drupal-8-on-ubuntu/#put-the-site-into-maintenance-mode)* by unchecking the box next to "Put site into maintenance mode."
 
 ## Additional Security
 

--- a/docs/websites/ecommerce/opencart-on-debian-6-squeeze.md
+++ b/docs/websites/ecommerce/opencart-on-debian-6-squeeze.md
@@ -14,7 +14,7 @@ published: 2011-09-16
 title: 'OpenCart on Debian 6 (Squeeze)'
 ---
 
-OpenCart is an open source storefront designed to give you flexibility and fine-grained control over your online storefront. Before getting started, you should have already set up a [LAMP stack](/docs/lamp-guides) on your Linode. You should have also [set the hostname](/docs/getting-started#setting-the-hostname).
+OpenCart is an open source storefront designed to give you flexibility and fine-grained control over your online storefront. Before getting started, you should have already set up a [LAMP stack](/docs/web-servers/lamp/) on your Linode. You should have also [set the hostname](/docs/getting-started/#setting-the-hostname).
 
 # PHP Settings
 

--- a/docs/websites/forums/install-and-run-askbot-on-ubuntu-16-04.md
+++ b/docs/websites/forums/install-and-run-askbot-on-ubuntu-16-04.md
@@ -29,18 +29,18 @@ In this guide, you'll install AskBot and deploy with **NGINX** as a web server, 
 
 ## Before You Begin
 
-1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) to create a standard user account, harden SSH access and remove unnecessary network services.
+2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services.
 
 3.  Update your system:
 
          sudo apt-get update && sudo apt-get upgrade
 
-4.  A Fully-Qualified Domain Name configured to point to your Linode. You can learn how to point domain names to Linode by following the [DNS Manager Overview](/docs/networking/dns/dns-manager-overview#add-records) guide.
+4.  A Fully-Qualified Domain Name configured to point to your Linode. You can learn how to point domain names to Linode by following the [DNS Manager Overview](/docs/networking/dns/dns-manager-overview/#add-records) guide.
 
 {{< note >}}
-Throughout this guide, replace `example_user` with a non-root user with `sudo` access. If you’re not familiar with Linux user permissions and the `sudo` command, see the [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+Throughout this guide, replace `example_user` with a non-root user with `sudo` access. If you’re not familiar with Linux user permissions and the `sudo` command, see the [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
 ## Install Dependencies and Create a Database

--- a/docs/websites/wikis/ikiwiki-on-ubuntu-9-10-karmic.md
+++ b/docs/websites/wikis/ikiwiki-on-ubuntu-9-10-karmic.md
@@ -16,9 +16,9 @@ title: 'Ikiwiki on Ubuntu 9.10 (Karmic)'
 
 
 
-Unlike some other popular wiki engines, Ikiwiki compiles static HTML pages which can be efficiently served with a basic web server. These are generated from a source directory that can be stored in the [version control](/docs/development/version-control/) system of your choice, though this guide assumes that you use [git](/docs/development/version-control/how-to-configure-git).
+Unlike some other popular wiki engines, Ikiwiki compiles static HTML pages which can be efficiently served with a basic web server. These are generated from a source directory that can be stored in the [version control](/docs/development/version-control/) system of your choice, though this guide assumes that you use [git](/docs/development/version-control/how-to-configure-git/).
 
-This guide is written for Ubuntu 9.10 (Karmic), and assumes that you've followed our [getting started guide](/docs/getting-started/) and have a running and updated system. Additionally, it is assume that you have a functioning [Apache web server](/docs/web-servers/apache/installation/ubuntu-9-10-karmic) and a working installation of [git](/docs/development/version-control/how-to-configure-git).
+This guide is written for Ubuntu 9.10 (Karmic), and assumes that you've followed our [getting started guide](/docs/getting-started/) and have a running and updated system. Additionally, it is assume that you have a functioning [Apache web server](/docs/web-servers/apache/apache-2-web-server-on-ubuntu-9-10-karmic/) and a working installation of [git](/docs/development/version-control/how-to-configure-git/).
 
 # Installing Ikiwiki
 
@@ -194,7 +194,7 @@ You may find yourself wondering why there are so many git repositories for a sin
 
 # Notes for Using Gitosis with Ikiwiki
 
-If you're using `gitosis` to manage the git repositories as described in the [introduction to Git](/docs/linux-tools/version-control/git) guide, there are a couple of configuration options for Ikiwiki that you'll need to keep in mind as you're setting things up. As `gitosis` needs to "own" the git repositories it manages, the `gitosis` user ends up executing `post-update` hook and wrappers, and as a result many Ikiwiki files need to be owned by the `gitosis` user. This should not present a concern as Ikiwiki's scripts are designed to be run securely by untrusted users. This means running `ikiwiki.cgi` as mode "6755". See the example [Ikiwiki configuration file](/docs/assets/655-ikiwiki.setup) for details on how to configure this.
+If you're using `gitosis` to manage the git repositories as described in the [introduction to Git](/docs/development/version-control/how-to-install-git-on-linux-mac-and-windows/) guide, there are a couple of configuration options for Ikiwiki that you'll need to keep in mind as you're setting things up. As `gitosis` needs to "own" the git repositories it manages, the `gitosis` user ends up executing `post-update` hook and wrappers, and as a result many Ikiwiki files need to be owned by the `gitosis` user. This should not present a concern as Ikiwiki's scripts are designed to be run securely by untrusted users. This means running `ikiwiki.cgi` as mode "6755". See the example [Ikiwiki configuration file](/docs/assets/655-ikiwiki.setup) for details on how to configure this.
 
 The files that needed to be owned by the `gitosis` user are the "destination" directory where Ikiwiki puts its output, the "source directory", and the bare repository. Run the following commands to set this ownership.
 


### PR DESCRIPTION
XR #1626 
Fixes:

Broken image: https://linode.com/docs/platform/linode-images/

Incorrect link syntax in note: https://linode.com/docs/quick-answers/linux/log-in-to-coreos-container-linux/

`Before You Begin` links to image rather than intended documentation: https://linode.com/docs/networking/vpn/vpn-firewall-killswitch-for-linux-and-macos-clients/
