### PR TITLE
linux-hardened kernel support was dropped.

### DIFF
--- a/docs/tools-reference/custom-kernels-distros/install-alpine-linux-on-your-linode/index.md
+++ b/docs/tools-reference/custom-kernels-distros/install-alpine-linux-on-your-linode/index.md
@@ -145,8 +145,8 @@ set default="Alpine Linux"
 set timeout=0
 
 menuentry "Alpine Linux" {
-    linux /vmlinuz-hardened root=/dev/sdb modules=sd-mod,usb-storage,ext4 console=ttyS0 quiet
-    initrd /initramfs-hardened
+    linux /vmlinuz-vanilla root=/dev/sdb modules=sd-mod,usb-storage,ext4 console=ttyS0 quiet
+    initrd /initramfs-vanilla
 }
 
 {{< /file >}}
@@ -205,9 +205,9 @@ features="ata ide scsi virtio base ext4"
 
     If you'll need other services, you can also add them now. The above is intended to serve as a starting point.
 
-7.  Install the [grsecurity](https://grsecurity.net/) kernel:
+7.  Install the kernel:
 
-        apk add linux-grsec
+        apk add linux-vanilla
 
 8.  Exit the chroot jail:
 


### PR DESCRIPTION
Alpine dropped support for grsec's hardened linux kernel. It is no longer part of the distribution.

see: https://git.alpinelinux.org/cgit/aports/commit/?id=94a65a421705eb0152c2a6cdeb0bffd269c58e97

from bellis@linode.com