### PR TITLE
Rebuild theme to add GitInfo Author Date for lastmod

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,10 @@ disqusShortname="linode-1"
 
 rssLimit = 15
 
+enableGitInfo = true
+
+[frontmatter]
+lastmod = [":git"]
 
 [blackfriday]
 fractions = false


### PR DESCRIPTION
This is the theme rebuild to add the changes from Hercules PR: https://github.com/linode/hercules/pull/117