### PR TITLE
Update Hugo version to .40.2 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
 before_install:
   - if [ $TEST_SUITE == docs404 ]; then
-      wget https://github.com/gohugoio/hugo/releases/download/v0.39/hugo_0.39_Linux-64bit.deb;
+      wget https://github.com/gohugoio/hugo/releases/download/v0.40.2/hugo_0.40.2_Linux-64bit.deb;
       sudo dpkg -i hugo*.deb;
       (hugo server &);
     fi


### PR DESCRIPTION
Updates Hugo version used in Travis builds to 0.40.2, which provides better support for the .GetPage.Content method we use in our content shortcode.