### PR TITLE
[Update] How To Build Caddy From Source

### DIFF
--- a/docs/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/web-servers/caddy/compile-caddy-from-source/index.md
@@ -30,7 +30,7 @@ You will need a current version of Go on your Linode. Read our guide on [install
 
 2. Navigate to the Caddy directory and start the build:
 
-        cd $GOPATH/src/github.com/mholt/caddy
+        cd $GOPATH/src/github.com/mholt/caddy/caddy
         go run build.go -goos=linux -goarch=amd64
 
 3. When the build finishes you will have a Caddy binary in the current directory. Move the binary to `/usr/bin` so that Caddy can function correctly:

--- a/docs/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/web-servers/caddy/compile-caddy-from-source/index.md
@@ -22,7 +22,11 @@ Caddy has recently updated their license, clearly defining what is considered pe
 
 You will need a current version of Go on your Linode. Read our guide on [installing Go](/docs/development/go/install-go-on-ubuntu/).
 
-1. Pull Caddy from the source. If you followed our guide on installing Go, the `$GOPATH` is `/usr/local/go`, otherwise use `$GOPATH/drc`
+1. Print your Go installation's current `$GOPATH`:
+
+        go env GOPATH
+
+1. Pull Caddy from the source. Replace `$GOPATH` with the path retrieved in the previous step.
 
         cd $GOPATH/src
         go get -u github.com/mholt/caddy

--- a/docs/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/web-servers/caddy/compile-caddy-from-source/index.md
@@ -30,7 +30,7 @@ You will need a current version of Go on your Linode. Read our guide on [install
 
 2. Navigate to the Caddy directory and start the build:
 
-        cd $GOPATH/src/go/src/github.com/mholt/caddy
+        cd $GOPATH/src/github.com/mholt/caddy
         go run build.go -goos=linux -goarch=amd64
 
 3. When the build finishes you will have a Caddy binary in the current directory. Move the binary to `/usr/bin` so that Caddy can function correctly:


### PR DESCRIPTION
This PR was created from original PR https://github.com/linode/docs/pull/2161 submitted by @theel0ja. It corrects the directory path to build Caddy from source and adds a step to view your Go installation's `$GOPATH`.