### PR TITLE
Add twisted version req

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -3,3 +3,4 @@ scrapy>=1.4.0
 pytest>=3.3.0
 tabulate>=0.8.2
 python-frontmatter>=0.4.2
+twisted==18.4.0


### PR DESCRIPTION
Added version requirement for Twisted, which is used by Scrapy.  Twisted released update on July 14th, which broke our docs404.py test.  