### PR TITLE
Apply Salt50 promo code to Salt guides

### DIFF
--- a/docs/applications/configuration-management/automate-a-static-site-deployment-with-salt/index.md
+++ b/docs/applications/configuration-management/automate-a-static-site-deployment-with-salt/index.md
@@ -6,7 +6,7 @@ description: 'Learn how to use Salt to configure a static site webserver and use
 keywords: ['salt','saltstack','github','webhooks','hugo','static site','deployment']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-10-15
-modified: 2018-10-15
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Automate Static Site Deployments with Salt, Git, and Webhooks"
@@ -18,6 +18,8 @@ external_resources:
 - '[SaltStack Git Fileserver Documentation](https://docs.saltstack.com/en/latest/topics/tutorials/gitfs.html#tutorial-gitfs)'
 - '[SaltStack Salt Formulas Documentation](https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html)'
 - '[GitHub Developer - Webhooks](https://developer.github.com/webhooks/)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 This guide will walk through the deployment of a static site using [SaltStack](https://github.com/saltstack/salt), which is a flexible configuration management system. The configuration files created for Salt will be version controlled using Git. Updates to your static site's code will be automatically communicated to the production system using webhooks, an event notification system for the web.

--- a/docs/applications/configuration-management/beginners-guide-to-salt/index.md
+++ b/docs/applications/configuration-management/beginners-guide-to-salt/index.md
@@ -5,13 +5,15 @@ author:
 description: 'A look into Salt''s primary components, features, and configurations for the new SaltStack user'
 keywords: ["salt", "automation", "saltstack", "configuration management"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2018-10-16
+modified: 2019-01-02
 modified_by:
   name: Linode
 published: 2018-10-16
 title: A Beginner's Guide to Salt
 external_resources:
  - '[SaltStack Documentation](https://docs.saltstack.com/)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 [Salt](https://www.saltstack.com) (also referred to as *SaltStack*) is a Python-based configuration management and orchestration system. Salt uses a master/client model in which a dedicated Salt *master* server manages one or more Salt *minion* servers. Two of Salt's primary jobs are:

--- a/docs/applications/configuration-management/configure-and-use-salt-cloud-and-cloud-maps-to-provision-systems/index.md
+++ b/docs/applications/configuration-management/configure-and-use-salt-cloud-and-cloud-maps-to-provision-systems/index.md
@@ -7,12 +7,14 @@ og_description: "Salt Cloud is a part of the SaltStack that makes provisioning m
 keywords: ["SaltStack", "Salt", "salt-cloud"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2017-10-27
-modified: 2018-10-11
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: 'Configure and Use Salt Cloud and Cloud Maps to Provision Systems'
 contributor:
   name: Sergey Bulavintsev
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 ![Salt Cloud](SaltCloud.jpg)

--- a/docs/applications/configuration-management/configure-and-use-salt-ssh/index.md
+++ b/docs/applications/configuration-management/configure-and-use-salt-ssh/index.md
@@ -6,12 +6,14 @@ description: 'Learn how to configure and use Salt SSH in this simple tutorial'
 keywords: ["Saltstack", " salt", " salt-ssh"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2017-07-25
-modified: 2017-08-15
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: 'Configure and Use Salt SSH to Manage Your Linodes'
 contributor:
   name: Sergey Bulavintsev
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 ## Introduction to Salt SSH

--- a/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
+++ b/docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
@@ -6,7 +6,7 @@ description: 'Configure Apache on Ubuntu, Debian and CentOS with Salt Stack.'
 keywords: ['salt','stack','saltstack','apache','httpd','ubuntu','debian','centos']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-10-19
-modified: 2018-11-08
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Configure Apache with Salt Stack"
@@ -15,6 +15,8 @@ external_resources:
 - '[Salt Apache_Conf State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_conf.html)'
 - '[Salt Apache_Site State Module](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.apache_site.html)'
 - '[Using Grains in SLS Modules](https://docs.saltstack.com/en/latest/topics/tutorials/states_pt3.html#using-grains-in-sls-modules)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 Salt is a powerful configuration management tool. In this guide you will create Salt state files that are capable of installing and configuring Apache on Ubuntu 18.04, Debian 9, or CentOS 7.

--- a/docs/applications/configuration-management/create-a-salt-execution-module/index.md
+++ b/docs/applications/configuration-management/create-a-salt-execution-module/index.md
@@ -6,13 +6,15 @@ description: 'Create a Salt execution module.'
 keywords: ['salt','execution module','saltstack']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-10-22
-modified: 2018-10-22
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Create a Salt Execution Module"
 external_resources:
 - '[Writing Execution Modules](https://docs.saltstack.com/en/latest/ref/modules/)'
 - '[Execution of Salt Modules From Within States](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.module.html#execution-of-salt-modules-from-within-states)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 A Salt *execution module* is a Python module that runs on a Salt minion. It perform tasks and returns data to the Salt master. In this tutorial you will create and install an execution module that will call the [US National Weather Service API](https://forecast-v3.weather.gov/documentation) and return the current temperature at a specified weather station. This example could easily be adapted to access any API.

--- a/docs/applications/configuration-management/getting-started-with-salt-basic-installation-and-setup/index.md
+++ b/docs/applications/configuration-management/getting-started-with-salt-basic-installation-and-setup/index.md
@@ -6,11 +6,13 @@ description: 'Salt is a server management platform that can control a number of 
 keywords: ["salt", "configuration management"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['applications/salt/install-salt/','applications/configuration-management/install-salt/','applications/configuration-management/install-and-configure-salt-master-and-minion-servers/']
-modified: 2018-03-23
+modified: 2019-01-02
 modified_by:
     name: Linode
 published: 2015-09-22
 title: Getting Started with Salt - Basic Installation and Setup
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 [Salt](https://saltstack.com/) is a Python-based configuration management platform designed to control a number of slave servers (called Minions in Salt terminology) from a single master server. This guide walks you through configuring a Salt Master and Minion, and is relevant to any supported Linux distribution.

--- a/docs/applications/configuration-management/introduction-to-jinja-templates-for-salt/index.md
+++ b/docs/applications/configuration-management/introduction-to-jinja-templates-for-salt/index.md
@@ -5,7 +5,7 @@ description: 'An introduction to Jinja using Salt configuration management examp
 keywords: ['salt','jinja','configuration management']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-10-29
-modified: 2018-10-29
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Introduction to Jinja Templates for Salt"
@@ -15,6 +15,8 @@ external_resources:
 - '[Salt Best Practices](https://docs.saltstack.com/en/latest/topics/best_practices.html#modularity-within-states)'
 - '[Salt States Tutorial](https://docs.saltstack.com/en/latest/topics/tutorials/states_pt1.html)'
 - '[Jinja Template Designer Documentation](http://jinja.pocoo.org/docs/2.10/templates/#import)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 ## Introduction to Templating Languages
 

--- a/docs/applications/configuration-management/monitoring-salt-minions-with-beacons/index.md
+++ b/docs/applications/configuration-management/monitoring-salt-minions-with-beacons/index.md
@@ -6,7 +6,7 @@ description: 'How to monitor Salt minions with beacons.'
 keywords: ['salt','saltstack','minion','minions','beacon','beacons','reactor','reactors','monitor','configuration drift','slack']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-10-19
-modified: 2018-10-19
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Monitoring Salt Minions with Beacons"
@@ -14,6 +14,8 @@ external_resources:
 - '[Salt Beacons Documentation](https://docs.saltstack.com/en/latest/topics/beacons/)'
 - '[Salt Beacon Modules](https://docs.saltstack.com/en/latest/ref/beacons/all/index.html)'
 - '[Salt Reactors Documentation](https://docs.saltstack.com/en/latest/topics/reactor/)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 Every action performed by Salt, such as applying a highstate or restarting a minion, generates an event. *Beacons* emit events for non-salt processes, such as system state changes or file changes. This guide will use Salt beacons to notify the Salt master of changes to minions, and Salt *reactors* to react to those changes.

--- a/docs/applications/configuration-management/salt-command-line-reference/index.md
+++ b/docs/applications/configuration-management/salt-command-line-reference/index.md
@@ -6,7 +6,7 @@ description: 'A reference for the SaltStack command line interface.'
 keywords: ['salt','saltstack','cli','command line','reference']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-10-03
-modified: 2018-10-03
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "SaltStack Command Line Reference"
@@ -16,6 +16,8 @@ contributor:
 external_resources:
 - '[SaltStack Command Line Documentation](https://docs.saltstack.com/en/latest/ref/cli/index.html)'
 - '[Linode Cloud Module](https://docs.saltstack.com/en/latest/ref/clouds/all/salt.cloud.clouds.linode.html)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 [SaltStack](https://github.com/saltstack/salt) is a powerful configuration management tool. The following is a quick-reference guide for Salt's command line interface (CLI).

--- a/docs/applications/configuration-management/secrets-management-with-salt/index.md
+++ b/docs/applications/configuration-management/secrets-management-with-salt/index.md
@@ -6,7 +6,7 @@ description: 'An overview of available options to manage secrets with SaltStack'
 keywords: ['salt','saltstack','secret','secure','management','sdb','gpg','vault']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-11-06
-modified: 2018-11-06
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Secrets Management with Salt"
@@ -18,6 +18,8 @@ external_resources:
   - '[Salt GPG Renderer](https://docs.saltstack.com/en/latest/ref/renderers/all/salt.renderers.gpg.html)'
   - '[Salt SDB Documentation](https://docs.saltstack.com/en/latest/topics/sdb/)'
   - '[Salt SDB Modules](https://docs.saltstack.com/en/latest/ref/sdb/all/index.html)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 Salt is a powerful configuration management tool which helps you manage your server deployments with configuration *state* files. These files are easily shared with others on your team and can be checked in to version control systems like Git.

--- a/docs/applications/configuration-management/test-salt-locally-with-kitchen-salt/index.md
+++ b/docs/applications/configuration-management/test-salt-locally-with-kitchen-salt/index.md
@@ -6,7 +6,7 @@ description: 'Test Salt states locally with Kitchen and kitchen-salt.'
 keywords: ['saltstack','salt','kitchen','kitchen-salt','kitchensalt','salt solo','saltsolo']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-10-15
-modified: 2018-12-14
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Test Salt States Locally with KitchenSalt"
@@ -16,6 +16,8 @@ external_resources:
 - '[Salt Formulas](https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html)'
 - '[Writing a Test](https://kitchen.ci/docs/getting-started/writing-test/)'
 - '[Sample Pytest tests](https://github.com/gtmanfred/wordpress-formula/tree/master/tests/integration)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 KitchenSalt allows you to use Test Kitchen to test your Salt configurations locally without a Salt master or minions. In this guide you will install KitchenSalt and use Docker to test a Salt state. This guide was created using a system running Ubuntu 18.04.

--- a/docs/applications/configuration-management/use-and-modify-official-saltstack-formulas/index.md
+++ b/docs/applications/configuration-management/use-and-modify-official-saltstack-formulas/index.md
@@ -6,7 +6,7 @@ description: 'Learn how to use and modify official SaltStack formulas to manage 
 keywords: ['salt', 'formulas', 'git']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-11-12
-modified: 2018-11-12
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Use and Modify Official SaltStack Formulas"
@@ -15,6 +15,8 @@ contributor:
 external_resources:
 - '[Salt Formulas](https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html)'
 - '[Git Fileserver Backend Walkthrough](https://docs.saltstack.com/en/latest/topics/tutorials/gitfs.html)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 ## Salt State Files

--- a/docs/applications/configuration-management/use-salt-states-to-configure-a-lamp-stack-on-a-minion/index.md
+++ b/docs/applications/configuration-management/use-salt-states-to-configure-a-lamp-stack-on-a-minion/index.md
@@ -6,11 +6,13 @@ description: 'Use Salt States to Create a LAMP Stack on Debian 8.'
 keywords: ["salt", "salt states", "linux", "apache", "mysql", "php", "debian 8"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['applications/salt/salt-states-configuration-apache-mysql-php/']
-modified: 2017-07-10
+modified: 2019-01-02
 modified_by:
     name: Linode
 published: 2015-07-02
 title: Use Salt States to Configure a LAMP Stack on a Minion
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 This tutorial will configure a Minion's LAMP stack with further use of Salt States. This tutorial is written for Debian 8 but can easily be adjusted for other Linux Distributions. You will need a working Salt master and minion configuration before starting this guide. If you need to set up that prerequisite, see our [Salt installation guide](/docs/applications/configuration-management/getting-started-with-salt-basic-installation-and-setup/) to get started.

--- a/docs/applications/configuration-management/use-salt-states-to-create-lamp-stack-and-fail2ban-across-salt-minions/index.md
+++ b/docs/applications/configuration-management/use-salt-states-to-create-lamp-stack-and-fail2ban-across-salt-minions/index.md
@@ -6,11 +6,13 @@ description: 'Use Salt States to Create a LAMP Stack and Fail2ban Across All Lis
 keywords: ["salt", "salt state", "lamp stack", "apache", "mysql", "php", "fail2ban", "salt minions", "debian 8"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['applications/salt/use-salt-states-to-create-lamp-stack-and-fail2ban-across-salt-minions/','applications/salt/salt-states-apache-mysql-php-fail2ban/']
-modified: 2016-11-22
+modified: 2019-01-02
 modified_by:
     name: Edward Angert
 published: 2015-07-02
 title: Use Salt States to Create LAMP Stack and Fail2ban Across Salt minions
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 Salt States can install and define a server setup on other servers. This tutorial demonstrates the use of Salt States to create a LAMP stack across all Salt Minions.

--- a/docs/applications/configuration-management/use-salt-states-to-create-lamp-stack-and-fail2ban-across-salt-minions/index.md
+++ b/docs/applications/configuration-management/use-salt-states-to-create-lamp-stack-and-fail2ban-across-salt-minions/index.md
@@ -8,7 +8,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['applications/salt/use-salt-states-to-create-lamp-stack-and-fail2ban-across-salt-minions/','applications/salt/salt-states-apache-mysql-php-fail2ban/']
 modified: 2019-01-02
 modified_by:
-    name: Edward Angert
+    name: Linode
 published: 2015-07-02
 title: Use Salt States to Create LAMP Stack and Fail2ban Across Salt minions
 promo_code_amount: '50'

--- a/docs/applications/media-servers/install-plex-media-server-with-salt/index.md
+++ b/docs/applications/media-servers/install-plex-media-server-with-salt/index.md
@@ -6,7 +6,7 @@ description: 'Install Plex Media Server on Ubuntu 18.04 with Salt masterless.'
 keywords: ['plex','media','server','ubuntu 18.04','ubuntu','salt','saltstack']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-11-13
-modified: 2018-11-13
+modified: 2019-01-02
 modified_by:
   name: Linode
 title: "Install Plex Media Server on Ubuntu 18.04 Using Salt Masterless"
@@ -16,6 +16,8 @@ external_resources:
   - '[Salt Masterless Walkthough](https://docs.saltstack.com/en/latest/topics/tutorials/quickstart.html)'
   - '[Salt Fileserver Backend Walthrough](https://docs.saltstack.com/en/latest/topics/tutorials/gitfs.html)'
   - '[Plex Media Server Quick State](https://support.plex.tv/articles/200264746-quick-start-step-by-step-guides/)'
+promo_code_amount: '50'
+promo_code: 'Salt50'
 ---
 
 Plex is a media server that allows you to stream video and audio content that you own to many different types of devices. In this guide you will learn how to use a masterless Salt minion to set up a Plex server, attach and use a Block Storage Volume, and how to connect to your media server to stream content to your devices.


### PR DESCRIPTION
Applying the $50 'Salt50' promo code to all Salt guides. 16 Salt guides were found and modified:

```
docs git:(develop) find docs | grep index.md | egrep -i salt
docs/applications/media-servers/install-plex-media-server-with-salt/index.md
docs/applications/configuration-management/introduction-to-jinja-templates-for-salt/index.md
docs/applications/configuration-management/test-salt-locally-with-kitchen-salt/index.md
docs/applications/configuration-management/monitoring-salt-minions-with-beacons/index.md
docs/applications/configuration-management/configure-apache-with-salt-stack/index.md
docs/applications/configuration-management/automate-a-static-site-deployment-with-salt/index.md
docs/applications/configuration-management/configure-and-use-salt-ssh/index.md
docs/applications/configuration-management/use-salt-states-to-configure-a-lamp-stack-on-a-minion/index.md
docs/applications/configuration-management/use-salt-states-to-create-lamp-stack-and-fail2ban-across-salt-minions/index.md
docs/applications/configuration-management/configure-and-use-salt-cloud-and-cloud-maps-to-provision-systems/index.md
docs/applications/configuration-management/use-and-modify-official-saltstack-formulas/index.md
docs/applications/configuration-management/beginners-guide-to-salt/index.md
docs/applications/configuration-management/secrets-management-with-salt/index.md
docs/applications/configuration-management/salt-command-line-reference/index.md
docs/applications/configuration-management/create-a-salt-execution-module/index.md
docs/applications/configuration-management/getting-started-with-salt-basic-installation-and-setup/index.md
```