### PR TITLE
Update dd command call in "Backup & Restore"

### DIFF
--- a/docs/security/encrypt-data-disk-with-dm-crypt/index.md
+++ b/docs/security/encrypt-data-disk-with-dm-crypt/index.md
@@ -170,7 +170,7 @@ Follow these steps very carefully.
 
 2.  Test a scenario where the LUKS header is accidentally overwritten:
 
-        dd if=/dev/zero of=/dev/sdX bs=128 count=1
+        dd conv=notrunc if=/dev/zero of=/dev/sdX bs=128 count=1
 
 3.  Trying to open your container will now return an error:
 


### PR DESCRIPTION
When following this guide, I ran into an issue where running the following command in "Backup & Restore" zeroed the entire block device:

> dd if=/dev/zero of=/dev/sdX bs=128 count=1

I updated the command to:

> dd conv=notrunc if=/dev/zero of=/dev/sdX bs=128 count=1

Using the updated command, only the header portion of the device is zeroed out and can be successfully restored from backup as per the rest of the example.