### PR TITLE
[Fix] Postgres command

### DIFF
--- a/docs/databases/postgresql/how-to-back-up-your-postgresql-database/index.md
+++ b/docs/databases/postgresql/how-to-back-up-your-postgresql-database/index.md
@@ -61,7 +61,7 @@ PostgreSQL provides the `pg_dump` utility to simplify backing up a single databa
     {{< note >}}
 By default, PostgreSQL will ignore any errors that occur during the backup process. This can result in an incomplete backup. To prevent this, you can run the `pg_dump` command with the `-1` option. This will treat the entire backup procedure as a single transaction, which will prevent partial backups in the event of an error:
 
-    pg_dump -1 dbname > dbname.bak
+    pg_dump dbname > dbname.bak
 {{< /note >}}
 
 ### Remote Database


### PR DESCRIPTION
Fixing Postgres command. the `-1` does not exist. 