### PR TITLE
[UPDATE] An Overview of IPv6 on Linode

### DIFF
--- a/docs/networking/an-overview-of-ipv6-on-linode/index.md
+++ b/docs/networking/an-overview-of-ipv6-on-linode/index.md
@@ -7,7 +7,7 @@ og_description: "This guide is a brief overview of IPv6 support on Linode, inclu
 keywords: ["ipv6 networking", "IP configuration"]
 aliases: ['networking/native-ipv6-networking/','networking/how-to-enable-native-ipv6-on-linux/']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2018-05-17
+modified: 2019-01-02
 modified_by:
   name: Linode
 published: 2011-05-03

--- a/docs/networking/an-overview-of-ipv6-on-linode/index.md
+++ b/docs/networking/an-overview-of-ipv6-on-linode/index.md
@@ -14,7 +14,7 @@ published: 2011-05-03
 title: An Overview of IPv6 on Linode
 external_resources:
  - '[Understanding IP Addressing](http://www.ripe.net/internet-coordination/press-centre/understanding-ip-addressing)'
- - '[IPv6 Subnet Cheat Sheet](http://www.ipv6ve.info/project-definition/ipv6-subnet-cheat-sheet-and-ipv6-cheat-sheet-reference)'
+ - '[IPv6 Chart](https://www.ripe.net/support/training/material/lir-training-course/LIR-Training-Handbook-Appendices/IPv6Chart_2015.pdf)'
 ---
 
 ![An Overview of IPv6 on Linode](an-overview-of-ipv6-on-linode-title-graphic.jpg "An Overview of IPv6 on Linode")


### PR DESCRIPTION
Replacing a [broken link](http://www.ipv6ve.info/project-definition/ipv6-subnet-cheat-sheet-and-ipv6-cheat-sheet-reference) to an 'IPv6 cheat sheet' in the More Information section.

Resolves #2208 