### PR TITLE
Fixed: adding HTTP to FirewallD's permanent ruleset

### DIFF
--- a/docs/web-servers/lamp/lamp-on-centos-7/index.md
+++ b/docs/web-servers/lamp/lamp-on-centos-7/index.md
@@ -149,6 +149,7 @@ ssh dhcpv6-client
 
 To allow connections to Apache, add HTTP as a service:
 
+    sudo firewall-cmd --zone=public --add-service=http --permanent
     sudo firewall-cmd --zone=public --add-service=http
 
 ## MySQL / MariaDB


### PR DESCRIPTION
I added a section about FirewallD when reviewing this PR:

https://github.com/linode/docs/pull/1863

I then merged that PR into master. Afterwards, I realized that the FirewallD change I made only included instructions for the runtime firewall ruleset, and not the permanent ruleset. Updating that with this new PR.