### PR TITLE
Custom promo code

### DIFF
--- a/ci/yaml_rules.json
+++ b/ci/yaml_rules.json
@@ -136,12 +136,24 @@
     "type": "list",
     "description": "List of operating systems to generate buttons"
   },
-  "promo": {
+  "promo_code_amount": {
+      "elements": false,
+	  "required": false,
+	  "type": "text",
+	  "description": "Amount to be displayed for custom promotion code message"
+    },
+  "promo_code": {
     "elements": false,
 	"required": false,
-	"type": "bool",
-	"description": "Set to false to disable DOCS10 promo code message"
+	"type": "text",
+	"description": "Name to be displayed for custom promotion code message"
   },
+  "promo_default": {
+      "elements": false,
+	  "required": false,
+	  "type": "bool",
+	  "description": "Set to false to disable DOCS10 promo code message"
+    },
   "published": {
     "elements": false,
     "required": true,

--- a/docs/platform/update-kernel/index.md
+++ b/docs/platform/update-kernel/index.md
@@ -12,7 +12,7 @@ modified_by:
 title: "How to Update your Linux Kernel"
 contributor:
   name: Linode
-promo: no
+promo_default: false
 ---
 
 ## Which Kernel Am I Running?

--- a/docs/quick-answers/linux-essentials/what-is-systemd/index.md
+++ b/docs/quick-answers/linux-essentials/what-is-systemd/index.md
@@ -5,9 +5,6 @@ author:
 description: 'An introduction to systemd and systemd unit files.'
 keywords: ['systemd','linux', 'init', 'unit files']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-promo_default: false
-promo_code: SALT50
-promo_code_amount: '50'
 published: 2018-09-12
 modified: 2018-09-12
 modified_by:

--- a/docs/quick-answers/linux-essentials/what-is-systemd/index.md
+++ b/docs/quick-answers/linux-essentials/what-is-systemd/index.md
@@ -5,6 +5,9 @@ author:
 description: 'An introduction to systemd and systemd unit files.'
 keywords: ['systemd','linux', 'init', 'unit files']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+promo_default: false
+promo_code: SALT50
+promo_code_amount: '50'
 published: 2018-09-12
 modified: 2018-09-12
 modified_by:

--- a/docs/security/meltdown-and-spectre/index.md
+++ b/docs/security/meltdown-and-spectre/index.md
@@ -11,7 +11,7 @@ modified: 2018-04-03
 modified_by:
   name: Linode
 title: 'What You Need to Do to Mitigate Meltdown and Spectre'
-promo: false
+promo_default: false
 external_resources:
   - '[MeltdownAttack.com](https://meltdownattack.com/)'
   - '[How to Install Software Updates](/docs/getting-started/#install-software-updates)'


### PR DESCRIPTION
This PR adds new `promo_code` and `promo_code_amount` YAML tags to the ci tests `yaml_rules.json`. It also updates any existing guides to use `promo_default` instead of `promo`.

This PR corresponds to hercules PR: https://github.com/linode/hercules/pull/107

Automated replacement of `promo` YAML tags was done with this python script: [rename.py](https://gist.github.com/leslitagordita/b3bd580fd2751298d827f6ae38bc64d2)