### PR TITLE
fix date formatting in content archetype

### DIFF
--- a/archetypes/content.md
+++ b/archetypes/content.md
@@ -5,8 +5,8 @@ author:
 description: 'Two to three sentences describing your guide.'
 keywords: ['list','of','keywords','and key phrases']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-published: {{ .Date.Format "2006-01-02" }}
-modified: {{ .Date.Format "2006-01-02" }}
+published: {{ now.Format "2006-01-02" }}
+modified: {{ now.Format "2006-01-02" }}
 modified_by:
   name: Linode
 title: "{{ replace .TranslationBaseName "-" " " | title }}"


### PR DESCRIPTION
This updates the date formatting string so that it does not generate an error when creating a new doc.

https://discourse.gohugo.io/t/specify-date-format-in-archetype/9015/4

Error:
```
~/.../Linode/docs $ hugo new content/troubleshooting/troubleshooting-failing-ssh-connections.md
ERROR 2018/06/01 08:47:51 Unable to find archetypes directory for theme "docsmith" at "/Users/sjacobs/Code/github/Linode/docs/themes/docsmith/archetypes"
Error: Failed to process archetype file "/Users/sjacobs/Code/github/Linode/docs/archetypes/content.md": template: content:8:19: executing "content" at <.Date.Format>: can't evaluate field Format in type $
tring
```