### PR TITLE
changed LetsEncrypt link to point to Linode's guide

### DIFF
--- a/docs/security/ssl/obtain-a-commercially-signed-tls-certificate/index.md
+++ b/docs/security/ssl/obtain-a-commercially-signed-tls-certificate/index.md
@@ -17,7 +17,7 @@ title: 'Obtain a Commercially Signed TLS Certificate'
 
 If you intend to host a publicly accessible website which will use HTTPS, then you will want to install a commercially signed TLS certificate so people visiting your site don't get warnings in their browser about an unsafe connection.
 
-The easiest method is to sign your certificate using [Let's Encrypt](https://letsencrypt.org/). The [CertBot](/docs/quick-answers/websites/secure-http-traffic-certbot/) tool makes obtaining and renewing certificates through Let's Encrypt extremely simple. However, this isn't a viable option for everyone.
+The easiest method is to sign your certificate using [Let's Encrypt](https://linode.com/docs/security/ssl/install-lets-encrypt-to-create-ssl-certificates/). The [CertBot](/docs/quick-answers/websites/secure-http-traffic-certbot/) tool makes obtaining and renewing certificates through Let's Encrypt extremely simple. However, this isn't a viable option for everyone.
 
 If you need [Domain Validation](https://en.wikipedia.org/wiki/Domain-validated_certificate) or [Extended Validation certificates](https://en.wikipedia.org/wiki/Extended_Validation_Certificate), you must create a Certificate Signing Request (CSR) for submission to a Certificate Authority (CA) such as Thawte or Verisign. This is the method for obtaining a signed TLS certificate that this guide focuses on.
 


### PR DESCRIPTION
Changed the LetsEncrypt link from pointing to the LetsEncrypt homepage, to pointing to Linode's guide on Let's Encrypt instead