### PR TITLE
[New] Configure Apache with SaltStack

### DIFF
--- a/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
+++ b/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
@@ -17,7 +17,7 @@ external_resources:
 - '[Using Grains in SLS Modules](https://docs.saltstack.com/en/latest/topics/tutorials/states_pt3.html#using-grains-in-sls-modules)'
 ---
 
-Salt is a powerful configuration management tool. In this guide you will create Salt state files that are capable of installing and configuring Apache on Ubunutu 18.04, Debian 9, and CentOS 7.
+Salt is a powerful configuration management tool. In this guide you will create Salt state files that are capable of installing and configuring Apache on Ubunutu 18.04, Debian 9, or CentOS 7.
 
 ## Before You Begin
 
@@ -37,7 +37,7 @@ The steps in this guide require root privileges. Be sure to run the steps below 
 
         mkdir /srv/salt
 
-2.  Create a Salt top file in `/srv/salt` that will be Salt's entry point to the Apache configuration:
+1.  Create a Salt top file in `/srv/salt` that will be Salt's entry point to the Apache configuration:
 
     {{< file "/srv/salt/top.sls" yaml >}}
 base:
@@ -58,7 +58,7 @@ base:
 
         mkdir /srv/pillar
 
-2.  Create a Pillar top file. This top file references the `apache.sls` Pillar file that you will create in the next step:
+1.  Create a Pillar top file. This top file references the `apache.sls` Pillar file that you will create in the next step:
 
     {{< file "/srv/pillar/top.sls" yaml >}}
 base:
@@ -80,7 +80,7 @@ domain: example.com
 
     This directory will be accessible from your Salt state files at `salt://example.com`.
 
-2.  Create an `index.html` file for your website in the `/srv/salt/example.com` directory, substituting `example.com` for the folder name you chose in the previous step. You will use this file as a test to make sure your website is functioning correctly.
+1.  Create an `index.html` file for your website in the `/srv/salt/example.com` directory, substituting `example.com` for the folder name you chose in the previous step. You will use this file as a test to make sure your website is functioning correctly.
 
     {{< file "/srv/salt/example.com/index.html" html >}}
 <html>
@@ -126,7 +126,7 @@ This guide will be going through the process of creating the Apache for Debian a
 
 1.  Create a state file named `apache-debian.sls` in `/srv/salt` and open it in a text editor of your choice.
 
-2.  Instruct Salt to install the `apache2` package and start the `apache2` service:
+1.  Instruct Salt to install the `apache2` package and start the `apache2` service:
 
     {{< file "/srv/salt/apache-debian.sls" yaml >}}
 apache2:
@@ -138,8 +138,6 @@ apache2 Service:
     - enable: True
     - require:
       - pkg: apache2
-    - watch:
-      - file: /etc/apache2/sites-available/{{ pillar['domain'] }}.conf
 
 ...
 {{< /file >}}
@@ -186,7 +184,7 @@ Enable tune_apache:
 ...
 {{< /file >}}
 
-    This step takes the `tune_apache.conf` file you created in [Configuration Files](http://localhost:1313/docs/applications/configuration-management/configure-apache-with-salt-stack/#configuration-files) step and transfers it to your Salt minion. Then, Salt enables that configuration file with the [apache_conf module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_conf.html).
+    This step takes the `tune_apache.conf` file you created in the [Configuration Files](http://localhost:1313/docs/applications/configuration-management/configure-apache-with-salt-stack/#configuration-files) step and transfers it to your Salt minion. Then, Salt enables that configuration file with the [apache_conf module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_conf.html).
 
 1.  Create the necessary directories:
 
@@ -246,7 +244,7 @@ Enable tune_apache:
 
     This step uses Salt's [apache module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache.html), (not to be confused with the `apache_site` module used in the previous step), to create your site's virtual host configuration file. The `this` variable signifies what would traditionally be include with `VirtualHost` within angle brackets in an Apache configuration file: `<VirtualHost *:80>`.
 
-1.  Enable your new virtual host configuration file"
+1.  Enable your new virtual host configuration file:
 
     {{< file "/srv/salt/apache-debian.sls" yaml >}}
 ...
@@ -271,8 +269,13 @@ Enable tune_apache:
     - source: salt://{{ pillar['domain'] }}/index.html
 {{< /file >}}
 
-    Any changes made to your `index.html` file on your Salt master will be propigated to your minion.
+    Any changes made to your `index.html` file on your Salt master will be propagated to your minion.
 
+    {{< note >}}
+Since Salt is not watching configuration files for a change to trigger a restart for Apache, you may need to use the command below from your Salt master.
+
+    salt '*' apache.signal restart
+{{< /note >}}
 
 ### Complete State File
 The complete `apache-debian.sls` file looks like this:
@@ -286,8 +289,6 @@ apache2 Service:
     - enable: True
     - require:
       - pkg: apache2
-    - watch:
-      - file: /etc/apache2/sites-available/{{ pillar['domain'] }}.conf
 
 Turn Off KeepAlive:
   file.replace:

--- a/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
+++ b/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
@@ -6,7 +6,7 @@ description: 'Configure Apache on Ubuntu, Debian and CentOS with Salt Stack.'
 keywords: ['salt','stack','saltstack','apache','httpd','ubuntu','debian','centos']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-10-19
-modified: 2018-10-19
+modified: 2018-11-08
 modified_by:
   name: Linode
 title: "Configure Apache with Salt Stack"
@@ -50,7 +50,7 @@ base:
     - apache-centos
 {{< /file >}}
 
-    This top file uses [compound matching](https://docs.saltstack.com/en/latest/topics/targeting/compound.html) to target your minions by operating system using Salt Grains. This will allow Salt to choose the appropriate Apache configuration depending on the Linux distribution. These matchers could be extended to be even more specific. For instance, if you wanted to only target minions with the ID of `web-server` that are running on Ubuntu, you might type `web* and G@os:Ubuntu`.
+    This top file uses [compound matching](https://docs.saltstack.com/en/latest/topics/targeting/compound.html) to target your minions by operating system using Salt Grains. This will allow Salt to choose the appropriate Apache configuration depending on the Linux distribution. These matchers could be extended to be even more specific. For instance, if you wanted to only target minions with the ID of `web-server` that are running on Ubuntu, you can type `web* and G@os:Ubuntu`.
 
 ### Pillar Files
 

--- a/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
+++ b/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
@@ -17,7 +17,7 @@ external_resources:
 - '[Using Grains in SLS Modules](https://docs.saltstack.com/en/latest/topics/tutorials/states_pt3.html#using-grains-in-sls-modules)'
 ---
 
-Salt is a powerful configuration management tool. In this guide you will create Salt state files that are capable of installing and configuring Apache on Ubunutu 18.04, Debian 9, or CentOS 7.
+Salt is a powerful configuration management tool. In this guide you will create Salt state files that are capable of installing and configuring Apache on Ubuntu 18.04, Debian 9, or CentOS 7.
 
 ## Before You Begin
 

--- a/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
+++ b/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
@@ -1,6 +1,6 @@
 ---
 author:
-  name: Linode Community
+  name: Linode
   email: docs@linode.com
 description: 'Configure Apache on Ubuntu, Debian and CentOS with Salt Stack.'
 keywords: ['salt','stack','saltstack','apache','httpd','ubuntu','debian','centos']
@@ -13,11 +13,11 @@ title: "Configure Apache with Salt Stack"
 external_resources:
 - '[Salt Apache State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache.html)'
 - '[Salt Apache_Conf State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_conf.html)'
-- '[Salt Apahce_Site State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_site.html)'
+- '[Salt Apache_Site State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_site.html)'
 - '[Using Grains in SLS Modules](https://docs.saltstack.com/en/latest/topics/tutorials/states_pt3.html#using-grains-in-sls-modules)'
 ---
 
-Salt is a powerful configuration management tool. In this guide we will create a Salt state file that is capable of installing and configuring Apache on Ubunutu 18.04, Debian 9, and CentOS 7.
+Salt is a powerful configuration management tool. In this guide you will create Salt state files that are capable of installing and configuring Apache on Ubunutu 18.04, Debian 9, and CentOS 7.
 
 ## Before You Begin
 
@@ -29,27 +29,58 @@ The following steps will be performed on your Salt master.
 The steps in this guide require root privileges. Be sure to run the steps below as `root` or with the `sudo` prefix. For more information on privileges, see our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
-## Set Up
+## Setting Up Your Salt Master and Managed Files
+
+### Salt Master SLS Files
 
 1.  Create the `/srv/salt` directory if it does not already exist:
 
         mkdir /srv/salt
 
-1.  Create a top file in `/srv/salt` that will be Salt's entry point to the Apache configuration:
+2.  Create a Salt top file in `/srv/salt` that will be Salt's entry point to the Apache configuration:
 
     {{< file "/srv/salt/top.sls" yaml >}}
+base:
+  'G@os_family:Debian':
+    - match: compound
+    - apache-debian
+
+  'G@os:CentOS':
+    - match: compound
+    - apache-centos
+{{< /file >}}
+
+    This top file uses [compound matching](https://docs.saltstack.com/en/latest/topics/targeting/compound.html) to target your minions by operating system using Salt Grains. This will allow Salt to choose the appropriate Apache configuration depending on the Linux distribution. These matchers could be extended to be even more specific. For instance, if you wanted to only target minions with the ID of `web-server` that are running on Ubuntu, you might type `web* and G@os:Ubuntu`.
+
+### Pillar Files
+
+1.  Create the `/srv/pillar` directory if it does not already exist:
+
+        mkdir /srv/pillar
+
+2.  Create a Pillar top file. This top file references the `apache.sls` Pillar file that you will create in the next step:
+
+    {{< file "/srv/pillar/top.sls" yaml >}}
 base:
   '*':
     - apache
 {{< /file >}}
 
-1.  Create a directory for your website files in the `/srv/salt` directory. You can choose to name this folder anything, but we will be using `example.com`:
+1.  Create the `apache.sls` file that was referenced in the previous step. This file defines Pillar data that will be used inside our Apache state file in the next section, in this case your domain name. Replace `example.com` with your domain:
+
+    {{< file "/srv/pillar/apache.sls" yaml >}}
+domain: example.com
+{{< /file >}}
+
+### Website Files
+
+1.  Create a directory for your website files in the `/srv/salt` directory. Replace `example.com` with your website domain name:
 
         mkdir /srv/salt/example.com
 
     This directory will be accessible from your Salt state files at `salt://example.com`.
 
-1.  Create an `index.html` file for your website in the `/srv/salt/example.com` directory, substituting `example.com` for the folder name you chose in the previous step. You will use this file as a test to make sure your website is functioning correctly.
+2.  Create an `index.html` file for your website in the `/srv/salt/example.com` directory, substituting `example.com` for the folder name you chose in the previous step. You will use this file as a test to make sure your website is functioning correctly.
 
     {{< file "/srv/salt/example.com/index.html" html >}}
 <html>
@@ -59,382 +90,517 @@ base:
 </html>
 {{< /file >}}
 
-## Creating the Apache State File
+### Configuration Files
 
-We will be going through the process of creating the Apache state file step by step. If you would like to view the entirety of the state file, scroll down to the bottom of this section.
+1.  Create a folder for your additional configuration files at `/srv/salt/files`. These files will be accessible at `salt://files`.
 
-1.  Create a state file named `apache.sls` in `/srv/salt` and open it in a text editor.
+        mkdir /srv/salt/files
 
-2.  Begin by declaring the Jinja variables that you'll be using in `apache.sls`:
+1.  Create a file called `tune_apache.conf` in `/srv/salt/files` and paste in the following block:
 
-    {{< file "/srv/salt/apache.sls" yaml >}}
-{% set domain = 'example.com' %}
-{% set debian = ['Debian', 'Ubuntu'] %}
+    {{< file "/srv/salt/files/tune_apache.conf" ApacheConf >}}
+<IfModule mpm_prefork_module>
+StartServers 4
+MinSpareServers 20
+MaxSpareServers 40
+MaxClients 200
+MaxRequestsPerChild 4500
+</IfModule>
+{{</ file >}}
 
-...
+    This MPM prefork module provides additional [tuning for your Apache installation](https://www.linode.com/docs/web-servers/apache-tips-and-tricks/tuning-your-apache-server/). This file will be managed by Salt and installed into the appropriate configuration directory in a later step.
+
+1.  If you will be installing Apache on a CentOS machine, create a file called `include_sites_enabled.conf` in `/srv/salt/files` and paste in the following:
+
+    {{< file "/srv/salt/files/include_sites_enabled.conf" ApacheConf >}}
+IncludeOptional sites-enabled/*.conf
 {{< /file >}}
 
-    The first variable is your website's domain name. This domain name will be used to configure an Apache virtual host and Apache's directory structure. Don't worry if you don't have your domain name DNS set up just yet, you will still be able access your server by its IP address.
+    This file will allow us to use file directories like those found on Debian installations to help organize the Apache configuration.
 
-    The second variable is an array of Linux distributions that share the same Apache installation steps, in this case Debian and Ubuntu. This variable will be used throughout `apache.sls` to determine our Apache installation logic.
+## Creating the Apache State File for Debian and Ubuntu
 
-1.  Instruct Salt to install the Apache package and ensure that Apache is running:
+### Individual Steps
 
-    {{< file "/srv/salt/apache.sls" yaml >}}
-...
+This guide will be going through the process of creating the Apache for Debian and Ubuntu state file step by step. If you would like to view the entirety of the state file, [you can view it at the end of this section](http://localhost:1313/docs/applications/configuration-management/configure-apache-with-salt-stack/#complete-state-file).
 
-{% if grains['os'] in debian %}
+1.  Create a state file named `apache-debian.sls` in `/srv/salt` and open it in a text editor of your choice.
+
+2.  Instruct Salt to install the `apache2` package and start the `apache2` service:
+
+    {{< file "/srv/salt/apache-debian.sls" yaml >}}
 apache2:
-{% else %}
-httpd:
-{% endif %}
-  pkg.installed: []
-  service.running: []
+  pkg.installed
+
+apache2 Service:
+  service.running:
+    - name: apache2
+    - enable: True
+    - require:
+      - pkg: apache2
+    - watch:
+      - file: /etc/apache2/sites-available/{{ pillar['domain'] }}.conf
 
 ...
 {{< /file >}}
 
-    This step uses a Jinja `if` statement and Salt grains to determine whether to install the `apache2` package on Debian-based systems, or to install the `httpd` package on CentOS systems. This pattern will be used throughout `apache.sls` to ensure that the script takes the proper actions.
+    Here Salt makes sure the `apache2` package is installed with `pkg.installed`. Likewise, it ensures the `apache2` service is running and enabled under `service.running`. Also under `service.running`, `apache-debian.sls` uses `require` to ensure that this command does not run before the `apache2` package is installed. This `require` step will be repeated throughout `apache-debain.sls`.
 
-1.  Tune your Apache configuration to run more optimally on your Linode by instructing salt to alter the Apache configuration file. For more information on tuning your Apache server, [visit our guide on the subject](https://www.linode.com/docs/web-servers/apache-tips-and-tricks/tuning-your-apache-server/).
+    Lastly, a `watch` statement is employed to restart the `apache2` service if your site's configuration file changes. You will define that configuration file in a later step. Note that this configuration file is named using the domain you supplied when creating your Salt Pillar file in the first section. This Pillar data will be used throughout `apache-debian.sls`.
 
-    {{< file "/srv/salt/apache.sls" yaml >}}
+1.  Turn off KeepAlive:
+
+    {{< file "/srv/salt/apache-debian.sls" yaml >}}
 ...
 
-Turn off KeepAlive:
+Turn Off KeepAlive:
   file.replace:
-  {% if grains['os'] in debian %}
     - name: /etc/apache2/apache2.conf
-  {% else %}
-    - name: /etc/httpd/conf/httpd.conf
-  {% endif %}
     - pattern: 'KeepAlive On'
     - repl: 'KeepAlive Off'
     - show_changes: True
+    - require:
+      - pkg: apache2
+...
+{{< /file >}}
 
-Append mpm_prefork module and on CentOS include /sites-enabled:
-  file.append:
-  {% if grains['os'] in debian %}
-    - name: /etc/apache2/apache2.conf
-  {% else %}
-    - name: /etc/httpd/conf/httpd.conf
-  {% endif %}
-    - text: |
-      {% if grains['os'] not in debian %}
-        IncludeOptional sites-enabled/*.conf
-      {% endif %}
-        <IfModule mpm_prefork_module>
-        StartServers 4
-        MinSpareServers 20
-        MaxSpareServers 40
-        MaxClients 200
-        MaxRequestsPerChild 4500
-        </IfModule>
+    KeepAlive allows multiple requests to be sent over the same TCP connection. For the purpose of this guide KeepAlive will be disabled. To disable it, Salt is instructed to find the KeepAlive directive in `/etc/apache2/apache2.conf` by matching a pattern and replacing it with `KeepAlive Off`. `show_changes` instructs Salt to display any changes it has made during a highstate.
+
+1.  Transfer `tune_apache.conf` to your minion and enable it:
+
+    {{< file "/srv/salt/apache-debian.sls" yaml >}}
+...
+
+/etc/apache2/conf-available/tune_apache.conf:
+  file.managed:
+    - source: salt://files/tune_apache.conf
+    - require:
+      - pkg: apache2
+
+Enable tune_apache:
+  apache_conf.enabled:
+    - name: tune_apache
+    - require:
+      - pkg: apache2
 
 ...
 {{< /file >}}
 
-     Here Jinja `if` statements are used to select the proper Apache configuration file, as the location of this file differs depending on the Linux distribution. `apache.sls` instructs Salt to find and change the `KeepAlive On` directive to `KeepAlive Off` using `file.replace`. Then, it uses `file.append` to append an MPM prefork module to the end of the Apache configuration file. Also, on CentOS systems, this step adds the `IncludeOptional` directive to ensure that Apache can find our configuration file in the `sites-enabled/` directory.
-
-1.  Change the document root for CentOS to match a Debian document root:
-
-    {{< file "/srv/salt/apache.sls" yaml >}}
-...
-
-{% if grains['os'] not in debian %}
-Change DocumentRoot:
-  file.replace:
-    - name: /etc/httpd/conf/httpd.conf
-    - pattern: 'DocumentRoot "/var/www/html"'
-    - repl: 'DocumentRoot "/var/www/html/{{ domain }}/public_html"'
-    - show_changes: True
-{% endif %}
-
-...
-{{< /file >}}
-
-    While this step is not typical for a CentOS Apache installation, it is a practice introduced on Debian distributions that helps to organize website files. Note that we include the Jinja `{{ domain }}` variable that we declared in step one as a folder in the DocumentRoot. We will create this folder in the next step.
+    This step takes the `tune_apache.conf` file you created in [Configuration Files](http://localhost:1313/docs/applications/configuration-management/configure-apache-with-salt-stack/#configuration-files) step and transfers it to your Salt minion. Then, Salt enables that configuration file with the [apache_conf module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_conf.html).
 
 1.  Create the necessary directories:
 
-    {{< file "/srv/salt/apache.sls" yaml >}}
+    {{< file "/srv/salt/apache-debian.sls" yaml>}}
 ...
 
-{% if grains['os'] not in debian %}
-/etc/httpd/sites-available:
+/var/www/html/{{ pillar['domain'] }}:
   file.directory
 
-/etc/httpd/sites-enabled:
-  file.directory
-{% endif %}
-
-/var/www/html/{{ domain }}:
+/var/www/html/{{ pillar['domain'] }}/log:
   file.directory
 
-/var/www/html/{{ domain }}/log:
+/var/www/html/{{ pillar['domain'] }}/backups:
   file.directory
 
-/var/www/html/{{ domain }}/backups:
-  file.directory
-
-/var/www/html/{{ domain }}/public_html:
+/var/www/html/{{ pillar['domain'] }}/public_html:
   file.directory
 
 ...
 {{< /file >}}
 
-    For a CentOS installations `apache.sls` instructs Salt to create the `sites-available` and `sites-enabled` directories. Then, it instructs Salt to create the `log`, `backups`, and `public_html` directories in the `/var/www/html/example.com` directory.
+1.  Disable the default virtual host configuration file:
 
-1.  Disable the default virtual host configuration on Debian based distributions:
-
-    {{< file "/srv/salt/apache.sls" yaml >}}
+    {{< file "/srv/salt/apache-debian.sls" yaml >}}
 ...
 
-{% if grains['os'] in debian %}
 000-default:
-  apache_site.disabled
-{% endif %}
+  apache_site.disabled:
+    - require:
+      - pkg: apache2
 
 ...
 {{< /file >}}
 
-    Debian based systems have access to the `apache_site` Salt state module, which is used to disable and enable site configurations.
+    This step uses Salt's [apache_site module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_site.html) to disable the default Apache virtual host configuration file, and is the same as running `a2dissite` on a Debian-based machine.
 
-1.  Set up the Apache virtual host configuration file and enable it:
+1.  Create your site's virtual host configuration file:
 
-    {{< file "/srv/salt/apache.sls" yaml >}}
+    {{< file "/srv/salt/apache-debian.sls" yaml >}}
 ...
 
-{% if grains['os'] in debian %}
-/etc/apache2/sites-available/{{ domain }}.conf:
-{% else %}
-/etc/httpd/sites-available/{{ domain }}.conf:
-{% endif %}
+/etc/apache2/sites-available/{{ pillar['domain'] }}.conf:
   apache.configfile:
     - config:
       - VirtualHost:
           this: '*:80'
           ServerName:
-            - {{ domain }}
+            - {{ pillar['domain'] }}
           ServerAlias:
-            - www.{{ domain }}
-          DocumentRoot: /var/www/html/{{ domain }}/public_html
-          ErrorLog: /var/www/html/{{ domain }}/log/error.log
-          CustomLog: /var/www/html/{{ domain }}/log/access.log combined
-{% if grains['os'] not in debian %}
-  file.symlink:
-    - target: /etc/httpd/sites-enabled/{{ domain }}.conf
-    - force: True
-{% endif %}
-
-{% if grains['os'] in debian %}
-example.com:
-  apache_site.enabled
-{% endif %}
+            - www.{{ pillar['domain'] }}
+          DocumentRoot: /var/www/html/{{ pillar['domain'] }}/public_html
+          ErrorLog: /var/www/html/{{ pillar['domain'] }}/log/error.log
+          CustomLog: /var/www/html/{{ pillar['domain'] }}/log/access.log combined
 
 ...
 {{< /file >}}
 
-    This section uses the `apache` Salt state module to configure your website's virtual host. The `this` variable signifies what would traditionally be include with `VirtualHost` within angle brackets in an Apache configuration file: `<VirtualHost *:80>`
+    This step uses Salt's [apache module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache.html), (not to be confused with the `apache_site` module used in the previous step), to create your site's virtual host configuration file. The `this` variable signifies what would traditionally be include with `VirtualHost` within angle brackets in an Apache configuration file: `<VirtualHost *:80>`.
 
-    On CentOS systems `apache.sls` instructs Salt to manually create a symlink of the virtual host configuration file located in `sites-available/` in `sites-enabled/`, whereas on Debian based systems `apache.sls` uses the `apache_site` state module to accomplish the same task.
+1.  Enable your new virtual host configuration file"
 
-1.  Transfer `index.html` to the minion:
-
-    {{< file "/srv/salt/apache.sls" yaml >}}
+    {{< file "/srv/salt/apache-debian.sls" yaml >}}
 ...
 
-/var/www/html/{{ domain }}/public_html/index.html:
+{{ pillar['domain'] }}:
+  apache_site.enabled:
+    - require:
+      - pkg: apache2
+
+...
+{{< /file >}}
+
+    This step uses the same `apache_site` module you used to disable the default virtual host file to enable your newly created virtual host file. `apache_site.enabled` creates a symlink from `/etc/apache2/sites-available/example.com.conf` to `/etc/apache2/sites-enabled/example.com.conf` and is the same as running `a2ensite` on a Debian-based machine.
+
+1.  Transfer your `index.html` website file to your minion:
+
+    {{< file "/srv/salt/apache-debian.sls" yaml >}}
+...
+
+/var/www/html/{{ pillar['domain'] }}/public_html/index.html:
   file.managed:
-    - source: salt://{{ domain }}/index.html
-
-...
+    - source: salt://{{ pillar['domain'] }}/index.html
 {{< /file >}}
 
-    This section manages the `index.html` file that was created to test your Salt configuration in `/srv/salt/example.com`, here accessed through the convenience method `salt://`. Any changes made to `index.html` on the Salt master will be transferred to the Salt minion on `state.apply`.
+    Any changes made to your `index.html` file on your Salt master will be propigated to your minion.
 
-1.  Open the proper ports on CentOS:
 
-    {{< file "/srv/salt/apache.sls" yaml >}}
-...
-
-{% if grains['os'] not in debian %}
-public:
-  firewalld.present:
-    - name: public
-    - ports:
-      - 22/tcp
-      - 80/tcp
-      - 443/tcp
-{% endif %}
-
-...
-{{< /file >}}
-
-    This command opens ports 80 and 443 for HTTP and HTTPS traffic, respectively. It also keeps the SSH port 22 open.
-
-    {{< note >}}
-Ensure that you declare all the ports you wish to remain open on your machine in this section. Failure to declare those ports will result in those ports being closed.
-{{< /note >}}
-
-1.  Manage SELinux on CentOS:
-
-    {{< file "/srv/salt/apache.sls" yaml >}}
-...
-
-{% if grains['os'] not in debian %}
-'semanage fcontext -a -t httpd_log_t "/var/www/html/{{ domain }}/.*\.log.*" && restorecon -R -v /var/www/html/{{ domain }}':
-  cmd.run
-{% endif %}
-
-...
-{{< /file >}}
-
-    This section is necessary for CentOS installations to allow Apache to access a non-default error and access log directory.
-
-1.  Lastly, instruct Salt to restart the Apache service for your changes to take place:
-
-    {{< file "/srv/salt/apache.sls" yaml >}}
-...
-
-{% if grains['os'] in debian %}
-'systemctl restart apache2.service':
-{% else %}
-'systemctl restart httpd.service':
-{% endif %}
-  cmd.run
-{{< /file >}}
-
-In summary, here is the entire state file you just created:
-
-{{< file "/srv/salt/apache.sls" yaml >}}
-{% set domain = 'example.com' %}
-{% set debian = ['Debian', 'Ubuntu'] %}
-
-{% if grains['os'] in debian %}
+### Complete State File
+The complete `apache-debian.sls` file looks like this:
+{{< file "/srv/salt/apache-debian.sls" yaml >}}
 apache2:
-{% else %}
-httpd:
-{% endif %}
-  pkg.installed: []
-  service.running: []
+  pkg.installed
 
-Turn off KeepAlive:
+apache2 Service:
+  service.running:
+    - name: apache2
+    - enable: True
+    - require:
+      - pkg: apache2
+    - watch:
+      - file: /etc/apache2/sites-available/{{ pillar['domain'] }}.conf
+
+Turn Off KeepAlive:
   file.replace:
-  {% if grains['os'] in debian %}
     - name: /etc/apache2/apache2.conf
-  {% else %}
-    - name: /etc/httpd/conf/httpd.conf
-  {% endif %}
     - pattern: 'KeepAlive On'
     - repl: 'KeepAlive Off'
     - show_changes: True
+    - require:
+      - pkg: apache2
 
-Append mpm_prefork module and on CentOS include /sites-enabled:
-  file.append:
-  {% if grains['os'] in debian %}
-    - name: /etc/apache2/apache2.conf
-  {% else %}
+/etc/apache2/conf-available/tune_apache.conf:
+  file.managed:
+    - source: salt://files/tune_apache.conf
+    - require:
+      - pkg: apache2
+
+Enable tune_apache:
+  apache_conf.enabled:
+    - name: tune_apache
+    - require:
+      - pkg: apache2
+
+/var/www/html/{{ pillar['domain'] }}:
+  file.directory
+
+/var/www/html/{{ pillar['domain'] }}/log:
+  file.directory
+
+/var/www/html/{{ pillar['domain'] }}/backups:
+  file.directory
+
+/var/www/html/{{ pillar['domain'] }}/public_html:
+  file.directory
+
+000-default:
+  apache_site.disabled:
+    - require:
+      - pkg: apache2
+
+/etc/apache2/sites-available/{{ pillar['domain'] }}.conf:
+  apache.configfile:
+    - config:
+      - VirtualHost:
+          this: '*:80'
+          ServerName:
+            - {{ pillar['domain'] }}
+          ServerAlias:
+            - www.{{ pillar['domain'] }}
+          DocumentRoot: /var/www/html/{{ pillar['domain'] }}/public_html
+          ErrorLog: /var/www/html/{{ pillar['domain'] }}/log/error.log
+          CustomLog: /var/www/html/{{ pillar['domain'] }}/log/access.log combined
+
+{{ pillar['domain'] }}:
+  apache_site.enabled:
+    - require:
+      - pkg: apache2
+
+/var/www/html/{{ pillar['domain'] }}/public_html/index.html:
+  file.managed:
+    - source: salt://{{ pillar['domain'] }}/index.html
+{{< /file >}}
+
+## Creating an Apache State File for CentOS
+
+### Individual Steps
+
+1.  Create a file called `apache-centos.sls` in `/srv/salt` and open it in a text editor of your choice.
+
+2.  On CentOS Apache is named `httpd`. Instruct Salt to install `httpd` and run the `httpd` service:
+
+    {{< file "/srv/salt/apache-centos.sls" yaml>}}
+httpd:
+  pkg.installed
+
+httpd Service:
+  service.running:
+    - name: httpd
+    - enable: True
+    - require:
+      - pkg: httpd
+    - watch:
+      - file: /etc/httpd/sites-available/{{ pillar['domain'] }}.conf
+
+...
+{{< /file >}}
+
+    Here Salt makes sure the `httpd` package is installed with `pkg.installed`. Likewise, it ensures the `httpd` service is running and enabled under `service.running`. Also under `service.running`, `apache-debian.sls` uses `require` to ensure that this command does not run before the `httpd` package is installed. This `require` step will be repeated throughout `apache-centos.sls`.
+
+    Lastly, a `watch` statement is employed to restart the `httpd` service if your site’s configuration file changes. You will define that configuration file in a later step. Note that this configuration file is named using the domain you supplied when creating your Salt Pillar file in the first section. This Pillar data will be used throughout `apache-centos.sls`.
+
+1.  Turn off KeepAlive:
+
+    {{< file "/srv/salt/apache-centos.sls" yaml >}}
+...
+
+Turn Off KeepAlive:
+  file.replace:
     - name: /etc/httpd/conf/httpd.conf
-  {% endif %}
-    - text: |
-      {% if grains['os'] not in debian %}
-        IncludeOptional sites-enabled/*.conf
-      {% endif %}
-        <IfModule mpm_prefork_module>
-        StartServers 4
-        MinSpareServers 20
-        MaxSpareServers 40
-        MaxClients 200
-        MaxRequestsPerChild 4500
-        </IfModule>
+    - pattern: 'KeepAlive On'
+    - repl: 'KeepAlive Off'
+    - show_changes: True
+    - require:
+      - pkg: httpd
+...
+{{< /file >}}
 
-{% if grains['os'] not in debian %}
+    KeepAlive allows multiple requests to be sent over the same TCP connection. For the purpose of this guide KeepAlive will be disabled. To disable it, Salt is instructed to find the KeepAlive directive in `/etc/httpd/conf/httpd.conf` by matching a pattern and replacing it with `KeepAlive Off`. `show_changes` instructs Salt to display any changes it has made during a highstate.
+
+1.  Change the DocumentRoot:
+
+    {{< file "/srv/salt/apache-centos.sls" yaml >}}
+...
+
 Change DocumentRoot:
   file.replace:
     - name: /etc/httpd/conf/httpd.conf
     - pattern: 'DocumentRoot "/var/www/html"'
-    - repl: 'DocumentRoot "/var/www/html/{{ domain }}/public_html"'
+    - repl: 'DocumentRoot "/var/www/html/{{ pillar['domain'] }}/public_html"'
     - show_changes: True
-{% endif %}
+    - require:
+      - pkg: httpd
 
-{% if grains['os'] not in debian %}
+...
+{{< /file >}}
+
+    Similar to the last step, in this step `salt-centos.sls` instructs Salt to search for the DocumentRoot directive in Apache's `httpd.conf` file, and replaces that line with the new document root. This allows for the use of a Debian-style site directory architecture.
+
+1.  Transfer the `tune_apache.conf` and `include_sites_enabled.conf` to your minion.
+
+    {{< file "/srv/salt/apache-centos.sls" yaml>}}
+...
+
+/etc/httpd/conf.d/tune_apache.conf:
+  file.managed:
+    - source: salt://files/tune_apache.conf
+    - require:
+      - pkg: httpd
+
+/etc/httpd/conf.d/include_sites_enabled.conf:
+  file.managed:
+    - source: salt://files/include_sites_enabled.conf
+    - require:
+      - pkg: httpd
+
+...
+{{< /file >}}
+
+1.  Create the necessary directories:
+
+    {{< file "srv/salt/apache-centos.sls" yaml >}}
+...
+
 /etc/httpd/sites-available:
   file.directory
 
 /etc/httpd/sites-enabled:
   file.directory
-{% endif %}
 
-/var/www/html/{{ domain }}:
+/var/www/html/{{ pillar['domain'] }}:
   file.directory
 
-/var/www/html/{{ domain }}/log:
+/var/www/html/{{ pillar['domain'] }}/backups:
   file.directory
 
-/var/www/html/{{ domain }}/backups:
+/var/www/html/{{ pillar['domain'] }}/public_html:
   file.directory
 
-/var/www/html/{{ domain }}/public_html:
-  file.directory
+...
+{{< /file >}}
 
-{% if grains['os'] in debian %}
-000-default:
-  apache_site.disabled
-{% endif %}
+1.  Create your site's virtual host configuration file:
 
-{% if grains['os'] in debian %}
-/etc/apache2/sites-available/{{ domain }}.conf:
-{% else %}
-/etc/httpd/sites-available/{{ domain }}.conf:
-{% endif %}
+    {{< file "/srv/salt/apache-centos.sls" yaml>}}
+...
+
+/etc/httpd/sites-available/{{ pillar['domain'] }}.conf:
   apache.configfile:
     - config:
       - VirtualHost:
           this: '*:80'
           ServerName:
-            - {{ domain }}
+            - {{ pillar['domain'] }}
           ServerAlias:
-            - www.{{ domain }}
-          DocumentRoot: /var/www/html/{{ domain }}/public_html
-          ErrorLog: /var/www/html/{{ domain }}/log/error.log
-          CustomLog: /var/www/html/{{ domain }}/log/access.log combined
-{% if grains['os'] not in debian %}
+            - www.{{ pillar['domain'] }}
+          DocumentRoot: /var/www/html/{{ pillar['domain'] }}/public_html
   file.symlink:
-    - target: /etc/httpd/sites-enabled/{{ domain }}.conf
+    - target: /etc/httpd/sites-enabled/{{ pillar['domain'] }}.conf
     - force: True
-{% endif %}
 
-{% if grains['os'] in debian %}
-example.com:
-  apache_site.enabled
-{% endif %}
+...
+{{< /file >}}
 
-/var/www/html/{{ domain }}/public_html/index.html:
+    This step uses Salt's [apache module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache.html) to create your site's virtual host configuration file. The `this` variable signifies what would traditionally be include with `VirtualHost` within angle brackets in an Apache configuration file: `<VirtualHost *:80>`.
+
+1.  Transfer your `index.html` website file to your minion:
+
+    {{< file "/srv/salt/apache-debian.sls" yaml >}}
+...
+
+/var/www/html/{{ pillar['domain'] }}/public_html/index.html:
   file.managed:
-    - source: salt://{{ domain }}/index.html
+    - source: salt://{{ pillar['domain'] }}/index.html
 
-{% if grains['os'] not in debian %}
-public:
+...
+{{< /file >}}
+
+    Any changes made to your `index.html` file on your Salt master will be propigated to your minion.
+
+1.  Configure your firewall to allow http and https traffic:
+
+    {{< file "/srv/salt/apache-centos.sls" yaml >}}
+...
+
+Configure Firewall:
   firewalld.present:
     - name: public
     - ports:
       - 22/tcp
       - 80/tcp
       - 443/tcp
-{% endif %}
+{{< /file >}}
 
-{% if grains['os'] not in debian %}
-'semanage fcontext -a -t httpd_log_t "/var/www/html/{{ domain }}/.*\.log.*" && restorecon -R -v /var/www/html/{{ domain }}':
-  cmd.run
-{% endif %}
+    {{< note >}}
+It is imperative that you list all ports you need open to your machine in this section. Failure to list these ports will result in their closure by Salt.
+{{< /note >}}
 
-{% if grains['os'] in debian %}
-'systemctl restart apache2.service':
-{% else %}
-'systemctl restart httpd.service':
-{% endif %}
-  cmd.run
+### Complete State File
+
+The complete `apache-centos.sls` file looks like this:
+
+   {{< file "/srv/salt/apache-centos.sls" yaml >}}
+httpd:
+  pkg.installed
+
+httpd Service:
+  service.running:
+    - name: httpd
+    - enable: True
+    - require:
+      - pkg: httpd
+    - watch:
+      - file: /etc/httpd/sites-available/{{ pillar['domain'] }}.conf
+
+Turn off KeepAlive:
+  file.replace:
+    - name: /etc/httpd/conf/httpd.conf
+    - pattern: 'KeepAlive On'
+    - repl: 'KeepAlive Off'
+    - show_changes: True
+    - require:
+      - pkg: httpd
+
+Change DocumentRoot:
+  file.replace:
+    - name: /etc/httpd/conf/httpd.conf
+    - pattern: 'DocumentRoot "/var/www/html"'
+    - repl: 'DocumentRoot "/var/www/html/{{ pillar['domain'] }}/public_html"'
+    - show_changes: True
+    - require:
+      - pkg: httpd
+
+/etc/httpd/conf.d/tune_apache.conf:
+  file.managed:
+    - source: salt://files/tune_apache.conf
+    - require:
+      - pkg: httpd
+
+/etc/httpd/conf.d/include_sites_enabled.conf:
+  file.managed:
+    - source: salt://files/include_sites_enabled.conf
+    - require:
+      - pkg: httpd
+
+/etc/httpd/sites-available:
+  file.directory
+
+/etc/httpd/sites-enabled:
+  file.directory
+
+/var/www/html/{{ pillar['domain'] }}:
+  file.directory
+
+/var/www/html/{{ pillar['domain'] }}/backups:
+  file.directory
+
+/var/www/html/{{ pillar['domain'] }}/public_html:
+  file.directory
+
+/etc/httpd/sites-available/{{ pillar['domain'] }}.conf:
+  apache.configfile:
+    - config:
+      - VirtualHost:
+          this: '*:80'
+          ServerName:
+            - {{ pillar['domain'] }}
+          ServerAlias:
+            - www.{{ pillar['domain'] }}
+          DocumentRoot: /var/www/html/{{ pillar['domain'] }}/public_html
+  file.symlink:
+    - target: /etc/httpd/sites-enabled/{{ pillar['domain'] }}.conf
+    - force: True
+
+/var/www/html/{{ pillar['domain'] }}/public_html/index.html:
+  file.managed:
+    - source: salt://{{ pillar['domain'] }}/index.html
+
+Configure Firewall:
+  firewalld.present:
+    - name: public
+    - ports:
+      - 22/tcp
+      - 80/tcp
+      - 443/tcp
 {{< /file >}}
 
 ## Running the Apache State File
@@ -443,4 +609,4 @@ On your Salt master, issue a highstate command:
 
     salt '*' state.apply
 
-After a few seconds you should see a list of the above commands and a summary of their successes. Navigate to your website's domain name if you have your DNS set up already, or your websites's public IP address. You should see your `index.html` file. You have now used Salt to configure Apache. Visit the links in the section below for more information.
+After a few moments you should see a list of Salt commands and a summary of their successes. Navigate to your website's domain name if you have your DNS set up already, or your website's public IP address. You should see your `index.html` file. You have now used Salt to configure Apache. Visit the links in the section below for more information.

--- a/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
+++ b/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
@@ -1,0 +1,446 @@
+---
+author:
+  name: Linode Community
+  email: docs@linode.com
+description: 'Configure Apache on Ubuntu, Debian and CentOS with Salt Stack.'
+keywords: ['salt','stack','saltstack','apache','httpd','ubuntu','debian','centos']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2018-10-19
+modified: 2018-10-19
+modified_by:
+  name: Linode
+title: "Configure Apache with Salt Stack"
+external_resources:
+- '[Salt Apache State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache.html)'
+- '[Salt Apache_Conf State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_conf.html)'
+- '[Salt Apahce_Site State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_site.html)'
+- '[Using Grains in SLS Modules](https://docs.saltstack.com/en/latest/topics/tutorials/states_pt3.html#using-grains-in-sls-modules)'
+---
+
+Salt is a powerful configuration management tool. In this guide we will create a Salt state file that is capable of installing and configuring Apache on Ubunutu 18.04, Debian 9, and CentOS 7.
+
+## Before You Begin
+
+You will need at least two Linodes with Salt installed. If you have not already, read our [Getting Started with Salt - Basic Installation and Setup Guide](https://www.linode.com/docs/applications/configuration-management/getting-started-with-salt-basic-installation-and-setup/) and follow the instructions for setting up a Salt master and minion.
+
+The following steps will be performed on your Salt master.
+
+{{< note >}}
+The steps in this guide require root privileges. Be sure to run the steps below as `root` or with the `sudo` prefix. For more information on privileges, see our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
+{{< /note >}}
+
+## Set Up
+
+1.  Create the `/srv/salt` directory if it does not already exist:
+
+        mkdir /srv/salt
+
+1.  Create a top file in `/srv/salt` that will be Salt's entry point to the Apache configuration:
+
+    {{< file "/srv/salt/top.sls" yaml >}}
+base:
+  '*':
+    - apache
+{{< /file >}}
+
+1.  Create a directory for your website files in the `/srv/salt` directory. You can choose to name this folder anything, but we will be using `example.com`:
+
+        mkdir /srv/salt/example.com
+
+    This directory will be accessible from your Salt state files at `salt://example.com`.
+
+1.  Create an `index.html` file for your website in the `/srv/salt/example.com` directory, substituting `example.com` for the folder name you chose in the previous step. You will use this file as a test to make sure your website is functioning correctly.
+
+    {{< file "/srv/salt/example.com/index.html" html >}}
+<html>
+  <body>
+    <h1>Server Up and Running!</h1>
+  </body>
+</html>
+{{< /file >}}
+
+## Creating the Apache State File
+
+We will be going through the process of creating the Apache state file step by step. If you would like to view the entirety of the state file, scroll down to the bottom of this section.
+
+1.  Create a state file named `apache.sls` in `/srv/salt` and open it in a text editor.
+
+2.  Begin by declaring the Jinja variables that you'll be using in `apache.sls`:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+{% set domain = 'example.com' %}
+{% set debian = ['Debian', 'Ubuntu'] %}
+
+...
+{{< /file >}}
+
+    The first variable is your website's domain name. This domain name will be used to configure an Apache virtual host and Apache's directory structure. Don't worry if you don't have your domain name DNS set up just yet, you will still be able access your server by its IP address.
+
+    The second variable is an array of Linux distributions that share the same Apache installation steps, in this case Debian and Ubuntu. This variable will be used throughout `apache.sls` to determine our Apache installation logic.
+
+1.  Instruct Salt to install the Apache package and ensure that Apache is running:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+{% if grains['os'] in debian %}
+apache2:
+{% else %}
+httpd:
+{% endif %}
+  pkg.installed: []
+  service.running: []
+
+...
+{{< /file >}}
+
+    This step uses a Jinja `if` statement and Salt grains to determine whether to install the `apache2` package on Debian-based systems, or to install the `httpd` package on CentOS systems. This pattern will be used throughout `apache.sls` to ensure that the script takes the proper actions.
+
+1.  Tune your Apache configuration to run more optimally on your Linode by instructing salt to alter the Apache configuration file. For more information on tuning your Apache server, [visit our guide on the subject](https://www.linode.com/docs/web-servers/apache-tips-and-tricks/tuning-your-apache-server/).
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+Turn off KeepAlive:
+  file.replace:
+  {% if grains['os'] in debian %}
+    - name: /etc/apache2/apache2.conf
+  {% else %}
+    - name: /etc/httpd/conf/httpd.conf
+  {% endif %}
+    - pattern: 'KeepAlive On'
+    - repl: 'KeepAlive Off'
+    - show_changes: True
+
+Append mpm_prefork module and on CentOS include /sites-enabled:
+  file.append:
+  {% if grains['os'] in debian %}
+    - name: /etc/apache2/apache2.conf
+  {% else %}
+    - name: /etc/httpd/conf/httpd.conf
+  {% endif %}
+    - text: |
+      {% if grains['os'] not in debian %}
+        IncludeOptional sites-enabled/*.conf
+      {% endif %}
+        <IfModule mpm_prefork_module>
+        StartServers 4
+        MinSpareServers 20
+        MaxSpareServers 40
+        MaxClients 200
+        MaxRequestsPerChild 4500
+        </IfModule>
+
+...
+{{< /file >}}
+
+     Here Jinja `if` statements are used to select the proper Apache configuration file, as the location of this file differs depending on the Linux distribution. `apache.sls` instructs Salt to find and change the `KeepAlive On` directive to `KeepAlive Off` using `file.replace`. Then, it uses `file.append` to append an MPM prefork module to the end of the Apache configuration file. Also, on CentOS systems, this step adds the `IncludeOptional` directive to ensure that Apache can find our configuration file in the `sites-enabled/` directory.
+
+1.  Change the document root for CentOS to match a Debian document root:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+{% if grains['os'] not in debian %}
+Change DocumentRoot:
+  file.replace:
+    - name: /etc/httpd/conf/httpd.conf
+    - pattern: 'DocumentRoot "/var/www/html"'
+    - repl: 'DocumentRoot "/var/www/html/{{ domain }}/public_html"'
+    - show_changes: True
+{% endif %}
+
+...
+{{< /file >}}
+
+    While this step is not typical for a CentOS Apache installation, it is a practice introduced on Debian distributions that helps to organize website files. Note that we include the Jinja `{{ domain }}` variable that we declared in step one as a folder in the DocumentRoot. We will create this folder in the next step.
+
+1.  Create the necessary directories:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+{% if grains['os'] not in debian %}
+/etc/httpd/sites-available:
+  file.directory
+
+/etc/httpd/sites-enabled:
+  file.directory
+{% endif %}
+
+/var/www/html/{{ domain }}:
+  file.directory
+
+/var/www/html/{{ domain }}/log:
+  file.directory
+
+/var/www/html/{{ domain }}/backups:
+  file.directory
+
+/var/www/html/{{ domain }}/public_html:
+  file.directory
+
+...
+{{< /file >}}
+
+    For a CentOS installations `apache.sls` instructs Salt to create the `sites-available` and `sites-enabled` directories. Then, it instructs Salt to create the `log`, `backups`, and `public_html` directories in the `/var/www/html/example.com` directory.
+
+1.  Disable the default virtual host configuration on Debian based distributions:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+{% if grains['os'] in debian %}
+000-default:
+  apache_site.disabled
+{% endif %}
+
+...
+{{< /file >}}
+
+    Debian based systems have access to the `apache_site` Salt state module, which is used to disable and enable site configurations.
+
+1.  Set up the Apache virtual host configuration file and enable it:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+{% if grains['os'] in debian %}
+/etc/apache2/sites-available/{{ domain }}.conf:
+{% else %}
+/etc/httpd/sites-available/{{ domain }}.conf:
+{% endif %}
+  apache.configfile:
+    - config:
+      - VirtualHost:
+          this: '*:80'
+          ServerName:
+            - {{ domain }}
+          ServerAlias:
+            - www.{{ domain }}
+          DocumentRoot: /var/www/html/{{ domain }}/public_html
+          ErrorLog: /var/www/html/{{ domain }}/log/error.log
+          CustomLog: /var/www/html/{{ domain }}/log/access.log combined
+{% if grains['os'] not in debian %}
+  file.symlink:
+    - target: /etc/httpd/sites-enabled/{{ domain }}.conf
+    - force: True
+{% endif %}
+
+{% if grains['os'] in debian %}
+example.com:
+  apache_site.enabled
+{% endif %}
+
+...
+{{< /file >}}
+
+    This section uses the `apache` Salt state module to configure your website's virtual host. The `this` variable signifies what would traditionally be include with `VirtualHost` within angle brackets in an Apache configuration file: `<VirtualHost *:80>`
+
+    On CentOS systems `apache.sls` instructs Salt to manually create a symlink of the virtual host configuration file located in `sites-available/` in `sites-enabled/`, whereas on Debian based systems `apache.sls` uses the `apache_site` state module to accomplish the same task.
+
+1.  Transfer `index.html` to the minion:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+/var/www/html/{{ domain }}/public_html/index.html:
+  file.managed:
+    - source: salt://{{ domain }}/index.html
+
+...
+{{< /file >}}
+
+    This section manages the `index.html` file that was created to test your Salt configuration in `/srv/salt/example.com`, here accessed through the convenience method `salt://`. Any changes made to `index.html` on the Salt master will be transferred to the Salt minion on `state.apply`.
+
+1.  Open the proper ports on CentOS:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+{% if grains['os'] not in debian %}
+public:
+  firewalld.present:
+    - name: public
+    - ports:
+      - 22/tcp
+      - 80/tcp
+      - 443/tcp
+{% endif %}
+
+...
+{{< /file >}}
+
+    This command opens ports 80 and 443 for HTTP and HTTPS traffic, respectively. It also keeps the SSH port 22 open.
+
+    {{< note >}}
+Ensure that you declare all the ports you wish to remain open on your machine in this section. Failure to declare those ports will result in those ports being closed.
+{{< /note >}}
+
+1.  Manage SELinux on CentOS:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+{% if grains['os'] not in debian %}
+'semanage fcontext -a -t httpd_log_t "/var/www/html/{{ domain }}/.*\.log.*" && restorecon -R -v /var/www/html/{{ domain }}':
+  cmd.run
+{% endif %}
+
+...
+{{< /file >}}
+
+    This section is necessary for CentOS installations to allow Apache to access a non-default error and access log directory.
+
+1.  Lastly, instruct Salt to restart the Apache service for your changes to take place:
+
+    {{< file "/srv/salt/apache.sls" yaml >}}
+...
+
+{% if grains['os'] in debian %}
+'systemctl restart apache2.service':
+{% else %}
+'systemctl restart httpd.service':
+{% endif %}
+  cmd.run
+{{< /file >}}
+
+In summary, here is the entire state file you just created:
+
+{{< file "/srv/salt/apache.sls" yaml >}}
+{% set domain = 'example.com' %}
+{% set debian = ['Debian', 'Ubuntu'] %}
+
+{% if grains['os'] in debian %}
+apache2:
+{% else %}
+httpd:
+{% endif %}
+  pkg.installed: []
+  service.running: []
+
+Turn off KeepAlive:
+  file.replace:
+  {% if grains['os'] in debian %}
+    - name: /etc/apache2/apache2.conf
+  {% else %}
+    - name: /etc/httpd/conf/httpd.conf
+  {% endif %}
+    - pattern: 'KeepAlive On'
+    - repl: 'KeepAlive Off'
+    - show_changes: True
+
+Append mpm_prefork module and on CentOS include /sites-enabled:
+  file.append:
+  {% if grains['os'] in debian %}
+    - name: /etc/apache2/apache2.conf
+  {% else %}
+    - name: /etc/httpd/conf/httpd.conf
+  {% endif %}
+    - text: |
+      {% if grains['os'] not in debian %}
+        IncludeOptional sites-enabled/*.conf
+      {% endif %}
+        <IfModule mpm_prefork_module>
+        StartServers 4
+        MinSpareServers 20
+        MaxSpareServers 40
+        MaxClients 200
+        MaxRequestsPerChild 4500
+        </IfModule>
+
+{% if grains['os'] not in debian %}
+Change DocumentRoot:
+  file.replace:
+    - name: /etc/httpd/conf/httpd.conf
+    - pattern: 'DocumentRoot "/var/www/html"'
+    - repl: 'DocumentRoot "/var/www/html/{{ domain }}/public_html"'
+    - show_changes: True
+{% endif %}
+
+{% if grains['os'] not in debian %}
+/etc/httpd/sites-available:
+  file.directory
+
+/etc/httpd/sites-enabled:
+  file.directory
+{% endif %}
+
+/var/www/html/{{ domain }}:
+  file.directory
+
+/var/www/html/{{ domain }}/log:
+  file.directory
+
+/var/www/html/{{ domain }}/backups:
+  file.directory
+
+/var/www/html/{{ domain }}/public_html:
+  file.directory
+
+{% if grains['os'] in debian %}
+000-default:
+  apache_site.disabled
+{% endif %}
+
+{% if grains['os'] in debian %}
+/etc/apache2/sites-available/{{ domain }}.conf:
+{% else %}
+/etc/httpd/sites-available/{{ domain }}.conf:
+{% endif %}
+  apache.configfile:
+    - config:
+      - VirtualHost:
+          this: '*:80'
+          ServerName:
+            - {{ domain }}
+          ServerAlias:
+            - www.{{ domain }}
+          DocumentRoot: /var/www/html/{{ domain }}/public_html
+          ErrorLog: /var/www/html/{{ domain }}/log/error.log
+          CustomLog: /var/www/html/{{ domain }}/log/access.log combined
+{% if grains['os'] not in debian %}
+  file.symlink:
+    - target: /etc/httpd/sites-enabled/{{ domain }}.conf
+    - force: True
+{% endif %}
+
+{% if grains['os'] in debian %}
+example.com:
+  apache_site.enabled
+{% endif %}
+
+/var/www/html/{{ domain }}/public_html/index.html:
+  file.managed:
+    - source: salt://{{ domain }}/index.html
+
+{% if grains['os'] not in debian %}
+public:
+  firewalld.present:
+    - name: public
+    - ports:
+      - 22/tcp
+      - 80/tcp
+      - 443/tcp
+{% endif %}
+
+{% if grains['os'] not in debian %}
+'semanage fcontext -a -t httpd_log_t "/var/www/html/{{ domain }}/.*\.log.*" && restorecon -R -v /var/www/html/{{ domain }}':
+  cmd.run
+{% endif %}
+
+{% if grains['os'] in debian %}
+'systemctl restart apache2.service':
+{% else %}
+'systemctl restart httpd.service':
+{% endif %}
+  cmd.run
+{{< /file >}}
+
+## Running the Apache State File
+
+On your Salt master, issue a highstate command:
+
+    salt '*' state.apply
+
+After a few seconds you should see a list of the above commands and a summary of their successes. Navigate to your website's domain name if you have your DNS set up already, or your websites's public IP address. You should see your `index.html` file. You have now used Salt to configure Apache. Visit the links in the section below for more information.


### PR DESCRIPTION
This guide demonstrates how to configure Apache with Salt on Ubuntu 18.04, CentOS 7 and Debian 9.