### PR TITLE
Reuse content shortcode for pyspark and R shiny

### DIFF
--- a/docs/development/python/introduction-to-pyspark.md
+++ b/docs/development/python/introduction-to-pyspark.md
@@ -31,37 +31,11 @@ The installation process requires the installation of Scala, which has Java JDK 
 
 ### Miniconda
 
-1.  Download and install Miniconda:
-
-        curl -OL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-        bash Miniconda3-latest-Linux-x86_64.sh
-
-2.  You will be prompted several times during the installation process. Review the terms and conditions and select "yes" for each prompt.
-
-3.  Restart your shell session for the changes to your PATH to take effect.
-
-
-4.  Check your Python version:
-
-        python --version
+{{< content "install_python_miniconda.md" >}}
 
 ### Java JDK 8
 
-1.  Install `software-properties-common` to easily add new repositories:
-
-        sudo apt-get install software-properties-common
-
-2.  Add the Java PPA in order to download from Oracle repositories:
-
-        sudo add-apt-repository ppa:webupd8team/java
-
-3.  Update the source list:
-
-        sudo apt-get update
-
-4.  Install the Java JDK 8:
-
-        sudo apt-get install oracle-java8-installer
+{{< content "install-java-8-ppa.md" >}}
 
 ### Scala
 

--- a/docs/development/r/how-to-deploy-rshiny-server-on-ubuntu-and-debian.md
+++ b/docs/development/r/how-to-deploy-rshiny-server-on-ubuntu-and-debian.md
@@ -54,34 +54,7 @@ The steps in this section should be completed on your Linode.
 
 ### Install R
 
-1.  Open `/etc/apt/sources.list` and add the following line to the end of the file:
-
-    Ubuntu:
-
-        deb http://cran.rstudio.com/bin/linux/ubuntu xenial/
-
-    Debian:
-
-        deb http://cran.rstudio.com/bin/linux/debian stretch-cran34/
-
-2.  Add the key ID for the CRAN network:
-
-    [Ubuntu GPG key](https://cran.rstudio.com/bin/linux/ubuntu/):
-
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-
-    [Debian GPG key](https://cran.rstudio.com/bin/linux/debian/):
-
-        sudo apt install dirmngr
-        sudo apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
-
-3.  Update the repository:
-
-        sudo apt update
-
-4.  Install the R binaries:
-
-        sudo apt install r-base
+{{< content "install_r_ubuntu.md" >}}
 
 ### Add the Shiny Package
 


### PR DESCRIPTION
Should be fixed since #1728 

Cleaning up old copy/paste workarounds.