### PR TITLE
Add post-resize mounting instructions for Block Storage Volumes

### DIFF
--- a/docs/platform/how-to-use-block-storage-with-your-linode.md
+++ b/docs/platform/how-to-use-block-storage-with-your-linode.md
@@ -122,13 +122,11 @@ Storage volumes **cannot** be sized down, only up. Keep this in mind when sizing
 
 5.  Reboot your Linode.
 
-6.  Once your Linode has restarted, make sure the volume is unmounted for
-safety:
+6.  Once your Linode has restarted, make sure the volume is unmounted for safety:
 
         umount /dev/disk/by-id/scsi-0Linode_Volume_BlockStorage1
 
-7.  Assuming you have an ext2, ext3, or ext4 partition, resize it to fill the
-new volume size:
+7.  Assuming you have an ext2, ext3, or ext4 partition, resize it to fill the new volume size:
 
         resize2fs /dev/disk/by-id/scsi-0Linode_Volume_BlockStorage1
 

--- a/docs/platform/how-to-use-block-storage-with-your-linode.md
+++ b/docs/platform/how-to-use-block-storage-with-your-linode.md
@@ -120,7 +120,21 @@ Storage volumes **cannot** be sized down, only up. Keep this in mind when sizing
 
     [![Linode Manager edit volume](/docs/assets/bs-volume-resizing-small.png)](/docs/assets/bs-volume-resizing.png)
 
-5.  Reboot your Linode and your volume resize will be completed.
+5.  Reboot your Linode.
+
+6.  Once your Linode has restarted, make sure the volume is unmounted for
+safety:
+
+        umount /dev/disk/by-id/scsi-0Linode_Volume_Record
+
+7.  Assuming you have an ext2, ext3, or ext4 partition, resize it to fill the
+new volume size:
+
+        resize2fs /dev/disk/by-id/scsi-0Linode_Volume_Record
+
+8.  Mount it back onto the filesystem:
+
+        mount /dev/disk/by-id/scsi-0Linode_Volume_Record /mnt/Record
 
 ## Where to Go From Here?
 

--- a/docs/platform/how-to-use-block-storage-with-your-linode.md
+++ b/docs/platform/how-to-use-block-storage-with-your-linode.md
@@ -125,16 +125,16 @@ Storage volumes **cannot** be sized down, only up. Keep this in mind when sizing
 6.  Once your Linode has restarted, make sure the volume is unmounted for
 safety:
 
-        umount /dev/disk/by-id/scsi-0Linode_Volume_Record
+        umount /dev/disk/by-id/scsi-0Linode_Volume_BlockStorage1
 
 7.  Assuming you have an ext2, ext3, or ext4 partition, resize it to fill the
 new volume size:
 
-        resize2fs /dev/disk/by-id/scsi-0Linode_Volume_Record
+        resize2fs /dev/disk/by-id/scsi-0Linode_Volume_BlockStorage1
 
 8.  Mount it back onto the filesystem:
 
-        mount /dev/disk/by-id/scsi-0Linode_Volume_Record /mnt/Record
+        mount /dev/disk/by-id/scsi-0Linode_Volume_BlockStorage1 /mnt/BlockStorage1
 
 ## Where to Go From Here?
 


### PR DESCRIPTION
Addresses DOCS-86 and DOCS-90 in JIRA.

When a BS Volume is resized through the Manager, a series of instructions for expanding the filesystem to fit the new size is displayed. These have been added to the guide.