### PR TITLE
Increase RSS limit: theme rebuild

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,7 +22,7 @@ disqusShortname="linode-1"
 
 #disableKinds = ["taxonomy", "taxonomyTerm"]
 
-rssLimit = 15
+rssLimit = 30
 
 enableGitInfo = true
 


### PR DESCRIPTION
RSS limit has been increased to 30 entries. Corresponding Hercules PR: https://github.com/linode/hercules/pull/123