### PR TITLE
Moved publish and modify date back by one day

### DIFF
--- a/docs/websites/cms/how-to-speed-up-a-wordpress-website/index.md
+++ b/docs/websites/cms/how-to-speed-up-a-wordpress-website/index.md
@@ -5,8 +5,8 @@ author:
 description: 'This guide shows how to analyze performance bottlenecks for a WordPress website and describes optimization best practices for WordPress'
 keywords: ["htaccess", "apache", "wordpress"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-published: 2018-06-27
-modified: 2018-06-27
+published: 2018-06-26
+modified: 2018-06-26
 modified_by:
   name: Linode
 title: 'How to Speed Up a WordPress Website'


### PR DESCRIPTION
The Speed Up WordPress guide was not appearing in websites/cms or in the search results, and we think this was because the publish date in the front matter was in the future when this guide was originally pushed to master