### PR TITLE
[UPDATE] Migrating from Tokyo 1 to Tokyo 2

### DIFF
--- a/docs/platform/tokyo2-migration/index.md
+++ b/docs/platform/tokyo2-migration/index.md
@@ -5,10 +5,10 @@ author:
 description: Linode is retiring our Tokyo 1 data center, and this guide shows how to migrate to our new Tokyo 2 location.
 keywords: ["tokyo 1", "tokyo 2", "migrate", "migration", "migrating", "data center"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2018-09-27
+modified: 2018-12-31
 modified_by:
   name: Linode
-published: 2018-09-27
+published: 2018-12-31
 title: Migrating from Tokyo 1 to Tokyo 2
 hiddenguide: true
 promo_default: false
@@ -26,27 +26,33 @@ The Tokyo 2 data center provides access to features that are not available in To
 
 ## When will My Linodes be Migrated?
 
-You will receive a support ticket from Linode that lists the scheduled dates and times for the migration of your Tokyo 1 Linodes. This ticket will be sent to you at least three months in advance of the start of your first migration.
+You will receive a support ticket from Linode that lists the scheduled dates and times for the migrations of your Tokyo 1 Linodes. This ticket will be sent to you at least three months in advance of the start of your first migration.
 
 Different Linodes will be scheduled to migrate on different dates and times. The support ticket you receive will list the migration schedule for all of your Tokyo 1 Linodes. **Linode will not be able to adjust this schedule of migrations.**
 
 You are able to move your servers to Tokyo 2 before the scheduled migration dates. We recommend that all customers move their servers early. Moving early will help you better control the uptime of your services.
 
+### Will my Linode Backups be Migrated?
+
+If your Tokyo 1 Linode is enrolled in the [Linode Backup Service](https://www.linode.com/backups), it will remain enrolled in the service after the migration. However, the saved backups and snapshots that have been created for your Linode prior to the migration **will not move** to the new Tokyo 2 facility. Instead, your Linode will start creating new scheduled backups after it is migrated to the Tokyo 2 date center (according to its [backup schedule](/docs/platform/disk-images/linode-backup-service/#schedule-backups)).
+
 ## What are My Options for Migrating?
 
 There are three different options for moving your servers to the Tokyo 2 data center. The first two of these methods can be followed before the scheduled migration deadlines for your Linodes.
 
-Regardless of which option you choose, **all of your Tokyo 1 Linodes' IP addresses will change** when moving to the new location. This includes all public and private IPv4 addresses, as well as public and link-local IPv6 addresses.
+Regardless of which option you choose, **all of your Tokyo 1 Linodes' IP addresses will change** when moving to the new location. This includes all public and private IPv4 addresses, as well as public and link-local IPv6 addresses. When the schedule for your Linodes' migrations is set, new IP addresses in the Tokyo 2 data center will be reserved in advance for each of your Tokyo 1 Linodes. These reserved addresses will be listed in the same support ticket that lists the schedule for your migrations.
 
 Later sections in this guide describe how to update your [network interface configuration](#update-your-network-configuration) and [DNS records](#update-dns-records) to use the new IPs.
-
-{{< note >}}
-If your Tokyo 1 Linode is enrolled in the [Linode Backup Service](https://www.linode.com/backups), it will remain enrolled in the service after the migration. However, the saved backups and snapshots that have been created for your Linode prior to the migration **will not move** to the new Tokyo 2 facility. Instead, your Linode will start creating new scheduled backups after it is migrated to the Tokyo 2 date center (according to its [backup schedule](/docs/platform/disk-images/linode-backup-service/#schedule-backups)).
-{{</ note >}}
 
 ### Option 1: Migrate Early
 
 When you receive the support ticket which lists your migration times, you will also see a new banner appear in the dashboard of each of your Tokyo 1 Linodes. This banner will give you the option to initiate an early migration of your Linode to Tokyo 2.
+
+{{< note >}}
+The early migration banner will actually appear on your Tokyo 1 Linodes' dashboards before you receive the support ticket for your scheduled migrations. You will be able to perform a migration as soon as you see this banner. However, new IPs in the Tokyo 2 data center will not be reserved for your Linode until you receive the support ticket.
+
+This means that if you migrate before you receive your ticket, you will not know what your new IP addresses will be before you start the migration. Once you start the early migration, your new Tokyo 2 IP addresses will become visible in the [Remote Access tab](/docs/platform/manager/remote-access/) of the Linode's dashboard.
+{{< /note >}}
 
 Clicking on the banner will take you to a new page which shows the estimated duration for the migration. This page will let you initiate the migration.
 
@@ -54,16 +60,15 @@ The following sequence executes when you start the migration:
 
 1.  If your Linode is running, your Linode is gracefully powered down.
 
-1.  At the same time, your Linode will be assigned new IP addresses. You will be able to view these new IPs from the [Remote Access tab](/docs/platform/manager/remote-access/) of your Linode's dashboard.
+1.  At the same time, your Linode will be assigned its reserved Tokyo 2 IP addresses. These new IPs will become visible in the [Remote Access tab](/docs/platform/manager/remote-access/) of your Linode's dashboard.
 
 1.  The migration of your Linode is started immediately after the shutdown completes.
 
 1.  If the Linode was running before the migration started, it will be automatically booted after the migration completes. If the Linode was not running, it will remain offline after the migration.
 
-You will be able to monitor the progress of your Linode's migration from its dashboard. While waiting on the migration to complete, [update your DNS records](#update-dns-records) to use your new IP addresses. DNS changes can take time to propagate, so we recommend doing this quickly after the migration is initiated.
+You will be able to monitor the progress of your Linode's migration from its dashboard. While waiting on the migration to complete, update your [DNS records](#update-dns-records) to use your new IP addresses. DNS changes can take time to propagate, so we recommend doing this quickly after the migration is initiated. Consider updating your [domain's TTL](#update-your-ttl) *before* you initiate the migration.
 
-When the migration finishes, you may need to update your Linode's [network configuration](#update-your-network-configuration) to use the new IPs.
-
+When the migration finishes, you may need to update your Linode's [network configuration](#update-your-network-configuration) to work properly with its new IP addresses.
 
 ### Option 2: Clone your Linodes
 
@@ -79,7 +84,11 @@ Cloning your Linodes offers these benefits:
 
 -   You will be able to set up your new Linodes in Tokyo 2 and verify that they run normally before you remove your Tokyo 1 Linodes.
 
--   When you have verified that your Tokyo 2 Linodes work, you can update your DNS records. Updating your DNS records will gracefully direct your users to your new servers without downtime.
+-   To move your customers to your new Tokyo 2 servers, you can update your DNS records with your new Tokyo 2 IP addresses. You can keep your Tokyo 1 servers running while you update your DNS. Updating your DNS records in this way will gracefully direct your users to your new servers without downtime.
+
+{{< note >}}
+New Linodes that you create in Tokyo 2 will not receive the IP addresses that are reserved for your Tokyo 1 Linodes' scheduled migrations. If you choose to clone your Linodes, your new Tokyo 2 Linodes' IP addresses will be listed in the [Remote Access tab](/docs/platform/manager/remote-access/) of your Linodes' dashboards.
+{{< /note >}}
 
 To clone a Linode, follow these steps:
 
@@ -87,11 +96,13 @@ To clone a Linode, follow these steps:
 
 1.  Follow the [cloning guide](/docs/platform/disk-images/clone-your-linode/) to complete the clone operation. When following these steps, enable all of the configuration profile options for your Linode.
 
-After you have created your new Linode and completed the clone, you may need to update your new Linode's [network configuration](#update-your-network-configuration). After making sure that your new Tokyo 2 servers all work as expected, [update your DNS records](#update-dns-records).
+1.  Boot the new Tokyo 2 Linode when the clone completes.
 
-{{< note >}}
+After you have completed the clone, you may need to update your new Linode's [network configuration](#update-your-network-configuration) to work properly with its new IP addresses. After making sure that your new Tokyo 2 servers all work as expected, update your [DNS records](#update-dns-records). Consider updating your [domain's TTL](#update-your-ttl) *before* you update your DNS records.
+
+{{< caution >}}
 If you clone your Tokyo 1 Linodes to Tokyo 2, your Tokyo 1 Linodes will remain running and active on your account by default. To prevent double-billing, [remove](/docs/platform/billing-and-support/billing-and-payments/#removing-services) the original Tokyo 1 Linodes after you have finished your clones.
-{{< /note >}}
+{{< /caution >}}
 
 ### Option 3: Migrate when Scheduled
 
@@ -101,7 +112,7 @@ If you do not choose to migrate or clone early, Linode will automatically start 
 If Linode initiates your migration when it is scheduled, **your Linode will not be powered on automatically when the migration finishes**. Your Linode is not powered on in order to minimize potential security issues that could result from booting under a new IP assignment.
 {{< /caution >}}
 
-After the scheduled migration completes, you can log into the Linode's dashboard and power it on. You may need to update your new Linode's [network configuration](#update-your-network-configuration). Then, [update your DNS records](#update-dns-records). You can also choose to update your DNS records as soon as the migration starts.
+After the scheduled migration completes, you can log into the Linode's dashboard and power it on. You may need to update your new Linode's [network configuration](#update-your-network-configuration) to work properly with its new IP addresses. Then, update your [DNS records](#update-dns-records). You can also choose to update your DNS records as soon as the migration starts. Consider updating your [domain's TTL](#update-your-ttl) *before* the scheduled migration starts.
 
 ## Update your Network Configuration
 
@@ -115,11 +126,17 @@ You may also need to update the configuration of your applications if they expli
 
 ## Update DNS Records
 
-To direct your users to your new Tokyo 2 servers' IPs, you need to update your DNS records to use the new IPs. If you are using Linode's DNS Manager, follow the DNS Manager guide to [update your records](/docs/platform/manager/dns-manager/#edit-records).
+To direct your users to your new Tokyo 2 servers' IPs, you need to update your DNS records to use the new IPs. If you are using Linode's DNS Manager, follow the DNS Manager guide to update your [DNS records](/docs/platform/manager/dns-manager/#edit-records).
 
 If you use a different DNS provider, you will need to visit that provider's website to update your records.
 
 {{< content "update-dns-at-common-name-server-authorities" >}}
+
+### Update your TTL
+
+DNS resolvers hold a cache for your domain's records. A resolver will update its cached records according to your domain's *Time To Live* (TTL) value. This means that when you update your DNS records, other DNS resolvers will not immediately update their records for your domain. Instead, they will receive your new records when their caches expires.
+
+Having a short TTL means that your users will be directed to your new IP addresses faster when you update your DNS records. It is recommended that you lower your TTL ahead of your migrations. To set the TTL, review the [DNS Manager](/docs/platform/manager/dns-manager/#set-the-time-to-live-or-ttl) guide. After you complete your migrations and have updated your DNS successfully, you can raise your TTL back to the default value of 24 hours.
 
 ## Contact Linode Support
 


### PR DESCRIPTION
When the migrations from Tokyo 1 to Tokyo 2 are scheduled, Linode will also reserve Tokyo 2 IP addresses for users' Tokyo 1 Linodes in advance of the migrations. These reserved IPs will be communicated to users in a support ticket to help them in planning their migrations. This guide update includes an explanation of this feature and how to take advantage of it.

As an added wrinkle, the dashboard for Tokyo 1 Linodes will show an early migration button *before* the official migration schedule is generated and sent to users, and users will be able to use this button to migrate to Tokyo 2. If a user migrates with this button before the migration schedule is set, then they will not have a Tokyo 2 IP reserved in advance for them; the reserved IPs are only provided when the migration schedule is set. This guide update acknowledges and explains this behavior.

A new section is included that explains how to update a domain's TTL ahead of the migration.