### PR TITLE
Dictionary clean up

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -15,13 +15,9 @@ ajp
 aker
 alives
 allmasquerade
-allnodes
-allrouters
 amavis
 amavisd
 amd64
-amongst
-analytics
 anonymize
 anonymizing
 ansible
@@ -46,7 +42,6 @@ authmysqlrc
 authn
 authomator
 authy
-autocomplete
 autocompletion
 autoconfiguration
 autoconfigure
@@ -77,17 +72,13 @@ backreference
 backreferences
 backtick
 backticks
-bak
 bampton
-barcode
-baremetal
 base64
 basearch
 bashdoor
 bashrc
 bc
 berkshelf
-bgrewriteaof
 binlog
 bitbucket
 bitrate
@@ -134,8 +125,6 @@ changeme
 changeset
 chatrooms
 cheatsheet
-checkboxes
-checkmark
 checksummed
 checksums
 chefspec
@@ -180,7 +169,6 @@ copyto
 coreutils
 corporateclean
 cpanminus
-cpu
 cqlsh
 cqlshrc
 craftbukkit
@@ -202,8 +190,6 @@ csum
 csv
 ctools
 ctrl
-customizability
-customizable
 cyberduck
 cyg
 cygwin
@@ -254,11 +240,9 @@ dialogs
 diavel
 diffie
 digium
-diplays
 dircaps
 directadmin
 dired
-displayfeatures
 disqus
 distro
 distros
@@ -313,7 +297,6 @@ elpaso
 email2email
 ender
 enix
-entrypoint
 env
 envs
 epel
@@ -323,7 +306,6 @@ esc
 etcd
 etcd0
 eth0
-everytime
 evhost
 example1
 example2
@@ -339,10 +321,8 @@ expirations
 ext2
 ext3
 ext4
-ext4
 facter
 facto
-fail2ban
 fail2ban
 failover
 failregex
@@ -436,7 +416,6 @@ gpg
 gradle
 grafana
 graylog
-graylog2
 graylog2
 greenbone
 greylist
@@ -554,7 +533,6 @@ ip6tables
 ipchains
 ipset
 ipsets
-iptabes
 iptables
 ipv4
 ipv6
@@ -570,7 +548,6 @@ isp
 issuewild
 iterable
 itk
-java6
 java6
 javac
 javascript
@@ -689,7 +666,6 @@ magento
 maildir
 maildirs
 maildrop
-maillbox
 mailname
 mailq
 mailserver
@@ -756,7 +732,6 @@ msg
 msgid
 msgpack
 msmtp
-mstmp
 mtr
 mtu
 multiarch
@@ -792,7 +767,6 @@ nameservers
 namespace
 namespaces
 nano
-natively
 ncurses
 neo
 neomake
@@ -843,10 +817,8 @@ nrcpt
 ns1
 ns2
 nsd4
-nsd4
 ntopng
 ntpd
-ntpong
 num
 numpy
 nvim
@@ -857,7 +829,6 @@ ohai
 ok
 oldstable
 oneof
-onone
 ons
 opencart
 opendkim
@@ -876,7 +847,6 @@ ossec
 ostemplate
 osx
 otomen
-ournaling
 overcommit
 overwatch
 ovpn
@@ -906,12 +876,10 @@ patroni
 pem
 pepi
 percona
-perfom
 permalink
 permalinks
 pflogsumm
 pgpass
-phar
 pharo
 phonebook
 php
@@ -931,7 +899,6 @@ ploop
 pluggable
 png
 pocketmine
-polcy
 pop3
 pop3d
 pop3s
@@ -964,7 +931,6 @@ pritunl
 procfile
 procmail
 procs
-programmatically
 prosodyctl
 proto
 proxied
@@ -1042,7 +1008,6 @@ rimap
 rkt
 rmem
 ro
-roadmap
 rocommunity
 rollout
 roundcube
@@ -1059,7 +1024,6 @@ rtf
 rtt
 rubocop
 rubygems
-rubygems1
 ruleset
 rulesets
 rundir
@@ -1082,7 +1046,6 @@ sasldb
 sbin
 sbopkg
 scgi
-schemas
 scm
 scp
 scrapy
@@ -1142,7 +1105,6 @@ smtp
 smtpd
 smux
 snakeoil
-snapsnot
 snipcart
 snmp
 snmpd
@@ -1173,7 +1135,6 @@ stackscript
 stackscripts
 stalkyard
 starttls
-stateful
 statusbar
 stderr
 steamlab
@@ -1189,7 +1150,6 @@ subfolder
 subkey
 subkeys
 submenu
-submodules
 subnet
 subnets
 subnetwork
@@ -1229,7 +1189,6 @@ tbz
 tcp
 tcpwrappers
 teamspeak
-templating
 tensorflow
 terraria
 testdb
@@ -1248,7 +1207,6 @@ timeframe
 timespan
 timewait
 timey
-timme
 tinc
 tincd
 tinydb
@@ -1300,7 +1258,6 @@ uncompress
 unencrypted
 unformatted
 unicast
-unintuitive
 uniq
 unmerged
 unmount
@@ -1316,7 +1273,6 @@ untracked
 untruncated
 untrusted
 unversioned
-uptime
 uri
 uris
 url
@@ -1400,7 +1356,6 @@ werkzug
 wg
 wget
 whatsmyip
-whitelist
 whitelisted
 whitelisting
 whitespace

--- a/ci/vale/styles/Linode/Terms.yml
+++ b/ci/vale/styles/Linode/Terms.yml
@@ -10,7 +10,9 @@ swap:
   'node[.]?js': Node.js
   'Post?gr?e(?:SQL)': PostgreSQL
   'java[ -]?scripts?': JavaScript
+  automattic: Automattic
   centOS: CentOS
+  cloudflare: Cloudflare
   debian: Debian
   fedora: Fedora
   gentoo: Gentoo
@@ -20,6 +22,7 @@ swap:
   linode: Linode
   longview: Longview
   macOS: macOS
+  metabase: Metabase
   miniconda: Miniconda
   nodebalancer: NodeBalancer
   nodebalancers: NodeBalancers
@@ -28,7 +31,5 @@ swap:
   ubuntu: Ubuntu
   wordpress: WordPress
   yaml: YAML
-  metabase: Metabase
-  cloudflare: Cloudflare
   urls: URLs
   uris: URIs

--- a/docs/databases/redis/redis-on-ubuntu-10-04-lucid.md
+++ b/docs/databases/redis/redis-on-ubuntu-10-04-lucid.md
@@ -160,7 +160,7 @@ After applying these configuration changes, restart Redis. All modifications to 
 
     /opt/redis/redis-cli bgrewriteaof
 
-You may wish to issue this command regularly, perhaps in a [cron job](/docs/tools-reference/tools/schedule-tasks-with-cron/), to ensure that the transaction journal doesn't expand exponentially. bgrewriteaof\` is non-destructive and can fail gracefully.
+You may wish to issue this command regularly, perhaps in a [cron job](/docs/tools-reference/tools/schedule-tasks-with-cron/), to ensure that the transaction journal doesn't expand exponentially. `bgrewriteaof` is non-destructive and can fail gracefully.
 
 # Distributed Data Stores with Master Slave Replication
 

--- a/docs/databases/redis/redis-on-ubuntu-12-04-precise-pangolin.md
+++ b/docs/databases/redis/redis-on-ubuntu-12-04-precise-pangolin.md
@@ -92,7 +92,7 @@ While running the Redis instance in this configuration is useful for testing and
 
 Redis is not necessarily intended to provide a completely consistent and fault-tolerant data storage layer, and in the default configuration there are some conditions that may cause your data store to lose up to 60 seconds of the most recent data. Make sure you understand the risks associated and the potential impact that this kind of data loss may have on your application before deploying Redis.
 
-If persistence is a major issue for your application, it is possible to use Redis in a transaction-ournaling mode that provides greater data resilience at the expense of some performance.
+If persistence is a major issue for your application, it is possible to use Redis in a transaction-journaling mode that provides greater data resilience at the expense of some performance.
 
 To use this mode, ensure that the following values are set in `redis.conf`:
 
@@ -115,7 +115,7 @@ All modifications to the data store will be logged. Every time Redis restarts, i
 
 This command should return `Background append only file rewriting started`.
 
-You may wish to issue this command regularly, perhaps in a [cron job](/docs/linux-tools/utilities/cron), to ensure that the transaction journal doesn't expand exponentially. bgrewriteaof\ is non-destructive and can fail gracefully.
+You may wish to issue this command regularly, perhaps in a [cron job](/docs/linux-tools/utilities/cron), to ensure that the transaction journal doesn't expand exponentially. `bgrewriteaof` is non-destructive and can fail gracefully.
 
 ## Distributed Data Stores with Master Slave Replication
 

--- a/docs/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7.md
@@ -491,7 +491,7 @@ Now you can test to see what the users of your email server would see with their
         ./dovecot.index.log
         ./tmp
 
-3.  Test the maillbox by using a mail client. For this test, using **mutt** is recommended. If it is not installed by default, install it with `yum install mutt`, then run:
+3.  Test the mailbox by using a mail client. For this test, using **mutt** is recommended. If it is not installed by default, install it with `yum install mutt`, then run:
 
         mutt -f .
 

--- a/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-5.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-5.md
@@ -463,7 +463,7 @@ Now test to see what the users of your email server would see with their email c
         ./dovecot.index.log
         ./tmp
 
-3.  Test the maillbox by using a mail client. For this test, using **mutt** is recommended. If it is not installed by default, install it with `yum install mutt`, then run:
+3.  Test the mailbox by using a mail client. For this test, using **mutt** is recommended. If it is not installed by default, install it with `yum install mutt`, then run:
 
         mutt -f .
 

--- a/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-6.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-6.md
@@ -457,7 +457,7 @@ Now you can test to see what the users of your email server would see with their
         ./dovecot.index.log
         ./tmp
 
-3.  Test the maillbox by using a mail client. For this test, using **mutt** is recommended. If it is not installed by default, install it with `yum install mutt`, then run:
+3.  Test the mailbox by using a mail client. For this test, using **mutt** is recommended. If it is not installed by default, install it with `yum install mutt`, then run:
 
         mutt -f .
 

--- a/docs/networking/diagnostics/install-ntopng-for-network-monitoring-on-debian8.md
+++ b/docs/networking/diagnostics/install-ntopng-for-network-monitoring-on-debian8.md
@@ -120,7 +120,7 @@ The option flags commented with `# optional` are **not mandatory.** All flags re
 | --interface | The network interface ntopng will monitor.  |
 | -w | HTTP address and port used to connect to the admin interface. While port `3005` is the default, you may define any.  |
 | --community | The license ntopng will run under. |
-| --daemon | ntpong can be used as a forward service or as a background daemon. |
+| --daemon | ntopng can be used as a forward service or as a background daemon. |
 | --dump-flows | Logged traffic can be shared with other services |
 | --disable-autologout | Forces ntopng to allow users to remain logged into the web interface without being deactivated for inactivity.|
 | --disable-login | 1 to disable password authentication, 0 to require authentication. |

--- a/docs/networking/nfs/how-to-mount-nfs-shares-on-debian-9.md
+++ b/docs/networking/nfs/how-to-mount-nfs-shares-on-debian-9.md
@@ -86,7 +86,7 @@ rpcbind mountd nfsd statd lockd rquotad : ALL : deny
 
         sudo systemctl restart nfs-kernel-server
 
-Done! Now you have a basic NFS server onone of your Linodes, configured to serve the `/var/nfsroot` directory to your second Linode.
+Done! Now you have a basic NFS server on one of your Linodes, configured to serve the `/var/nfsroot` directory to your second Linode.
 
 ## NFS Client Setup
 

--- a/docs/platform/automating-server-builds.md
+++ b/docs/platform/automating-server-builds.md
@@ -46,7 +46,7 @@ These methods are discussed in further detail below, with the exception of [Lino
 
 ### Linode Backup Service
 
-If you subscribe to the [Linode Backup Service](http://www.linode.com/backups/), you can create a golden disk by making a manual backup of an existing disk. Take a *snapsnot* of the disk to back it up, and then restore it to your other Linodes. There's no need to clone or resize the disk. The snapshot will be stored until you overwrite it with another backup.
+If you subscribe to the [Linode Backup Service](http://www.linode.com/backups/), you can create a golden disk by making a manual backup of an existing disk. Take a *snapshot* of the disk to back it up, and then restore it to your other Linodes. There's no need to clone or resize the disk. The snapshot will be stored until you overwrite it with another backup.
 
 1.  Use the Linode's existing disk, or [create a new disk](/docs/platform/disk-images/disk-images-and-configuration-profiles/#creating-a-disk-with-a-linux-distribution-installed).
 2.  Install all necessary packages and configure the system settings.

--- a/docs/platform/linode-backup-service.md
+++ b/docs/platform/linode-backup-service.md
@@ -106,7 +106,7 @@ You can make a manual backup of your Linode by taking a *snapshot*. Here's how:
 Taking a new snapshot will overwrite a saved snapshot.
 {{< /note >}}
 
-4.  A warning appears asking if you would like to overwrite the previous snapsnot. Click **OK**.
+4.  A warning appears asking if you would like to overwrite the previous snapshot. Click **OK**.
 
 The Linode Backup Service initiates the manual snapshot. Be patient. Creating the manual snapshot can take several minutes, depending on the size of your Linode and the amount of data you have stored on it. Other Linode Manager jobs for this Linode will not run until the snapshot job has been completed.
 

--- a/docs/security/encrypt-data-disk-with-dm-crypt.md
+++ b/docs/security/encrypt-data-disk-with-dm-crypt.md
@@ -133,7 +133,7 @@ Remember to replace `sdX` with the name of the device you want to encrypt.
         cd /root/ && umount /root/encrypted && cryptsetup close sdX-plain
 
 {{< caution >}}
-As mentioned earlier, dm-crypt in plain mode doesn't check to see if you're using the same password or encryption settings everytime. This exposes your server to the risk of being re-encrypted and having useful data overwritten. It's a good idea to routinely specify encryption settings on the command line every time you use dm-crypt in plain mode. Here's an example you can use: `cryptsetup --verify-passphrase --hash ripemd160 --cipher aes-cbc-essiv:sha256 --key-size 256 open --type plain /dev/sdX sdX-plain`
+As mentioned earlier, dm-crypt in plain mode doesn't check to see if you're using the same password or encryption settings every time. This exposes your server to the risk of being re-encrypted and having useful data overwritten. It's a good idea to routinely specify encryption settings on the command line every time you use dm-crypt in plain mode. Here's an example you can use: `cryptsetup --verify-passphrase --hash ripemd160 --cipher aes-cbc-essiv:sha256 --key-size 256 open --type plain /dev/sdX sdX-plain`
 {{< /caution >}}
 
 ## How to Use dm-crypt with LUKS

--- a/docs/security/getting-started-with-selinux.md
+++ b/docs/security/getting-started-with-selinux.md
@@ -146,7 +146,7 @@ SELinux marks every single object on a machine with a *context*. That means ever
 
 ### SELinux Boolean
 
-An SELinux Boolean is a variable that can be toggled on and off without needing to reload or recompile an SELinux polcy. You can view the list of boolean variables using the `getsebool -a` command. It's a long list, so you can pipe it through `grep` to narrow down the results:
+An SELinux Boolean is a variable that can be toggled on and off without needing to reload or recompile an SELinux policy. You can view the list of boolean variables using the `getsebool -a` command. It's a long list, so you can pipe it through `grep` to narrow down the results:
 
 
     [root@centos ~]# getsebool -a | grep xdm

--- a/docs/security/visualize-server-security-on-centos-7-with-an-elastic-stack-and-wazuh.md
+++ b/docs/security/visualize-server-security-on-centos-7-with-an-elastic-stack-and-wazuh.md
@@ -499,7 +499,7 @@ The new Kibana subdomain will need to be configured in the Linode DNS Manager.
 
 ## Open the Kibana Port
 
-Kibana's default access port, `5601`, must be opened for TCP traffic. Instructions are presented below for UFW, Iptabes, and FirewallD.
+Kibana's default access port, `5601`, must be opened for TCP traffic. Instructions are presented below for UFW, Iptables, and FirewallD.
 
 **UFW**
 

--- a/docs/tools-reference/linux-system-administration-basics.md
+++ b/docs/tools-reference/linux-system-administration-basics.md
@@ -725,6 +725,6 @@ port 587
 {{< /file-excerpt >}}
 
 
-The `.msmptrc` file needs to be set to mode 600 and owned by the user account that will be sending mail. For example, if the configuration file is located at `/srv/smtp/msmtprc`, you can call mstmp with the following command:
+The `.msmptrc` file needs to be set to mode 600 and owned by the user account that will be sending mail. For example, if the configuration file is located at `/srv/smtp/msmtprc`, you can call msmtp with the following command:
 
     /usr/bin/msmtp --file=/srv/smtp/msmtprc

--- a/docs/uptime/analytics/google-analytics-for-websites.md
+++ b/docs/uptime/analytics/google-analytics-for-websites.md
@@ -75,7 +75,7 @@ If you copy the above code, replace `UA-00000000-0` with your **tracking ID**.
 
 At this time you may want to consider enabling the *[demographics](https://support.google.com/analytics/answer/2819948?hl=en)* feature of Google Analytics. If you decide to do so, you will need to add an additional line of code to your JavaScript in the steps below. Insert the following between the lines containing `ga('create', 'UA-00000000-0', 'auto');` and `ga('send', 'pageview');`:
 
-ga('require', 'displayfeatures');
+    ga('require', 'displayfeatures');
 
 Should you decide to disable the demographics feature at a later date, simply remove the above code.
 {{< /note >}}
@@ -143,7 +143,7 @@ ga('send', 'pageview');
     {{< note >}}
 At this time you may want to consider enabling the *[demographics](https://support.google.com/analytics/answer/2819948?hl=en)* feature of Google Analytics. If you decide to do so, you will need to add an additional line of code to your JavaScript in the steps below. Insert the following between the lines containing `ga('create', 'UA-00000000-0', 'auto');` and `ga('send', 'pageview');`:
 
-ga('require', 'displayfeatures');
+    ga('require', 'displayfeatures');
 
 Should you decide to disable the demographics feature at a later date, simply remove the above code.
 {{< /note >}}

--- a/docs/uptime/analytics/google-analytics-on-wordpress.md
+++ b/docs/uptime/analytics/google-analytics-on-wordpress.md
@@ -88,7 +88,7 @@ If you copy the above code, replace `UA-00000000-0` with your **tracking ID**.
 
 At this time you may want to consider enabling the *[demographics](https://support.google.com/analytics/answer/2819948?hl=en)* feature of Google Analytics. If you decide to do so, you will need to add an additional line of code to your JavaScript in the steps below. Insert the following between the lines containing `ga('create', 'UA-00000000-0', 'auto');` and `ga('send', 'pageview');`:
 
-ga('require', 'displayfeatures');
+    ga('require', 'displayfeatures');
 
 Should you decide to disable the demographics feature at a later date, simply remove the above code.
 {{< /note >}}

--- a/docs/uptime/monitoring/top-htop-iotop.md
+++ b/docs/uptime/monitoring/top-htop-iotop.md
@@ -126,7 +126,7 @@ Although there are a vast number of `top` commands, some of the more common ones
 -  **`H`**: Show individual threads for all processes.
 -  **`i`**: Toggles whether idle processes will be displayed.
 -  **`U` or `u`**: Filter processes by the owner's username.
--  **`1`**: Toggles between CPUs/CPU cores. When it reads *%Cpu(s)* all CPUs are being considered. *%Cpu* followed by a number denotes a single CPU core.
+-  **`1`**: Toggles between CPUs/CPU cores. When it reads `%Cpu(s)` all CPUs are being considered. `%Cpu` followed by a number denotes a single CPU core.
 -  **`L`**: Locate string.
 -  **`<`, `>`**: Select sort field (from column names).
 -  **`k`**: Kill a process. You will be prompted to enter the PID.

--- a/docs/uptime/reboot-survival-guide.md
+++ b/docs/uptime/reboot-survival-guide.md
@@ -32,7 +32,7 @@ Linode maintains an RSS feed and web page for cataloging current and deprecated 
 
 Updating certain packages will occasionally require a system reboot too. This does not happen often, but when necessary, the terminal output will inform you that a reboot is needed.
 
-It's not uncommon to see *[fsck](http://linux.die.net/man/8/fsck)* run a filesystem scan on reboot. This does not mean anything is broken--fsck is a regularly scheduled process for optimal system health. Some Linux distros run fsck on every boot, others run the tool after a certain duration, and most distros perfom a filesystem check after unclean shutdowns.
+It's not uncommon to see *[fsck](http://linux.die.net/man/8/fsck)* run a filesystem scan on reboot. This does not mean anything is broken--fsck is a regularly scheduled process for optimal system health. Some Linux distros run fsck on every boot, others run the tool after a certain duration, and most distros perform a filesystem check after unclean shutdowns.
 
 ## Backups
 

--- a/docs/web-servers/apache-tips-and-tricks/tuning-your-apache-server.md
+++ b/docs/web-servers/apache-tips-and-tricks/tuning-your-apache-server.md
@@ -36,7 +36,7 @@ More specific resources for resource tuning Apache includes Apache `mod_status` 
 
 ### Apache mod_status
 
-Apache `mod_status` diplays information related to incoming server connections by generating a detailed status page. View an example of this page at [Apache's own website](http://www.apache.org/server-status).
+Apache `mod_status` displays information related to incoming server connections by generating a detailed status page. View an example of this page at [Apache's own website](http://www.apache.org/server-status).
 
 1.  Open your website's configuration file. This file is located at `/etc/apache2/sites-available/example.com.conf` on Debian/Ubuntu systems or `/etc/httpd/conf.d/vhost.conf` on CentOS/Fedora systems.
 

--- a/docs/websites/cms/install-wordpress-using-wp-cli-on-ubuntu-14-04.md
+++ b/docs/websites/cms/install-wordpress-using-wp-cli-on-ubuntu-14-04.md
@@ -41,7 +41,7 @@ This guide is written for a non-root user. Commands that require elevated privil
 
 ## Install WP-CLI
 
-1.  WP-CLI is available as a PHP Archive file (.phar). You can download it using either `wget` or `curl` commands:
+1.  WP-CLI is available as a PHP Archive file (`.phar`). You can download it using either `wget` or `curl` commands:
 
         curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 
@@ -49,7 +49,7 @@ This guide is written for a non-root user. Commands that require elevated privil
 
         wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 
-2.  You need to make this .phar file executable and move it to `/usr/local/bin` so that it can be run directly:
+2.  You need to make this `.phar` file executable and move it to `/usr/local/bin` so that it can be run directly:
 
         chmod +x wp-cli.phar
         sudo mv wp-cli.phar /usr/local/bin/wp


### PR DESCRIPTION
 * Removed duplicates
 * Remove words with no impact
 * Added back ticks to `bgrewriteaof` with single usage
 * Instances of incorrectly spelled words from initial commit (`diplays`, `snapsnot`, `iptabes`)
 * Establish `everytime` as two words