### PR TITLE
[Update] Install Node.js Shortguide

### DIFF
--- a/docs/development/nodejs/install-nodejs-nodesource/index.md
+++ b/docs/development/nodejs/install-nodejs-nodesource/index.md
@@ -23,6 +23,6 @@ headless: true
 
 3.  The setup script will run an `apt-get update` automatically, so you can install Node.js right away:
 
-        sudo apt install nodejs
+        sudo apt install nodejs npm
 
 The Node Package Manager (NPM) will be installed alongside Node.js.


### PR DESCRIPTION
NPM is no longer installed alongside Node.js, so it was added to to the install list. This is in response to issue #1979.