### PR TITLE
Rebuild theme for promo fix

### DIFF
--- a/themes/docsmith/layouts/_default/single.html
+++ b/themes/docsmith/layouts/_default/single.html
@@ -12,12 +12,12 @@
         <div class="row">
           <div id="article-body" class="col-sm-9 col-sm-push-3 doc">
             {{ partial "article_header" . }}
+	    {{ if ne .Params.promo_default false }}
             <div class="row">
-              {{ if ne .Params.promo_default false }}
               <div class="col-sm-9">{{ partial "promo_code" . }}</div>
-              {{ end }}
               <div class="col-sm-3">{{ partial "share" . }}</div>
             </div>
+	    {{ end }}
             {{ partial "github" . }}
             {{ partial "operating_systems" . }}
             {{ partial "deprecated" . }}


### PR DESCRIPTION
This theme rebuild PR corresponds to https://github.com/linode/hercules/pull/109.

When testing this theme rebuild: 
- View /docs/security/meltdown-and-spectre/ - observe that no promo code or share button appear.
- Update any guide's front matter with the following YAML: promo_code_default: false, promo_code: 'SALT50' and promo_code_amount: '50'. Observe that a promo banner appears with the defined text.
- View any guide to ensure that default promo code 10 banner appears as expected.