### PR TITLE
Fix YAML spacing in Salt-Cloud doc

### DIFF
--- a/docs/applications/configuration-management/configure-and-use-salt-cloud-and-cloud-maps-to-provision-systems/index.md
+++ b/docs/applications/configuration-management/configure-and-use-salt-cloud-and-cloud-maps-to-provision-systems/index.md
@@ -60,9 +60,9 @@ Configure and test access to the Linode API.
 
     {{< file "/etc/salt/cloud.providers.d/linode.conf" conf >}}
 linode-provider:
-    apikey: <Your API key>
-    password: <Default password for the new instances>
-        driver: linode
+  apikey: <Your API key>
+  password: <Default password for the new instances>
+  driver: linode
 {{< /file >}}
 
     {{< note >}}
@@ -120,10 +120,10 @@ For this example, create an instance with minimal size, using a CentOS 7 image, 
 
     {{< file "/etc/salt/cloud.profiles.d/linode-london-1024.conf" conf >}}
 linode_1024:
-    provider: linode-provider
-    size: Linode 1024
-    image: CentOS 7
-    location: London, England, UK
+  provider: linode-provider
+  size: Linode 1024
+  image: CentOS 7
+  location: London, England, UK
 {{< /file >}}
 
     You can use one file for all profiles, or use one file per instance profile. All files from `/etc/salt/cloud.profiles.d/` are read during execution.
@@ -134,7 +134,7 @@ linode_1024:
 
     {{< file "/etc/salt/cloud.conf.d/master.conf" >}}
 minion:
-    master: saltmaster.example.com
+  master: saltmaster.example.com
 {{< /file >}}
 
     Another option is to set this parameter for specific instance profile:
@@ -142,23 +142,23 @@ minion:
     {{< file "/etc/salt/cloud.profiles.d/linode-london-1024.conf" conf >}}
 linode_1024_with_master:
 provider: linode-provider
-    size: Linode 1024
-    image: CentOS 7
-    location: London, England, UK
-    minion:
-        master: mymaster.example.com
+  size: Linode 1024
+  image: CentOS 7
+  location: London, England, UK
+  minion:
+    master: mymaster.example.com
 {{< /file >}}
 
 3.  Set up [SSH key authentication](/docs/security/use-public-key-authentication-with-ssh/) for your instance. To do this during provisioning, set up the profile as follows, replacing the `ssh_pubkey` and `ssh_key_file` with key information for an SSH key on your master server:
 
     {{< file "/etc/salt/cloud.profiles.d/linode-london-1024.conf" conf >}}
 linode_1024_with_ssh_key:
-    provider: linode-provider
-    size: Linode 1024
-    image: CentOS 7
-    location: London, England, UK
-    ssh_pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHEOLLbeXgaqRQT9NBAopVz366SdYc0KKX33vAnq+2R user@host
-    ssh_key_file: ~/.ssh/id_ed25519
+  provider: linode-provider
+  size: Linode 1024
+  image: CentOS 7
+  location: London, England, UK
+  ssh_pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHEOLLbeXgaqRQT9NBAopVz366SdYc0KKX33vAnq+2R user@host
+  ssh_key_file: ~/.ssh/id_ed25519
 {{< /file >}}
 
     {{< note >}}
@@ -256,8 +256,8 @@ Get full information about instances using `-F` option:
 
     {{< file "/etc/salt/cloud.conf.d/query.conf" >}}
 query.selection:
-    - image
-    - size
+  - image
+  - size
 {{< /file >}}
 
 2.  Execute selective query using `-S` option:
@@ -299,8 +299,8 @@ In this example, Cloud map will define two instances: `linode_web` and `linode_d
 
     {{< file "/etc/salt/cloud.conf.d/linode.map" >}}
 linode_1024:
-    - linode_web
-    - linode_db
+  - linode_web
+  - linode_db
 {{< /file >}}
 
     Cloud map file allows you to define instances from several Linode accounts or even from a different provider. Check the [Cloud Map documentation](https://docs.saltstack.com/en/latest/topics/cloud/map.html) for an in-depth guide.


### PR DESCRIPTION
The config examples should be two spaces instead of a tab and `driver` in `/etc/salt/cloud.providers.d/linode.conf` is intended too far and will cause a block mapping error for salt-cloud commands:

```
a block mapping
  in "/etc/salt/cloud.providers.d/linode.conf", line 2, column 5
expected <block end>, but found '<block mapping start>'
  in "/etc/salt/cloud.providers.d/linode.conf", line 4, column 7
[ERROR   ] Error parsing configuration file: /etc/salt/cloud.providers.d/linode.conf - while parsing a block mapping
  in "/etc/salt/cloud.providers.d/linode.conf", line 2, column 5
expected <block end>, but found '<block mapping start>'
  in "/etc/salt/cloud.providers.d/linode.conf", line 4, column 7
[ERROR   ] Profile test_profile is not defined

```