### PR TITLE
Apply Concentrations Taxonomy

### DIFF
--- a/ci/yaml_rules.json
+++ b/ci/yaml_rules.json
@@ -26,6 +26,12 @@
 	  "type": "text",
 	  "description": "In a guide written for the current Linode Manager, if a new version of the guide exists written for the new Linode Manager, use this in the original guide to embed a link to the new guide. Must use alias-style relative links (e.g. platform/manager/dns-manager-cloud-manager/)."
   },
+  "concentrations": {
+    "elements": false,
+    "required": false,
+    "type": "list",
+    "description": "A list of development section concentrations. Case sensitive, capitalize words where appropriate. Could be one of: 'Scripting, Automation, and Build Tools', 'Web Applications', 'Unit Testing', or 'Scientific Computing and Big Data'"
+  },
   "h1_title": {
     "elements": false,
     "required": false,

--- a/docs/concentrations/_index.md
+++ b/docs/concentrations/_index.md
@@ -1,0 +1,4 @@
+---
+title: Concentrations
+description: "Select a development concentration to view all related guides."
+---

--- a/docs/concentrations/scientific-computing-and-big-data/_index.md
+++ b/docs/concentrations/scientific-computing-and-big-data/_index.md
@@ -1,0 +1,3 @@
+---
+title: Scientific Computing and Big Data
+---

--- a/docs/concentrations/scripting-automation-and-build-tools/_index.md
+++ b/docs/concentrations/scripting-automation-and-build-tools/_index.md
@@ -1,0 +1,3 @@
+---
+title: Scripting, Automation, and Build Tools
+---

--- a/docs/concentrations/web-applications/_index.md
+++ b/docs/concentrations/web-applications/_index.md
@@ -1,0 +1,3 @@
+---
+title: Web Applications
+---

--- a/docs/development/clojure-deployment-with-immutant-and-wildfly-on-ubuntu-14-04/index.md
+++ b/docs/development/clojure-deployment-with-immutant-and-wildfly-on-ubuntu-14-04/index.md
@@ -21,6 +21,7 @@ external_resources:
   - '[Immutant 2](http://immutant.org/documentation/current/apidoc/)'
   - '[Script to install JBoss Wildfly 10.x as service in Linux](https://gist.github.com/sukharevd/6087988)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 Clojure is a general-purpose programming language with an emphasis on functional programming. It is a dialect of the Lisp programming language running on the Java Virtual Machine (JVM). While Clojure allows you to write elegant and concise code, its ability to make use of the existing JVM infrastructure, such as libraries, tools and application servers, makes it also a very practical choice.

--- a/docs/development/frameworks/apache-tomcat-on-ubuntu-16-04/index.md
+++ b/docs/development/frameworks/apache-tomcat-on-ubuntu-16-04/index.md
@@ -15,6 +15,7 @@ external_resources:
  - '[Tomcat Home Page](http://tomcat.apache.org/)'
  - '[Tomcat FAQ](http://wiki.apache.org/tomcat/FAQ)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 Apache Tomcat is an open-source software implementation of the Java Servlet and Java Server Pages technologies. With this guide, you'll run applications within Tomcat using the OpenJDK implementation of the Java development environment.

--- a/docs/development/frameworks/yesod-nginx-mysql-on-debian-7-wheezy/index.md
+++ b/docs/development/frameworks/yesod-nginx-mysql-on-debian-7-wheezy/index.md
@@ -18,6 +18,7 @@ external_resources:
  - '[Haskell Wiki for *cabal-install*](http://www.haskell.org/haskellwiki/Cabal-Install)'
  - '[Information for *yesod-platform*](http://hackage.haskell.org/package/yesod-platform)'
  - '[Yesod Quick Start Guide](http://www.yesodweb.com/page/quickstart)'
+concentrations: ["Web Applications"]
 ---
 
 

--- a/docs/development/go/getting-started-with-go-packages/index.md
+++ b/docs/development/go/getting-started-with-go-packages/index.md
@@ -18,6 +18,7 @@ external_resources:
   - '[The Go Standard Library](https://golang.org/pkg/)'
   - '[Go Essentials for Full Stack Web Development](https://www.packtpub.com/web-development/go-essentials-full-stack-web-development-video/)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 ## What is Go?

--- a/docs/development/go/getting-started-with-go-packages/index.md
+++ b/docs/development/go/getting-started-with-go-packages/index.md
@@ -18,7 +18,6 @@ external_resources:
   - '[The Go Standard Library](https://golang.org/pkg/)'
   - '[Go Essentials for Full Stack Web Development](https://www.packtpub.com/web-development/go-essentials-full-stack-web-development-video/)'
 audiences: ["beginner"]
-concentrations: ["Web Applications"]
 ---
 
 ## What is Go?

--- a/docs/development/java/how-to-deploy-spring-boot-applications-nginx-ubuntu-16-04/index.md
+++ b/docs/development/java/how-to-deploy-spring-boot-applications-nginx-ubuntu-16-04/index.md
@@ -17,6 +17,7 @@ external_resources:
 - '[SDKMAN!](http://sdkman.io/)'
 - '[Gradle](https://gradle.org/)'
 audiences: ["intermediate"]
+concentrations: ["Web Applications"]
 ---
 
 ![How to Deploy Spring Boot Applications on NGINX on Ubuntu 16.04](deploy-spring-boot-nginx-reverse-proxy.jpg "How to Deploy Spring Boot Applications on NGINX on Ubuntu 16.04")

--- a/docs/development/java/java-development-wildfly-centos-7/index.md
+++ b/docs/development/java/java-development-wildfly-centos-7/index.md
@@ -17,6 +17,7 @@ contributor:
 external_resources:
  - '[WildFly Administration Guide](https://books.google.com.sa/books?id=rufiBAAAQBAJ)'
 audiences: ["intermediate"]
+concentrations: ["Web Applications"]
 ---
 
 ![Java Development with WildFly on CentOS 7](Java-Development-with-WildFly-on-CentOS-7-smg.jpg)

--- a/docs/development/javascript/deploy-a-react-app-on-linode/index.md
+++ b/docs/development/javascript/deploy-a-react-app-on-linode/index.md
@@ -18,6 +18,7 @@ external_resources:
 - '[React - A JavaScript library for building user interfaces](https://reactjs.org/)'
 - '[Deploy a React App with Sass Using NGINX](http://zabana.me/notes/build-deploy-react-app-with-nginx.html)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 ## What is React?

--- a/docs/development/julia/why-learn-julia/index.md
+++ b/docs/development/julia/why-learn-julia/index.md
@@ -15,6 +15,7 @@ external_resources:
 - '[Julia By Example](https://juliabyexample.helpmanual.io/)'
 - '[JuliaBox](https://juliabox.com/)'
 audiences: ["beginner"]
+concentrations: ["Scientific Computing and Big Data"]
 ---
 ![Why You Should Learn Julia](Why_You_Should_Learn_Julia_smg.jpg)
 

--- a/docs/development/nodejs/how-to-install-nodejs-and-nginx-on-debian/index.md
+++ b/docs/development/nodejs/how-to-install-nodejs-and-nginx-on-debian/index.md
@@ -20,6 +20,7 @@ external_resources:
  - '[Node Version Manager](https://github.com/creationix/nvm)'
  - '[npm](https://www.npmjs.com/)'
 audiences: ["intermediate"]
+concentrations: ["Web Applications"]
 ---
 
 ![Install Node.js and NGINX on Debian](How_to_Install_Nodejs_and_Nginx_on_Debian_smg.jpg)

--- a/docs/development/nodejs/use-nightmarejs-to-automate-headless-browsing/index.md
+++ b/docs/development/nodejs/use-nightmarejs-to-automate-headless-browsing/index.md
@@ -18,6 +18,7 @@ external_resources:
   - '[Nightmare.js Homepage](http://www.nightmarejs.org/)'
   - '[Nightmare.js Github Repository](https://github.com/segmentio/nightmare)'
 audiences: ["intermediate"]
+concentrations: ["Scripting, Automation, and Build Tools"]
 ---
 
 ![Use Nightmare.js to Automate Headless Browsing](nightmarejs-automate-headless-browsing-title.jpg "Use Nightmare.js to Automate Headless Browsing")

--- a/docs/development/python/introduction-to-pyspark/index.md
+++ b/docs/development/python/introduction-to-pyspark/index.md
@@ -16,6 +16,7 @@ external_resources:
 - '[Spark Documentation](https://spark.apache.org/)'
 - '[PySpark Documentation](https://spark.apache.org/docs/latest/api/python/#)'
 audiences: ["intermediate"]
+concentrations: ["Scientific Computing and Big Data"]
 ---
 
 ![Introduction to PySpark](PySpark.jpg)

--- a/docs/development/python/string-manipulation-python-3/index.md
+++ b/docs/development/python/string-manipulation-python-3/index.md
@@ -14,6 +14,7 @@ title: 'String Manipulation in Python 3'
 external_resources:
 - '[Official f-strings Documentation](https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings)'
 audiences: ["beginner"]
+concentrations: ["Scripting, Automation, and Build Tools"]
 ---
 
 ## Strings in Python

--- a/docs/development/python/task-queue-celery-rabbitmq/index.md
+++ b/docs/development/python/task-queue-celery-rabbitmq/index.md
@@ -16,6 +16,7 @@ external_resources:
 - '[Celery Project page](http://www.celeryproject.org/)'
 - '[Official Celery Documentation](http://docs.celeryproject.org/en/latest/index.html)'
 audiences: ["intermediate"]
+concentrations: ["Scripting, Automation, and Build Tools"]
 ---
 
 ![How to Set Up a Task Queue with Celery and RabbitMQ](how-to-set-up-a-task-queue-with-celery-and-rabbitmq-smg.jpg)

--- a/docs/development/python/use-scrapy-to-extract-data-from-html-tags/index.md
+++ b/docs/development/python/use-scrapy-to-extract-data-from-html-tags/index.md
@@ -16,6 +16,7 @@ external_resources:
 - '[Scrapy Project page](https://scrapy.org/)'
 - '[Official Scrapy Documentation](https://doc.scrapy.org/en/latest/index.html)'
 audiences: ["intermediate"]
+concentrations: ["Scripting, Automation, and Build Tools"]
 ---
 
 ![Use Scrapy to Extract Data from HTML Tags](Use-Scrapy-to-Extract-Data-From-HTML-Tags-smg.jpg)

--- a/docs/development/r/how-to-deploy-rshiny-server-on-ubuntu-and-debian/index.md
+++ b/docs/development/r/how-to-deploy-rshiny-server-on-ubuntu-and-debian/index.md
@@ -15,6 +15,7 @@ external_resources:
   - '[Shiny Server – Introduction](https://shiny.rstudio.com/articles/shiny-server.html)'
   - '[Gallery of Shiny Apps](https://shiny.rstudio.com/gallery/)'
 audiences: ["beginner"]
+concentrations: ["Scientific Computing and Big Data"]
 ---
 
 ![How to Deploy Interactive R Apps with Shiny Server](shiny-server.jpg)

--- a/docs/development/r/how-to-deploy-rstudio-server-using-an-nginx-reverse-proxy/index.md
+++ b/docs/development/r/how-to-deploy-rstudio-server-using-an-nginx-reverse-proxy/index.md
@@ -12,6 +12,7 @@ modified_by:
 published: 2018-01-29
 title: 'How to Deploy RStudio Server Using an NGINX Reverse Proxy'
 audiences: ["beginner"]
+concentrations: ["Scientific Computing and Big Data"]
 ---
 
 ![How to Deploy Rstudio using an NGINX reverse proxy](How_to_Deploy_RStudio_Server_Using_an_NGINX_Reverse_Proxy_smg.jpg)

--- a/docs/development/r/how-to-install-r-on-ubuntu-and-debian/index.md
+++ b/docs/development/r/how-to-install-r-on-ubuntu-and-debian/index.md
@@ -12,6 +12,7 @@ modified_by:
 published: 2018-01-29
 title: 'How to install R on Ubuntu and Debian'
 audiences: ["beginner"]
+concentrations: ["Scientific Computing and Big Data"]
 ---
 
 ![How to install R on Ubuntu and Debian](install-r-ubuntu-debian-title.jpg "How to install R on Ubuntu and Debian title graphic")

--- a/docs/development/ror/ruby-on-rails-apache-debian-8/index.md
+++ b/docs/development/ror/ruby-on-rails-apache-debian-8/index.md
@@ -18,6 +18,7 @@ external_resources:
  - '[Ruby on Rails Homepage](http://rubyonrails.org/)'
  - '[mod_rails Documentation for Apache Servers](http://www.modrails.com/documentation/Users%20guide%20Apache.html)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 Ruby on Rails is a rapid development web framework that allows web designers and developers to implement dynamic fully featured web applications. This guide deploys Rails applications using the Phusion Passenger or `mod_rails` method. Passenger allows you to embed Rails apps directly in Apache applications without needing to worry about FastCGI or complex web server proxies.

--- a/docs/development/ror/ruby-on-rails-apache-debian/index.md
+++ b/docs/development/ror/ruby-on-rails-apache-debian/index.md
@@ -16,6 +16,7 @@ external_resources:
  - '[Ruby on Rails Homepage](http://rubyonrails.org/)'
  - '[Phusion Passenger](https://www.phusionpassenger.com/)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 ![Ruby on Rails with Apache on Debian](ruby_on_rails_with_apache_debian.jpg "Ruby on Rails with Apache on Debian")

--- a/docs/development/ror/ruby-on-rails-nginx-debian/index.md
+++ b/docs/development/ror/ruby-on-rails-nginx-debian/index.md
@@ -21,6 +21,7 @@ external_resources:
  - '[NGINX Documentation](http://nginx.org/en/docs/)'
  - '[NGINX Configuration](/docs/websites/nginx/basic-nginx-configuration)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 ![Ruby on Rails with nginx on Debian](ruby_on_rails_with_nginx_debian_8_smg.png "Ruby on Rails with nginx on Debian 8")

--- a/docs/development/ror/ruby-on-rails-with-nginx-on-debian-7-wheezy/index.md
+++ b/docs/development/ror/ruby-on-rails-with-nginx-on-debian-7-wheezy/index.md
@@ -18,6 +18,7 @@ external_resources:
  - '[Nginx Documentation](http://nginx.org/en/docs/)'
  - '[Nginx Configuration](/docs/websites/nginx/basic-nginx-configuration)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 Ruby on Rails is a popular rapid development web framework that allows web designers and developers to implement fully featured dynamic web applications using the Ruby programming language. This guide describes the required process for deploying Ruby on Rails with Passenger and the Nginx web server on Debian 7 (Wheezy). For the purposes of this tutorial, it is assumed that you've followed the steps outlined in our [getting started guide](/docs/getting-started/), that your system is up to date, and that you've logged into your Linode as root via SSH.

--- a/docs/development/ror/use-unicorn-and-nginx-on-ubuntu-14-04/index.md
+++ b/docs/development/ror/use-unicorn-and-nginx-on-ubuntu-14-04/index.md
@@ -17,6 +17,7 @@ contributor:
 external_resources:
  - '[Ruby on Rails](http://rubyonrails.org/)'
 audiences: ["beginner"]
+concentrations: ["Web Applications"]
 ---
 
 Ruby on Rails is a popular web-application framework that allows developers to create dynamic web applications. This guide describes how to deploy Rails applications on servers using Unicorn and nginx on Ubuntu 14.04.


### PR DESCRIPTION
Per the [Development Housekeeping doc](https://docs.google.com/spreadsheets/d/1YK_caIoi3IZ6gYdlccT71LtfpH8dIAkLldIW2Yg7Iko/edit#gid=1022191634), I applied the concentrations taxonomy to the designated guides.

A way to test this would be to pull down the [Hercules PR that introduces these taxonomies](https://github.com/linode/hercules/pull/108) and navigate to `/docs/concentrations` and compare the listed taxonomy terms to the housekeeping doc.