### PR TITLE
Apply Audience Taxonomy to Development Section Guides

### DIFF
--- a/ci/yaml_rules.json
+++ b/ci/yaml_rules.json
@@ -5,6 +5,12 @@
     "type": "list",
     "description": "Other locations where this guide can be found. Should be an array of entries in the form /applications/big-data/using-big-data/"
   },
+  "audiences": {
+    "elements": false,
+    "required": false,
+    "type": "list",
+    "description": "An array of audiences. Could be Foundational, Beginner, Intermediate, or Expert"
+  },
   "author": {
     "elements": [
       "name",

--- a/docs/audiences/_index.md
+++ b/docs/audiences/_index.md
@@ -1,0 +1,4 @@
+---
+title: Audiences
+description: "View development guides based on audience experience level."
+---

--- a/docs/audiences/beginner/_index.md
+++ b/docs/audiences/beginner/_index.md
@@ -1,0 +1,3 @@
+---
+title: Beginner
+---

--- a/docs/audiences/foundational/_index.md
+++ b/docs/audiences/foundational/_index.md
@@ -1,0 +1,3 @@
+---
+title: Foundational
+---

--- a/docs/audiences/intermediate/_index.md
+++ b/docs/audiences/intermediate/_index.md
@@ -1,0 +1,3 @@
+---
+title: Intermediate
+---

--- a/docs/development/ci/automate-builds-with-jenkins-on-ubuntu/index.md
+++ b/docs/development/ci/automate-builds-with-jenkins-on-ubuntu/index.md
@@ -17,7 +17,7 @@ title: 'How to Automate Builds with Jenkins on Ubuntu'
 external_resources:
  - '[Jenkins User Documentation](https://jenkins.io/doc/)'
  - '[Blue Ocean Documentation](https://jenkins.io/doc/book/blueocean/)'
-audiences: ["beginner"]
+audiences: ["intermediate"]
 ---
 
 [Jenkins](https://jenkins.io) is an open-source automation server that allows you to build pipelines to automate the process of building, testing, and deploying applications. In this guide, you will implement a basic workflow to speed up your Continuous Integration and Continuous Delivery (CI/CD) process.

--- a/docs/development/ci/automate-builds-with-jenkins-on-ubuntu/index.md
+++ b/docs/development/ci/automate-builds-with-jenkins-on-ubuntu/index.md
@@ -17,6 +17,7 @@ title: 'How to Automate Builds with Jenkins on Ubuntu'
 external_resources:
  - '[Jenkins User Documentation](https://jenkins.io/doc/)'
  - '[Blue Ocean Documentation](https://jenkins.io/doc/book/blueocean/)'
+audiences: ["beginner"]
 ---
 
 [Jenkins](https://jenkins.io) is an open-source automation server that allows you to build pipelines to automate the process of building, testing, and deploying applications. In this guide, you will implement a basic workflow to speed up your Continuous Integration and Continuous Delivery (CI/CD) process.

--- a/docs/development/ci/how-to-develop-and-deploy-your-applications-using-wercker/index.md
+++ b/docs/development/ci/how-to-develop-and-deploy-your-applications-using-wercker/index.md
@@ -16,6 +16,7 @@ contributor:
   name: Damaso Sanoja
 external_resources:
  - '[Wercker Developer Documentation](http://devcenter.wercker.com/docs/home)'
+audiences: ["intermediate"]
 ---
 
 

--- a/docs/development/ci/introduction-ci-cd/index.md
+++ b/docs/development/ci/introduction-ci-cd/index.md
@@ -14,6 +14,7 @@ modified_by:
 title: Introduction to Continuous Integration/Continuous Delivery (CI/CD)
 external_resources:
   - '[How to Automate Builds with Jenkins on Ubuntu](/docs/development/ci/automate-builds-with-jenkins-on-ubuntu/)'
+audiences: ["foundational", "beginner"]
 ---
 
 ## What is Continuous Integration?

--- a/docs/development/ci/use-buildbot-for-software-testing-on-ubuntu/index.md
+++ b/docs/development/ci/use-buildbot-for-software-testing-on-ubuntu/index.md
@@ -14,6 +14,7 @@ title: Use Buildbot for Software Testing on Ubuntu 18.04
 external_resources:
 - '[Official Buildbot Tutorial](http://docs.buildbot.net/current/tutorial/)'
 - '[Buildbot Documentation](http://docs.buildbot.net/current/index.html)'
+audiences: ["intermediate"]
 ---
 
 [Buildbot](https://buildbot.net/) is an open source system for testing software projects. In this guide, you will set up a Linode as a Buildbot server to use as a continuous integration platform to test code. Similarly to hosted solutions like Travis CI, Buildbot is an automated testing platform that can watch for code changes, test a project's code, and send notifications regarding build failures.
@@ -22,13 +23,13 @@ external_resources:
 
 1.  Familiarize yourself with Linode's [Getting Started](/docs/getting-started/) guide and complete the steps for deploying and setting up a Linode running Ubuntu 18.04, including setting the hostname and timezone.
 
-1.  This guide uses `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) guide to create a standard user account, harden SSH access and remove unnecessary network services.
+2.  This guide uses `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) guide to create a standard user account, harden SSH access and remove unnecessary network services.
 
-1.  Ensure your system is up to date:
+3.  Ensure your system is up to date:
 
         sudo apt update && sudo apt upgrade
 
-1.  Complete the [Add DNS Records](/docs/websites/set-up-web-server-host-website/#add-dns-records) steps to register a domain name that will point to your Linode instance hosting Buildbot.
+4.  Complete the [Add DNS Records](/docs/websites/set-up-web-server-host-website/#add-dns-records) steps to register a domain name that will point to your Linode instance hosting Buildbot.
 
     {{< note >}}
 Replace each instance of `example.com` in this guide with your Buildbot site's domain name.

--- a/docs/development/ci/what-is-immutable-infrastructure/index.md
+++ b/docs/development/ci/what-is-immutable-infrastructure/index.md
@@ -12,6 +12,7 @@ modified_by:
 title: "Immutable Infrastructure"
 contributor:
   name: Linode
+audiences: ["intermediate"]
 ---
 
 ## What is Immutable Infrastructure?

--- a/docs/development/clojure-deployment-with-immutant-and-wildfly-on-ubuntu-14-04/index.md
+++ b/docs/development/clojure-deployment-with-immutant-and-wildfly-on-ubuntu-14-04/index.md
@@ -20,7 +20,7 @@ external_resources:
   - '[Luminus Framework](http://www.luminusweb.net/docs)'
   - '[Immutant 2](http://immutant.org/documentation/current/apidoc/)'
   - '[Script to install JBoss Wildfly 10.x as service in Linux](https://gist.github.com/sukharevd/6087988)'
-
+audiences: ["beginner"]
 ---
 
 Clojure is a general-purpose programming language with an emphasis on functional programming. It is a dialect of the Lisp programming language running on the Java Virtual Machine (JVM). While Clojure allows you to write elegant and concise code, its ability to make use of the existing JVM infrastructure, such as libraries, tools and application servers, makes it also a very practical choice.

--- a/docs/development/frameworks/apache-tomcat-on-ubuntu-16-04/index.md
+++ b/docs/development/frameworks/apache-tomcat-on-ubuntu-16-04/index.md
@@ -14,6 +14,7 @@ title: 'Install Apache Tomcat on Ubuntu 16.04'
 external_resources:
  - '[Tomcat Home Page](http://tomcat.apache.org/)'
  - '[Tomcat FAQ](http://wiki.apache.org/tomcat/FAQ)'
+audiences: ["beginner"]
 ---
 
 Apache Tomcat is an open-source software implementation of the Java Servlet and Java Server Pages technologies. With this guide, you'll run applications within Tomcat using the OpenJDK implementation of the Java development environment.

--- a/docs/development/go/getting-started-with-go-packages/index.md
+++ b/docs/development/go/getting-started-with-go-packages/index.md
@@ -17,6 +17,7 @@ external_resources:
   - '[A Tour of Go](https://tour.golang.org/)'
   - '[The Go Standard Library](https://golang.org/pkg/)'
   - '[Go Essentials for Full Stack Web Development](https://www.packtpub.com/web-development/go-essentials-full-stack-web-development-video/)'
+audiences: ["beginner"]
 ---
 
 ## What is Go?

--- a/docs/development/go/install-go-on-ubuntu/index.md
+++ b/docs/development/go/install-go-on-ubuntu/index.md
@@ -11,6 +11,7 @@ modified: 2018-01-29
 modified_by:
   name: Linode
 title: 'How to Install Go on Ubuntu'
+audiences: ["beginner"]
 ---
 
 ![How to Install Go on Ubuntu](install-go-ubuntu-title.jpg "How to Install Go on Ubuntu")

--- a/docs/development/introduction-to-websockets/index.md
+++ b/docs/development/introduction-to-websockets/index.md
@@ -18,6 +18,7 @@ external_resources:
   - '[Vanessa Wang, *The Definitive Guide to HTML5 WebSocket*](https://www.apress.com/in/book/9781430247401)'
   - '[About HTML5 WebSocket](https://www.websocket.org/aboutwebsocket.html)'
   - '[The WebSocket Protocol](https://tools.ietf.org/html/rfc6455)'
+audiences: ["beginner"]
 ---
 
 ## What are WebSockets?

--- a/docs/development/iot/install-thingsboard-iot-dashboard/index.md
+++ b/docs/development/iot/install-thingsboard-iot-dashboard/index.md
@@ -14,6 +14,7 @@ title: 'View IoT Data with ThingsBoard'
 external_resources:
   - '[Getting Started – ThingsBoard](https://thingsboard.io/docs/getting-started-guides/helloworld)'
   - '[ThingsBoard Github Repo](https://github.com/thingsboard/thingsboard)'
+audiences: ["intermediate"]
 ---
 
 ![View IoT Data with ThingsBoard](ThingsBoard.jpg)

--- a/docs/development/java/how-to-deploy-spring-boot-applications-nginx-ubuntu-16-04/index.md
+++ b/docs/development/java/how-to-deploy-spring-boot-applications-nginx-ubuntu-16-04/index.md
@@ -16,6 +16,7 @@ external_resources:
 - '[Spring Boot](https://projects.spring.io/spring-boot/)'
 - '[SDKMAN!](http://sdkman.io/)'
 - '[Gradle](https://gradle.org/)'
+audiences: ["intermediate"]
 ---
 
 ![How to Deploy Spring Boot Applications on NGINX on Ubuntu 16.04](deploy-spring-boot-nginx-reverse-proxy.jpg "How to Deploy Spring Boot Applications on NGINX on Ubuntu 16.04")

--- a/docs/development/java/install-java-on-centos/index.md
+++ b/docs/development/java/install-java-on-centos/index.md
@@ -13,6 +13,7 @@ published: 2017-06-01
 title: Install Java on Centos 7
 external_resources:
 - '[Fedora Wiki Java Entry](https://fedoraproject.org/wiki/Java)'
+audiences: ["beginner"]
 ---
 
 ![Install Java on CentOS 7](install-java-on-centos-7-title-graphic.jpg "Install Java on CentOS 7")

--- a/docs/development/java/install-java-on-debian/index.md
+++ b/docs/development/java/install-java-on-debian/index.md
@@ -13,6 +13,7 @@ published: 2017-06-01
 title: Install Java on Debian 8
 external_resources:
 - '[Java Debian Wiki](https://wiki.debian.org/Java)'
+audiences: ["beginner"]
 ---
 
 Java is a powerful programming language. Software written in Java can be compiled and run on any system. Unlike Python or C, Java does not come pre-installed on Linode distribution images. This guide installs the OpenJDK 7 runtime environment and development kit in Debian 8. OpenJDK is the free and open-source implementation of the Java SE Development Kit.

--- a/docs/development/java/install-java-on-ubuntu-16-04/index.md
+++ b/docs/development/java/install-java-on-ubuntu-16-04/index.md
@@ -16,6 +16,7 @@ contributor:
   link: https://github.com/pbzona
 external_resources:
  - '[Oracle Java](https://www.oracle.com/java/index.html)'
+audiences: ["beginner"]
 
 ---
 

--- a/docs/development/java/install-java-on-ubuntu-18-04/index.md
+++ b/docs/development/java/install-java-on-ubuntu-18-04/index.md
@@ -23,6 +23,7 @@ contributor:
   link: 'https://github.com/pbzona'
 external_resources:
   - '[Oracle Java](https://www.oracle.com/java/index.html)'
+audiences: ["beginner"]
 ---
 
 [Java](https://www.oracle.com/java/index.html) is one of the world's most popular programming languages. Java can be used to create anything from software to basic web applications.

--- a/docs/development/java/java-development-wildfly-centos-7/index.md
+++ b/docs/development/java/java-development-wildfly-centos-7/index.md
@@ -16,6 +16,7 @@ contributor:
     link: https://github.com/ashraffouad
 external_resources:
  - '[WildFly Administration Guide](https://books.google.com.sa/books?id=rufiBAAAQBAJ)'
+audiences: ["intermediate"]
 ---
 
 ![Java Development with WildFly on CentOS 7](Java-Development-with-WildFly-on-CentOS-7-smg.jpg)

--- a/docs/development/javascript/deploy-a-react-app-on-linode/index.md
+++ b/docs/development/javascript/deploy-a-react-app-on-linode/index.md
@@ -17,6 +17,7 @@ contributor:
 external_resources:
 - '[React - A JavaScript library for building user interfaces](https://reactjs.org/)'
 - '[Deploy a React App with Sass Using NGINX](http://zabana.me/notes/build-deploy-react-app-with-nginx.html)'
+audiences: ["beginner"]
 ---
 
 ## What is React?

--- a/docs/development/julia/why-learn-julia/index.md
+++ b/docs/development/julia/why-learn-julia/index.md
@@ -14,6 +14,7 @@ external_resources:
 - '[Julia](https://julialang.org/)'
 - '[Julia By Example](https://juliabyexample.helpmanual.io/)'
 - '[JuliaBox](https://juliabox.com/)'
+audiences: ["beginner"]
 ---
 ![Why You Should Learn Julia](Why_You_Should_Learn_Julia_smg.jpg)
 

--- a/docs/development/monitor-filesystem-events-with-pyinotify/index.md
+++ b/docs/development/monitor-filesystem-events-with-pyinotify/index.md
@@ -17,6 +17,7 @@ external_resources:
 - '[Pyinotify on Github](https://github.com/seb-m/pyinotify)'
 - '[Pyinotify API documentation](http://seb-m.github.com/pyinotify)'
 - '[Inotify manpage](http://www.kernel.org/doc/man-pages/online/pages/man7/inotify.7.html)'
+audiences: ["intermediate"]
 ---
 
 ![banner_image](Monitor_Filesystem_Events_with_Pyinotify_smg.jpg)

--- a/docs/development/nodejs/how-to-install-nodejs-and-nginx-on-debian/index.md
+++ b/docs/development/nodejs/how-to-install-nodejs-and-nginx-on-debian/index.md
@@ -19,6 +19,7 @@ external_resources:
  - '[NodeSchool](http://nodeschool.io/)'
  - '[Node Version Manager](https://github.com/creationix/nvm)'
  - '[npm](https://www.npmjs.com/)'
+audiences: ["intermediate"]
 ---
 
 ![Install Node.js and NGINX on Debian](How_to_Install_Nodejs_and_Nginx_on_Debian_smg.jpg)

--- a/docs/development/nodejs/how-to-install-nodejs/index.md
+++ b/docs/development/nodejs/how-to-install-nodejs/index.md
@@ -15,6 +15,7 @@ external_resources:
  - '[NodeSchool](http://nodeschool.io/)'
  - '[Node Version Manager](https://github.com/creationix/nvm)'
  - '[npm](https://www.npmjs.com/)'
+audiences: ["beginner"]
 ---
 
 [Node.js](https://nodejs.org/) is a cross-platform runtime environment for server-side JavaScript applications. Node.js uses [V8](https://developers.google.com/v8/), Google's JavaScript engine, which is also found in Chromium and Chrome. Depending on the use case, Node.js can supplement or replace traditional web servers and tools such as Apache, nginx, or PHP.

--- a/docs/development/nodejs/install-configure-selenium-grid-ubuntu-16-04/index.md
+++ b/docs/development/nodejs/install-configure-selenium-grid-ubuntu-16-04/index.md
@@ -15,6 +15,7 @@ h1_title: 'Use Selenium Grid for Cross-Browser Compatibility Testing'
 external_resources:
   - '[Selenium Project Home](https://www.seleniumhq.org/projects/webdriver/)'
   - '[Selenium Node.js Documentation](http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index.html)'
+audiences: ["intermediate"]
 ---
 
 ## What is Selenium Grid?

--- a/docs/development/nodejs/use-nightmarejs-to-automate-headless-browsing/index.md
+++ b/docs/development/nodejs/use-nightmarejs-to-automate-headless-browsing/index.md
@@ -17,6 +17,7 @@ contributor:
 external_resources:
   - '[Nightmare.js Homepage](http://www.nightmarejs.org/)'
   - '[Nightmare.js Github Repository](https://github.com/segmentio/nightmare)'
+audiences: ["intermediate"]
 ---
 
 ![Use Nightmare.js to Automate Headless Browsing](nightmarejs-automate-headless-browsing-title.jpg "Use Nightmare.js to Automate Headless Browsing")

--- a/docs/development/perl/manage-cpan-modules-with-cpan-minus/index.md
+++ b/docs/development/perl/manage-cpan-modules-with-cpan-minus/index.md
@@ -15,6 +15,7 @@ title: Manage CPAN Modules with cpanminus
 external_resources:
  - '[cpanminus Documentation](http://search.cpan.org/~miyagawa/App-cpanminus-0.9929/lib/App/cpanminus.pm)'
  - '[cpanminus Development](http://github.com/miyagawa/cpanminus/)'
+audiences: ["beginner"]
 ---
 
 ![banner_image](Manage_CPAN_Modules_with_cpanminus_smg.jpg)

--- a/docs/development/python/create-a-python-virtualenv-on-ubuntu-1610/index.md
+++ b/docs/development/python/create-a-python-virtualenv-on-ubuntu-1610/index.md
@@ -17,6 +17,7 @@ contributor:
   link: https://twitter.com/chrispiccini11
 external_resources:
 - '[virtualenv Documentation](http://virtualenv.pypa.io/)'
+audiences: ["beginner"]
 ---
 
 ![Create a Python Virtual Environment on Ubuntu 16.10](python-ve-u16-title.jpg "Create a Python Virtual Environment on Ubuntu 16.10")

--- a/docs/development/python/introduction-to-pyspark/index.md
+++ b/docs/development/python/introduction-to-pyspark/index.md
@@ -15,6 +15,7 @@ external_resources:
 - '[AMPLab Paper on RDDs](https://www.usenix.org/system/files/conference/nsdi12/nsdi12-final138.pdf)'
 - '[Spark Documentation](https://spark.apache.org/)'
 - '[PySpark Documentation](https://spark.apache.org/docs/latest/api/python/#)'
+audiences: ["intermediate"]
 ---
 
 ![Introduction to PySpark](PySpark.jpg)

--- a/docs/development/python/manage-python-environments-pipenv/index.md
+++ b/docs/development/python/manage-python-environments-pipenv/index.md
@@ -11,6 +11,7 @@ modified_by:
   name: Linode
 published: 2018-05-01
 title: Manage Python Packages and Virtual Environments with Pipenv
+audiences: ["beginner"]
 ---
 
 ## What is Pipenv?

--- a/docs/development/python/string-manipulation-python-3/index.md
+++ b/docs/development/python/string-manipulation-python-3/index.md
@@ -13,6 +13,7 @@ modified_by:
 title: 'String Manipulation in Python 3'
 external_resources:
 - '[Official f-strings Documentation](https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings)'
+audiences: ["beginner"]
 ---
 
 ## Strings in Python

--- a/docs/development/python/task-queue-celery-rabbitmq/index.md
+++ b/docs/development/python/task-queue-celery-rabbitmq/index.md
@@ -15,6 +15,7 @@ contributor:
 external_resources:
 - '[Celery Project page](http://www.celeryproject.org/)'
 - '[Official Celery Documentation](http://docs.celeryproject.org/en/latest/index.html)'
+audiences: ["intermediate"]
 ---
 
 ![How to Set Up a Task Queue with Celery and RabbitMQ](how-to-set-up-a-task-queue-with-celery-and-rabbitmq-smg.jpg)

--- a/docs/development/python/use-scrapy-to-extract-data-from-html-tags/index.md
+++ b/docs/development/python/use-scrapy-to-extract-data-from-html-tags/index.md
@@ -15,6 +15,7 @@ contributor:
 external_resources:
 - '[Scrapy Project page](https://scrapy.org/)'
 - '[Official Scrapy Documentation](https://doc.scrapy.org/en/latest/index.html)'
+audiences: ["intermediate"]
 ---
 
 ![Use Scrapy to Extract Data from HTML Tags](Use-Scrapy-to-Extract-Data-From-HTML-Tags-smg.jpg)

--- a/docs/development/r/how-to-deploy-rshiny-server-on-ubuntu-and-debian/index.md
+++ b/docs/development/r/how-to-deploy-rshiny-server-on-ubuntu-and-debian/index.md
@@ -14,6 +14,7 @@ title: 'How to Deploy Interactive R Apps with Shiny Server'
 external_resources:
   - '[Shiny Server – Introduction](https://shiny.rstudio.com/articles/shiny-server.html)'
   - '[Gallery of Shiny Apps](https://shiny.rstudio.com/gallery/)'
+audiences: ["beginner"]
 ---
 
 ![How to Deploy Interactive R Apps with Shiny Server](shiny-server.jpg)

--- a/docs/development/r/how-to-deploy-rstudio-server-using-an-nginx-reverse-proxy/index.md
+++ b/docs/development/r/how-to-deploy-rstudio-server-using-an-nginx-reverse-proxy/index.md
@@ -11,6 +11,7 @@ modified_by:
   name: Linode
 published: 2018-01-29
 title: 'How to Deploy RStudio Server Using an NGINX Reverse Proxy'
+audiences: ["beginner"]
 ---
 
 ![How to Deploy Rstudio using an NGINX reverse proxy](How_to_Deploy_RStudio_Server_Using_an_NGINX_Reverse_Proxy_smg.jpg)

--- a/docs/development/r/how-to-install-r-on-ubuntu-and-debian/index.md
+++ b/docs/development/r/how-to-install-r-on-ubuntu-and-debian/index.md
@@ -11,6 +11,7 @@ modified_by:
   name: Linode
 published: 2018-01-29
 title: 'How to install R on Ubuntu and Debian'
+audiences: ["beginner"]
 ---
 
 ![How to install R on Ubuntu and Debian](install-r-ubuntu-debian-title.jpg "How to install R on Ubuntu and Debian title graphic")

--- a/docs/development/ror/ruby-on-rails-apache-debian-8/index.md
+++ b/docs/development/ror/ruby-on-rails-apache-debian-8/index.md
@@ -17,6 +17,7 @@ og_description: 'This tutorial will teach you how to use an Apache web server wi
 external_resources:
  - '[Ruby on Rails Homepage](http://rubyonrails.org/)'
  - '[mod_rails Documentation for Apache Servers](http://www.modrails.com/documentation/Users%20guide%20Apache.html)'
+audiences: ["beginner"]
 ---
 
 Ruby on Rails is a rapid development web framework that allows web designers and developers to implement dynamic fully featured web applications. This guide deploys Rails applications using the Phusion Passenger or `mod_rails` method. Passenger allows you to embed Rails apps directly in Apache applications without needing to worry about FastCGI or complex web server proxies.

--- a/docs/development/ror/ruby-on-rails-apache-debian/index.md
+++ b/docs/development/ror/ruby-on-rails-apache-debian/index.md
@@ -15,6 +15,7 @@ title: 'Install Ruby on Rails with Apache on Debian 9'
 external_resources:
  - '[Ruby on Rails Homepage](http://rubyonrails.org/)'
  - '[Phusion Passenger](https://www.phusionpassenger.com/)'
+audiences: ["beginner"]
 ---
 
 ![Ruby on Rails with Apache on Debian](ruby_on_rails_with_apache_debian.jpg "Ruby on Rails with Apache on Debian")

--- a/docs/development/ror/ruby-on-rails-nginx-debian/index.md
+++ b/docs/development/ror/ruby-on-rails-nginx-debian/index.md
@@ -20,6 +20,7 @@ external_resources:
  - '[NGINX Home Page](http://nginx.org/)'
  - '[NGINX Documentation](http://nginx.org/en/docs/)'
  - '[NGINX Configuration](/docs/websites/nginx/basic-nginx-configuration)'
+audiences: ["beginner"]
 ---
 
 ![Ruby on Rails with nginx on Debian](ruby_on_rails_with_nginx_debian_8_smg.png "Ruby on Rails with nginx on Debian 8")

--- a/docs/development/ror/ruby-on-rails-with-nginx-on-debian-7-wheezy/index.md
+++ b/docs/development/ror/ruby-on-rails-with-nginx-on-debian-7-wheezy/index.md
@@ -17,6 +17,7 @@ external_resources:
  - '[Nginx Home Page](http://nginx.org/)'
  - '[Nginx Documentation](http://nginx.org/en/docs/)'
  - '[Nginx Configuration](/docs/websites/nginx/basic-nginx-configuration)'
+audiences: ["beginner"]
 ---
 
 Ruby on Rails is a popular rapid development web framework that allows web designers and developers to implement fully featured dynamic web applications using the Ruby programming language. This guide describes the required process for deploying Ruby on Rails with Passenger and the Nginx web server on Debian 7 (Wheezy). For the purposes of this tutorial, it is assumed that you've followed the steps outlined in our [getting started guide](/docs/getting-started/), that your system is up to date, and that you've logged into your Linode as root via SSH.

--- a/docs/development/ror/use-unicorn-and-nginx-on-ubuntu-14-04/index.md
+++ b/docs/development/ror/use-unicorn-and-nginx-on-ubuntu-14-04/index.md
@@ -16,6 +16,7 @@ contributor:
     link: https://twitter.com/rootaux
 external_resources:
  - '[Ruby on Rails](http://rubyonrails.org/)'
+audiences: ["beginner"]
 ---
 
 Ruby on Rails is a popular web-application framework that allows developers to create dynamic web applications. This guide describes how to deploy Rails applications on servers using Unicorn and nginx on Ubuntu 14.04.

--- a/docs/development/use-a-linode-for-web-development-on-remote-devices/index.md
+++ b/docs/development/use-a-linode-for-web-development-on-remote-devices/index.md
@@ -17,6 +17,7 @@ title: 'Use a Linode for Web Development on Remote Devices'
 external_resources:
  - '[Docker Docs](http://docs.docker.com/)'
  - '[Portainer](https://portainer.io/)'
+audiences: ["beginner"]
 ---
 
 ![Use a Linode for Web Development on Remote Devices](Linode_WebDev.jpg "WebDev_Title Graphic")

--- a/docs/development/version-control/how-to-configure-git/index.md
+++ b/docs/development/version-control/how-to-configure-git/index.md
@@ -15,6 +15,7 @@ external_resources:
  - '[Learn Git with Bitbucket Cloud](https://www.atlassian.com/git/tutorials/learn-git-with-bitbucket-cloud)'
  - '[Pro Git Book](https://git-scm.com/book/en/v2)'
  - '[Github Guides](https://guides.github.com/)'
+audiences: ["foundational"]
 ---
 
 ![Git Started Today](git_getting_started.png)

--- a/docs/development/version-control/how-to-install-git-and-clone-a-github-repository/index.md
+++ b/docs/development/version-control/how-to-install-git-and-clone-a-github-repository/index.md
@@ -14,6 +14,7 @@ modified_by:
   name: Linode
 published: 2015-02-06
 title: How to Install Git and Clone a GitHub Repository
+audiences: ["beginner"]
 ---
 
 ![How to Install Git and Clone a GitHub Repository](install-clone-github-repo-title.jpg "How to Install Git and Clone a GitHub Repository title graphic")

--- a/docs/development/version-control/how-to-install-git-on-linux-mac-and-windows/index.md
+++ b/docs/development/version-control/how-to-install-git-on-linux-mac-and-windows/index.md
@@ -17,6 +17,7 @@ external_resources:
  - '[Learn Git with Bitbucket Cloud](https://www.atlassian.com/git/tutorials/learn-git-with-bitbucket-cloud)'
  - '[Pro Git Book](https://git-scm.com/book/en/v2)'
  - '[Github Guides](https://guides.github.com/)'
+audiences: ["foundational"]
 ---
 
 ## Introduction to Git

--- a/docs/development/version-control/how-to-unbundle-nginx-from-omnibus-gitlab-for-serving-multiple-websites/index.md
+++ b/docs/development/version-control/how-to-unbundle-nginx-from-omnibus-gitlab-for-serving-multiple-websites/index.md
@@ -17,6 +17,7 @@ title: 'How to Unbundle nginx from Omnibus GitLab for Serving Multiple Websites'
 external_resources:
  - '[Updating GitLab via Omnibus GitLab](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/update.md)'
  - '[Installing Passenger + nginx](https://www.phusionpassenger.com/library/install/nginx/install/oss/trusty/)'
+audiences: ["intermediate"]
 ---
 
 

--- a/docs/development/version-control/install-gitlab-on-ubuntu-14-04-trusty-tahr/index.md
+++ b/docs/development/version-control/install-gitlab-on-ubuntu-14-04-trusty-tahr/index.md
@@ -19,6 +19,7 @@ external_resources:
  - '[GitLab Documentation](https://www.gitlab.com/documentation/)'
  - '[GitLab Requirements](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/install/requirements.md)'
  - '[GitLab Manual Installation](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/install/installation.md)'
+audiences: ["intermediate"]
 ---
 
 

--- a/docs/development/version-control/install-gogs-on-debian/index.md
+++ b/docs/development/version-control/install-gogs-on-debian/index.md
@@ -18,6 +18,7 @@ external_resources:
     - '[Gogs official site](http://gogs.io)'
     - '[Gogs documentation](http://gogs.io/docs)'
     - '[Gogs: GitLab alternative in Go](http://blog.gopheracademy.com/birthday-bash-2014/gogs-gitlab-alternative-in-go/)'
+audiences: ["intermediate"]
 ---
 
 

--- a/docs/development/version-control/introduction-to-version-control/index.md
+++ b/docs/development/version-control/introduction-to-version-control/index.md
@@ -13,6 +13,7 @@ published: 2013-09-18
 title: Introduction to Version Control
 external_resources:
  - '[Version Control Systems](/docs/development/version-control/)'
+audiences: ["foundational"]
 ---
 
 In the [Hosting a Website](/docs/websites/hosting-a-website/) guide, you learned how to host your website by installing and configuring a web server, database, and PHP. Now it's time to implement version control to protect your data and handle code updates smoothly. By the time you reach the end of this guide, you'll know how to use many of the version control methods and tools used by large organizations.

--- a/docs/development/version-control/manage-distributed-version-control-with-mercurial/index.md
+++ b/docs/development/version-control/manage-distributed-version-control-with-mercurial/index.md
@@ -13,6 +13,7 @@ published: 2010-04-26
 title: Manage Distributed Version Control with Mercurial
 external_resources:
  - '[HG Init, a Guide by Joel Spolsky](http://hginit.com/)'
+audiences: ["beginner"]
 ---
 
 [Mercurial](https://www.mercurial-scm.org/) is one of the leading distributed version control systems which allows software developers and teams of collaborators to work on a common code base without the need to rely on a centralized server or constant network connection. Mercurial runs on multiple platforms and can be used to manage code projects on many different operating systems.


### PR DESCRIPTION
Per the [Development Housekeeping document](https://docs.google.com/spreadsheets/d/1YK_caIoi3IZ6gYdlccT71LtfpH8dIAkLldIW2Yg7Iko/edit#gid=1022191634), this PR applies the `audience` taxonomy to the guides in the Development section.

An easy way to test this would be to pull down the [Hercules PR](https://github.com/linode/hercules/pull/108) that introduces taxonomies, and navigate to docs/audiences. There should only be three of them: Foundational, Beginner, and Intermediate. There were no Expert guides. If there are more than three, then there are probably spelling mistakes in the YAML (though I checked of course and I didn't find any).