### PR TITLE
[UPDATE] Set up a Hardened OpenVPN Server on Debian 9

### DIFF
--- a/docs/networking/vpn/set-up-a-hardened-openvpn-server/index.md
+++ b/docs/networking/vpn/set-up-a-hardened-openvpn-server/index.md
@@ -113,6 +113,7 @@ Replace any instances of `eth0` with the name of your network interface.
 
 # Allow traffic on the TUN interface so OpenVPN can communicate with eth0.
 -A INPUT -i tun0 -j ACCEPT
+-A FORWARD -i tun0 -j ACCEPT
 -A OUTPUT -o tun0 -j ACCEPT
 
 # Log any packets which don't fit the rules above.


### PR DESCRIPTION
Adds the rule: `-A FORWARD -i tun0 -j ACCEPT` to the TUN interface rules. This was suggested to us by a reader. This is in line with the iptables rules laid out within our Tunnel Your Internet Traffic Through an OpenVPN Server guide.