### PR TITLE
Remove spectre banner

### DIFF
--- a/themes/docsmith/layouts/index.html
+++ b/themes/docsmith/layouts/index.html
@@ -21,7 +21,6 @@
 
     </div>
   </div>
-  {{ partial "spectre_alert" . }}
   {{ $tiles := where .Site.Pages "Params.show_on_frontpage" true }}
   {{ range $i, $section := $tiles }}
   {{ if mod (add $i 1) 3 | eq 1 }}<div class="row-tiles">{{ end }}


### PR DESCRIPTION
Removed banner from index.html. Kept spectre_alert.html to be reused in the future when a banner is needed.  Open for discussion.