### PR TITLE
[New] KitchenSalt Shortguide

### DIFF
--- a/docs/applications/configuration-management/test-kitchen-shortguide/index.md
+++ b/docs/applications/configuration-management/test-kitchen-shortguide/index.md
@@ -1,0 +1,19 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+description: 'Try this Salt Guide with KitchenSalt'
+keywords: []
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2018-11-09
+modified: 2018-11-09
+modified_by:
+  name: Linode
+title: "Try This Salt Guide with KitchenSalt Shortguide"
+headless: true
+show_on_rss_feed: false
+---
+
+## Try This Guide Using Test Kitchen
+
+To try this guide out locally, read the [Test Salt States Locally with KitchenSalt](/docs/applications/configuration-management/test-salt-locally-with-kitchen-salt/) guide and create a local testing environment.


### PR DESCRIPTION
A small shortguide that reads: 
## Try This Guide Using Test Kitchen

To try this guide out locally, read the [Test Salt States Locally with KitchenSalt](/docs/applications/configuration-management/test-salt-locally-with-kitchen-salt/) guide and create a local testing environment.