### PR TITLE
[Update] Deprecate Let's Encrypt guide.

### DIFF
--- a/docs/security/ssl/install-lets-encrypt-to-create-ssl-certificates/index.md
+++ b/docs/security/ssl/install-lets-encrypt-to-create-ssl-certificates/index.md
@@ -13,6 +13,8 @@ title: "Install Let's Encrypt to Create SSL Certificates"
 contributor:
   name: 'Sean Webber'
   link: 'https://github.com/seanthewebber'
+deprecated: true
+deprecated_link: quick-answers/websites/secure-http-traffic-certbot/
 external_resources:
   - "[Let's Encrypt Homepage](https://letsencrypt.org/)"
 ---


### PR DESCRIPTION
This PR deprecates the guide and links to the Certbot guide.