### PR TITLE
Fixed Gopath problem and wrong folder in Caddy install guide

### DIFF
--- a/docs/email/running-a-mail-server/index.md
+++ b/docs/email/running-a-mail-server/index.md
@@ -220,6 +220,7 @@ Here are some of the most popular spam and virus filter services:
 - [Amavis](http://www.amavis.org) is an open source content filter for email that integrates directly with your MTA. It does some checking on its own, and can also be used in conjunction with more robust spam and virus filters.
 - [Clam AntiVirus](http://www.clamav.net/lang/en/) is a popular, free, and open-source virus scanner.
 - [SpamAssassin](http://spamassassin.apache.org) is a very popular free spam filter.
+- [Anti-Spam SMTP Proxy Server](https://sourceforge.net/projects/assp/) Anti-Spam SMTP Proxy Server implements multiple spam filters.
 
 #### What to do if your server has been blacklisted
 

--- a/docs/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/web-servers/caddy/compile-caddy-from-source/index.md
@@ -30,7 +30,7 @@ You will need a current version of Go on your Linode. Read our guide on [install
 
 2. Navigate to the Caddy directory and start the build:
 
-        cd $GOPATH/src/github.com/mholt/caddy
+        cd $GOPATH/src/github.com/mholt/caddy/caddy
         go run build.go -goos=linux -goarch=amd64
 
 3. When the build finishes you will have a Caddy binary in the current directory. Move the binary to `/usr/bin` so that Caddy can function correctly:

--- a/docs/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/web-servers/caddy/compile-caddy-from-source/index.md
@@ -30,7 +30,7 @@ You will need a current version of Go on your Linode. Read our guide on [install
 
 2. Navigate to the Caddy directory and start the build:
 
-        cd $GOPATH/src/go/src/github.com/mholt/caddy
+        cd $GOPATH/src/github.com/mholt/caddy
         go run build.go -goos=linux -goarch=amd64
 
 3. When the build finishes you will have a Caddy binary in the current directory. Move the binary to `/usr/bin` so that Caddy can function correctly:


### PR DESCRIPTION
```
user@server:~/go/src$ cd $GOPATH/src/go/src/github.com/mholt/caddy
-bash: cd: /home/user/go/src/go/src/github.com/mholt/caddy: No such file or directory
```