### PR TITLE
sshd service restart - error

### DIFF
--- a/docs/security/securing-your-server/index.md
+++ b/docs/security/securing-your-server/index.md
@@ -202,7 +202,7 @@ You may want to leave password authentication enabled if you connect to your Lin
 
     If your init system is SystemV or Upstart (CentOS 6, Debian 7, Ubuntu 14.04):
 
-        sudo service ssh restart
+        sudo service sshd restart
 
 ### Use Fail2Ban for SSH Login Protection
 


### PR DESCRIPTION
sshd should be used instead of ssh in centos (I don't know about other distros