### PR TITLE
[UPDATE] SteamCMD and CSGO guides

### DIFF
--- a/docs/game-servers/install-steamcmd-for-a-steam-game-server/index.md
+++ b/docs/game-servers/install-steamcmd-for-a-steam-game-server/index.md
@@ -28,36 +28,41 @@ This guide is intended to get you quickly up and running with SteamCMD on your L
 This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
-## Before You Install
+## Before You Begin
 
 1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  Update Your Operating System:
+1.  Update Your Operating System:
 
     **CentOS**
 
         sudo yum update
 
-    **Debian / Ubuntu**
+    **Debian, Ubuntu**
 
         sudo apt update && sudo apt upgrade
 
+1.  [Install the `screen` utility](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/#installing-gnu-screen), which will be used later when running SteamCMD. For more information about how screen works, review the rest of our [Using GNU Screen to Manage Persistent Terminal Sessions](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/) guide.
 
 ## Secure Your Game Server
 
 Game servers and clients are an especially ripe target for attack. Use our [Securing Your Server](/docs/security/securing-your-server/) guide to:
 
-1.  [Add a Steam user account](/docs/security/securing-your-server/#add-a-limited-user-account). Make the username `steam` to coincide with the rest of [Linode's Steam guides](/docs/applications/game-servers/), as well as Valve's official documentation. Be sure to give the `steam` user `sudo` privileges.
+1.  [Add a limited Linux user](/docs/security/securing-your-server/#add-a-limited-user-account) to your server. Make the username `steam` to coincide with the rest of [Linode's Steam guides](/docs/applications/game-servers/), as well as Valve's official documentation. Be sure to give the `steam` user `sudo` privileges.
 
-2.  [Harden SSH access](/docs/security/securing-your-server/#harden-ssh-access).
+1.  [Harden SSH access](/docs/security/securing-your-server/#harden-ssh-access).
 
-3.  [Remove unused network-facing services](/docs/security/securing-your-server/#remove-unused-network-facing-services).
+1.  [Remove unused network-facing services](/docs/security/securing-your-server/#remove-unused-network-facing-services).
 
-4.  If you are using iptables, complete the [Configure a firewall](/docs/security/securing-your-server/#configure-a-firewall) steps **using the rulesets below**. If instead you are using **firewalld**, skip ahead to step 5.
+1.  If you are using [**iptables**](/docs/security/firewalls/control-network-traffic-with-iptables/) (which is set in Linode's Ubuntu and Debian images by default), follow the [Configure your Firewall Using IPTables](#configure-your-firewall-using-iptables) section.
 
-    *IPv4*
+1.  If instead you are using [**firewalld**](/docs/security/firewalls/introduction-to-firewalld-on-centos/) (as in Linode's CentOS 7 and Fedora images), follow the [Configure your Firewall Using FirewallD](#configure-your-firewall-using-firewalld) section.
 
-    {{< file "iptables" >}}
+### Configure your Firewall Using IPTables
+
+1.  Create two files named `v4` and `v6` in your home directory to record your IPv4 and IPv6 firewall rules:
+
+    {{< file "~/v4" >}}
 *filter
 
 # Allow all loopback (lo0) traffic and reject traffic
@@ -72,8 +77,8 @@ Game servers and clients are an especially ripe target for attack. Use our [Secu
 -A INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT
 
 # Allow the Steam client.
--A INPUT -p udp -m udp --sport 27000:27030 --dport 1025:65355 -j ACCEPT
--A INPUT -p udp -m udp --sport 4380 --dport 1025:65355 -j ACCEPT
+-A INPUT -p udp -m udp --dport 27000:27030 -j ACCEPT
+-A INPUT -p udp -m udp --dport 4380 -j ACCEPT
 
 # Allow inbound traffic from established connections.
 # This includes ICMP error returns.
@@ -90,15 +95,7 @@ Game servers and clients are an especially ripe target for attack. Use our [Secu
 COMMIT
 {{< /file >}}
 
-    {{< note >}}
-Some Steam games require a few additional rules which can be found in our [Steam game guides](/docs/applications/game-servers/). Steam can also use multiple port ranges for various purposes, but they should only be allowed if your game(s) make use of those services. See [this](https://support.steampowered.com/kb_article.php?ref=8571-GLVN-8711) Steam Support page for more information.
-{{< /note >}}
-
-    *IPv6*
-
-    Steam currently supports multiplayer play over IPv4 only, so a Steam server only needs basic IPv6 firewall rules, shown below.
-
-    {{< file "iptables" >}}
+    {{< file "v6" >}}
 *filter
 
 # Allow all loopback (lo0) traffic and reject traffic
@@ -119,14 +116,63 @@ Some Steam games require a few additional rules which can be found in our [Steam
 COMMIT
 {{< /file >}}
 
-5.  If you are using **firewalld** (CentOS 7, Fedora) instead of iptables, **use these rules**. If you are using iptables, do skip this step.
+    {{< note >}}
+Some Steam games require a few additional rules which can be found in our [Steam game guides](/docs/applications/game-servers/). Steam can also use multiple port ranges for various purposes, but they should only be allowed if your game(s) make use of those services. See [this](https://support.steampowered.com/kb_article.php?ref=8571-GLVN-8711) Steam Support page for more information.
+
+Steam currently supports multiplayer play over IPv4 only, so a Steam server only needs basic IPv6 firewall rules, shown below.
+{{< /note >}}
+
+1.  Import the rulesets into your firewall to activate them:
+
+        sudo iptables-restore < ~/v4
+        sudo ip6tables-restore < ~/v6
+
+1.  [Install iptables-persistent](/docs/security/firewalls/control-network-traffic-with-iptables/#install-iptables-persistent). If you don't install this software, your firewall rules will not persist through reboots of your Linode.
+
+1.  If iptables-persistent was already installed, reconfigure the package so that it recognizes your new rulesets:
+
+        sudo dpkg-reconfigure iptables-persistent
+
+1.  Confirm that your firewall rules are active:
+
+        sudo iptables -vL
+
+    The output should look similar to:
+
+        Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
+        pkts bytes target     prot opt in     out     source               destination
+            0     0 ACCEPT     all  --  lo     any     anywhere             anywhere
+            0     0 REJECT     all  --  !lo    any     localhost/8          anywhere             reject-with icmp-port-unreachable
+            0     0 ACCEPT     icmp --  any    any     anywhere             anywhere             state NEW icmp echo-request
+            0     0 ACCEPT     tcp  --  any    any     anywhere             anywhere             state NEW tcp dpt:ssh
+            0     0 ACCEPT     udp  --  any    any     anywhere             anywhere             udp dpts:27000:27030
+            0     0 ACCEPT     udp  --  any    any     anywhere             anywhere             udp dpt:4380
+            0     0 ACCEPT     all  --  any    any     anywhere             anywhere             state RELATED,ESTABLISHED
+            0     0 LOG        all  --  any    any     anywhere             anywhere             limit: avg 3/min burst 5 LOG level debug prefix "iptables_INPUT_denied: "
+            0     0 REJECT     all  --  any    any     anywhere             anywhere             reject-with icmp-port-unreachable
+
+        Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
+        pkts bytes target     prot opt in     out     source               destination
+            0     0 LOG        all  --  any    any     anywhere             anywhere             limit: avg 3/min burst 5 LOG level debug prefix "iptables_FORWARD_denied: "
+            0     0 REJECT     all  --  any    any     anywhere             anywhere             reject-with icmp-port-unreachable
+
+        Chain OUTPUT (policy ACCEPT 60 packets, 8304 bytes)
+        pkts bytes target     prot opt in     out     source               destination
+
+1.  If you ever import new rules into your firewall in the future, be sure to reconfigure iptables-persistent again afterward:
+
+        sudo dpkg-reconfigure iptables-persistent
+
+### Configure your Firewall Using FirewallD
+
+1.  Set up your ruleset:
 
         sudo firewall-cmd --zone="public" --add-service=ssh --permanent
         sudo firewall-cmd --zone="public" --add-forward-port=port=27000-27030:proto=udp:toport=1025-65355 --permanent
         sudo firewall-cmd --zone="public" --add-forward-port=port=4380:proto=udp:toport=1025-65355 --permanent
         sudo firewall-cmd --reload
 
-    Switch on firewalld and verify your ruleset:
+1.  Switch on firewalld and verify your ruleset:
 
         sudo systemctl start firewalld
         sudo systemctl enable firewalld
@@ -134,76 +180,75 @@ COMMIT
 
 ## Install SteamCMD
 
-First, install `screen` to run Steam games in a separate session:
-
-**CentOS 7**
-
-    sudo yum install screen
-
-**Debian / Ubuntu**
-
-    sudo apt-get install screen
-
+SteamCMD can be installed via your distribution's [package manager](#from-package-repositories-recommended), or through a [manual method](#install-manually).
 
 ### From Package Repositories (Recommended)
 
-Installing via the package manager allows you to more easily download updates and security patches, so we strongly recommend using this method if your distribution includes the SteamCMD package.
+Installing via the package manager allows you to more easily download updates and security patches, so we strongly recommend using this method if your distribution includes the SteamCMD package. The package is available for Ubuntu and Debian deployments.
 
-1.  Install the package:
+-   **Ubuntu**
 
-        sudo apt-get install steamcmd
+    1.  Install the package:
 
-    {{< note >}}
-On Debian you need to add the `non-free` area of the repository to your sources, because the package is available only there.
+            sudo apt-get install steamcmd
 
-To do so, edit the `/etc/apt/sources.list` file, and include `non-free` at the end of each `deb` and `deb-src` line:
+    1.  Create a symlink to the `steamcmd` executable in a convenient place, such as your home directory:
 
-    deb http://mirrors.linode.com/debian stretch main non-free
-    deb-src http://mirrors.linode.com/debian stretch main non-free
-    ...
+            cd ~
+            ln -s /usr/games/steamcmd steamcmd
 
-Then, add the i386 architecture, update your package list, and install `steamcmd`:
+-   **Debian**
 
-    sudo dpkg --add-architecture i386
-    sudo apt update
-    sudo apt-get install steamcmd
-{{< /note >}}
+    1.  Add the `non-free` area to the repositories in your sources list, because the `steamcmd` package is only available from this area. To do so, edit your `/etc/apt/sources.list` file and include `non-free` at the end of each `deb` and `deb-src` line, as in this snippet:
 
-1.  Create a symlink to the `steamcmd` executable in a convenient place, such as your home directory:
+        {{< file "/etc/apt/sources.list" >}}
+deb http://mirrors.linode.com/debian stretch main non-free
+deb-src http://mirrors.linode.com/debian stretch main non-free
+...
+{{< /file >}}
 
-        cd ~
-        ln -s /usr/games/steamcmd steamcmd
+    1.  Add the i386 architecture, update your package list, and install `steamcmd`:
 
-### Manually
+            sudo dpkg --add-architecture i386
+            sudo apt update
+            sudo apt-get install steamcmd
+
+    1.  Create a symlink to the `steamcmd` executable in a convenient place, such as your home directory:
+
+            cd ~
+            ln -s /usr/games/steamcmd steamcmd
+
+### Install Manually
+
+If your package manager does not include the `steamcmd` package, install it manually:
 
 1.  Newly created Linodes use 64-bit Linux operating systems. Since Steam is compiled for i386, install the appropriate libraries. For CentOS, also install `wget`.
 
-    **CentOS 7**
+    -   **CentOS 7, Fedora**
 
-        sudo yum install glibc.i686 libstdc++.i686 wget
+            sudo yum install glibc.i686 libstdc++.i686 wget
 
-    **Debian / Ubuntu**
+    -   **Debian, Ubuntu**
 
-        sudo apt-get install lib32gcc1
+            sudo apt-get install lib32gcc1
 
     {{< note >}}
 Running `dpkg --add-architecture i386` is not necessary at this point. Our Steam game guides add [multiarch support](https://wiki.debian.org/Multiarch/HOWTO) only when a game requires it.
 {{< /note >}}
 
-2.  Create the directory for SteamCMD and change to it:
+1.  Create the directory for SteamCMD and change to it:
 
         mkdir ~/Steam && cd ~/Steam
 
-3.  Download the SteamCMD tarball:
+1.  Download the SteamCMD tarball:
 
         wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz
 
-4.  Extract the installation and runtime files:
+1.  Extract the installation and runtime files:
 
         tar -xvzf steamcmd_linux.tar.gz
 
-#### Add an Error Fix
-
+{{< note >}}
 When running a Steam game, you may encounter the following error:
 
     /home/steam/.steam/sdk32/libsteam.so: cannot open shared object file: No such file or directory
@@ -213,17 +258,19 @@ The game server will still operate despite this error, and it should be somethin
     mkdir -p ~/.steam/sdk32/
     ln -s ~/Steam/linux32/steamclient.so ~/.steam/sdk32/steamclient.so
 
+{{< /note >}}
+
 ## Run SteamCMD
 
-1.  Run the executable in a screen.
+1.  Run the executable in a screen session:
 
     If you have installed SteamCMD from repositories:
 
-        screen ./steamcmd
+        screen ~/.steam/steamcmd
 
     If you have installed SteamCMD manually:
 
-        screen ./steamcmd.sh
+        screen ~/Steam/steamcmd.sh
 
     That will return an output similar to below and leave you at the `Steam>` prompt:
 
@@ -250,7 +297,7 @@ The game server will still operate despite this error, and it should be somethin
 
         Steam>
 
-2.  Most Steam game servers allow anonymous logins. You can verify this for your title with Valve's list of [dedicated Linux servers](https://developer.valvesoftware.com/wiki/Dedicated_Servers_List#Linux_Dedicated_Servers).
+1.  Most Steam game servers allow anonymous logins. You can verify this for your title with Valve's list of [dedicated Linux servers](https://developer.valvesoftware.com/wiki/Dedicated_Servers_List#Linux_Dedicated_Servers).
 
     To log in anonymously:
 
@@ -261,14 +308,22 @@ The game server will still operate despite this error, and it should be somethin
         login example_user
 
     {{< caution >}}
-Be aware that some versions of the Steam CLI do **not** obfuscate passwords. If you're signing in with your Steam account, be aware of your local screen's security.
+Some versions of the Steam CLI do **not** obfuscate passwords. If you're signing in with your Steam account, be aware of your local screen's security.
 {{< /caution >}}
 
-    {{< note >}}
-You can exit the `Steam>` prompt at any time by typing `quit`.
-{{< /note >}}
+## Exit SteamCMD
 
-3.  To exit the screen session without disrupting the Steam process, press **CTRL + A** and then **D**. To resume, use the `screen -r` command. For more information, check out our guide on [how to use screen sessions](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/).
+### Detach from the Screen Session
+
+To exit the screen session which contains the Steam process *without* disrupting the Steam process, enter **Control+A** followed by **Control+D** on your keyboard. You can later return to the screen session by entering:
+
+    screen -r
+
+For more information on managing your screen sessions, review our [Using GNU Screen to Manage Persistent Terminal Sessions](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions/) guide.
+
+### Stop SteamCMD
+
+To stop the Steam process and remove your screen session, enter `quit` at the `Steam>` command prompt, or enter **Control+C** on your keyboard.
 
 ## Next Steps
 

--- a/docs/game-servers/install-steamcmd-for-a-steam-game-server/index.md
+++ b/docs/game-servers/install-steamcmd-for-a-steam-game-server/index.md
@@ -5,7 +5,6 @@ author:
 description: 'Install SteamCMD, a command-line version of the Steam client, which works with games that use SteamPipe. Installing SteamCMD is a prerequisite before hosting a Steam title on your own game server.'
 keywords: ["steam", "steamcmd", "steam cmd", "games", "game server", "steam server", "steampipe"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2019-02-01
 modified_by:
   name: Linode
 published: 2016-02-15

--- a/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-14-04/index.md
+++ b/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-14-04/index.md
@@ -6,7 +6,6 @@ description: 'This Counter Strike: Global Offensive (CS:GO) server guide contain
 keywords: ["counter strike", "counter strike global offensive", "csgo", "cs:go", "csgo server", "csgo server hosting", " steam servers", "game servers", "games", "ubuntu", "ubuntu 14.04"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2016-02-25
-modified: 2019-02-01
 modified_by:
     name: Linode
 title: 'Launch a Counter Strike: Global Offensive (CS:GO) server on Ubuntu 14.04'

--- a/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-14-04/index.md
+++ b/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-14-04/index.md
@@ -12,9 +12,11 @@ modified_by:
 title: 'Launch a Counter Strike: Global Offensive (CS:GO) server on Ubuntu 14.04'
 contributor:
     name: Sam Mauldin
-aliases: ['applications/game-servers/csgo-server-debian-ubuntu/','applications/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-14-04/']
+aliases: ['applications/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-14-04/']
 external_resources:
- - '[Valve Developer Community - Counter-Strike: Global Offensive Dedicated Servers](https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers)'
+  - '[Valve Developer Community - Counter-Strike: Global Offensive Dedicated Servers](https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers)'
+deprecated: true
+deprecated_link: 'game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-18-04/'
 dedicated_cpu_link: true
 ---
 
@@ -164,4 +166,4 @@ These settings are changed in the launch command.
 
 ### RCON
 
-When logged into the server, you can open the RCON console with the backtick button (<code>`</code>), or your mapped key. To log in type `rcon_password` followed by your password. For more information regarding RCON, click [here](/docs/game-servers/team-fortress2-on-debian-and-ubuntu/#rcon).
+When logged into the server, you can open the RCON console with the backtick button (`` ` ``), or your mapped key. To log in type `rcon_password` followed by your password. For more information regarding RCON, click [here](/docs/game-servers/team-fortress2-on-debian-and-ubuntu/#rcon).

--- a/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-18-04/index.md
+++ b/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-18-04/index.md
@@ -5,7 +5,7 @@ author:
 description: 'This Counter Strike: Global Offensive (CS:GO) server guide contains instructions on how to install SteamCMD, download the dedicated server, and launch the game server.'
 keywords: ["counter strike", "counter strike global offensive", "csgo", "cs:go", "csgo server", "csgo server hosting", " steam servers", "game servers", "games", "ubuntu", "ubuntu 14.04"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-published: 2016-02-25
+published: 2019-01-07
 modified_by:
     name: Linode
 title: 'Launch a Counter Strike: Global Offensive (CS:GO) server on Ubuntu 18.04'

--- a/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-18-04/index.md
+++ b/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-18-04/index.md
@@ -6,7 +6,6 @@ description: 'This Counter Strike: Global Offensive (CS:GO) server guide contain
 keywords: ["counter strike", "counter strike global offensive", "csgo", "cs:go", "csgo server", "csgo server hosting", " steam servers", "game servers", "games", "ubuntu", "ubuntu 14.04"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2016-02-25
-modified: 2016-02-29
 modified_by:
     name: Linode
 title: 'Launch a Counter Strike: Global Offensive (CS:GO) server on Ubuntu 18.04'

--- a/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-18-04/index.md
+++ b/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-18-04/index.md
@@ -1,0 +1,159 @@
+---
+author:
+    name: Linode Community
+    email: docs@linode.com
+description: 'This Counter Strike: Global Offensive (CS:GO) server guide contains instructions on how to install SteamCMD, download the dedicated server, and launch the game server.'
+keywords: ["counter strike", "counter strike global offensive", "csgo", "cs:go", "csgo server", "csgo server hosting", " steam servers", "game servers", "games", "ubuntu", "ubuntu 14.04"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2016-02-25
+modified: 2016-02-29
+modified_by:
+    name: Linode
+title: 'Launch a Counter Strike: Global Offensive (CS:GO) server on Ubuntu 18.04'
+contributor:
+    name: Linode
+aliases: ['applications/game-servers/csgo-server-debian-ubuntu/','applications/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-14-04/']
+external_resources:
+  - '[Valve Developer Community - Counter-Strike: Global Offensive Dedicated Servers](https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers)'
+dedicated_cpu_link: true
+---
+
+[Counter Strike: Global Offensive](http://store.steampowered.com/app/730) (CS:GO) is a first-person shooter by Valve. Hosting your own server gives you full control over your game and game modes, so you can play the exact flavor of CS:GO you want. This guide contains instructions on how to download the dedicated server and launch the game server.
+
+<!-- ![Launch a Counter Strike GO server on Ubuntu 14.04](launch-a-cs-go-server-on-ubuntu-14-04.png) -->
+
+## Before You Begin
+
+1.  [Create a Linode](/docs/getting-started-new-manager/#create-a-linode) running Ubuntu 18.04.
+
+1.  Create a [Steam](http://store.steampowered.com) account if you do not have one, and download [Counter Strike: Global Offensive](http://store.steampowered.com/app/730/) to your computer.
+
+1.  A Steam game server login token (GSLT) is required to host a public CS:GO server. Without the token, client connections are restricted to the LAN only. [Register your GSLT](https://steamcommunity.com/dev/managegameservers) on Steam's website. Enter `730` as the App ID when creating your GSLT. Review [Steam's documentation](https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers#Registering_Game_Server_Login_Token) for more information about GSLTs.
+
+1.  Complete our guide: [Install SteamCMD for a Steam Game Server](/docs/applications/game-servers/install-steamcmd-for-a-steam-game-server). This will get SteamCMD installed and running on your Linode and this guide will pick up where the SteamCMD page leaves off.
+
+    {{< note >}}
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups) guide.
+{{< /note >}}
+
+## Prerequisites for Counter-Strike: Global Offensive
+
+After following the SteamCMD guide, some firewall modifications are needed specifically for CS:GO:
+
+1.  [Stop the SteamCMD process](/docs/game-servers/install-steamcmd-for-a-steam-game-server/#stop-steamcmd)  if it is currently running.
+
+1.  Replace a firewall rule to slightly extend the UDP port range available to the game. This command assumes that you have **only** the iptables rules in place from the SteamCMD guide:
+
+        sudo iptables -R INPUT 5 -p udp -m udp --dport 26900:27030 -j ACCEPT
+
+1.  Reconfigure iptables-persistent to ensure that your new rule persists:
+
+        sudo dpkg-reconfigure iptables-persistent
+
+## Install Counter Strike: Global Offense
+
+1.  [Run SteamCMD and login to Steam](/docs/game-servers/install-steamcmd-for-a-steam-game-server/#run-steamcmd) inside a screen session.
+
+1.  From the SteamCMD prompt, install CS:GO to the `steam` user's home directory:
+
+        force_install_dir ./csgo-ds
+        app_update 740 validate
+
+    This can take some time. If the download looks as if it has frozen, be patient. Once the download is complete, you should see this output:
+
+        Success! App '740' fully installed.
+
+        Steam>
+
+1.  Exit SteamCMD:
+
+        quit
+
+    {{< note >}}
+To update CS:GO, run the above 4 commands again.
+{{< /note >}}
+
+## Configure the Server
+
+1.  Create a file called `server.cfg` using your preferred text editor with the contents of the following snippet. The location you should save this file to depends on how you installed SteamCMD:
+
+    | SteamCMD Installation Method | File Location |
+    | ------------------- | ------------- |
+    | Package manager | `~/.steam/steamcmd/csgo-ds/csgo/cfg/server.cfg` |
+    | Manual installation | `~/Steam/csgo-ds/csgo/cfg/server.cfg` |
+
+    The value for `hostname` will displayed to users that join your server. Replace the values of `sv_password` and `rcon_password` with two different and unique passwords that you don't use elsewhere.
+
+    {{< file "server.cfg" aconf >}}
+hostname "The name of your CS:GO server"
+sv_password "server_password"
+sv_timeout 60
+rcon_password "rcon_password"
+mp_autoteambalance 1
+mp_limitteams 1
+writeid
+writeip
+{{< /file >}}
+
+    `sv_password` is the password users will need to enter to join the server. `rcon_password` is the [RCON](https://developer.valvesoftware.com/wiki/Source_RCON_Protocol) password, which is used to remotely control the game server from within the game. For an extensive list of `server.cfg` options, see [this page](http://csgodev.com/csgodev-server-cfg-for-csgo/).
+
+1.  Create a startup script for CS:GO with the following snippet. Name the file `startcsgo.sh` and save it to your `steam` user's home directory. Set the value of the `YOUR_GSLT` variable at the top to be your game server login token. Set the value of the `CSGO_INSTALL_LOCATION` variable at the top according to the table below.
+
+    {{< file "~/startcsgo.sh" >}}
+#!/bin/sh
+
+YOUR_GSLT=
+CSGO_INSTALL_LOCATION=
+
+cd $CSGO_INSTALL_LOCATION
+screen -S "Counter-Strike: Global Offensive Server" ./srcds_run -game csgo -usercon +game_type 0 +game_mode 1 +mapgroup mg_bomb +map de_dust2 +sv_setsteamaccount $YOUR_GSLT -net_port_try 1
+{{< /file >}}
+
+    | SteamCMD Installation Method | CSGO_INSTALL_LOCATION |
+    | ------------------- | ------------- |
+    | Package manager | `~/.steam/steamcmd/csgo-ds/` |
+    | Manual installation | `~/Steam/csgo-ds/` |
+
+    When run, the script will execute a Dust2 server in competitive game mode in a [screen session](/docs/networking/ssh/using-gnu-screen-to-manage-persistent-terminal-sessions). For more startup modes and game options, see Valve's [CS:GO wiki](https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers#Starting_the_Server).
+
+1.  Make the script executable:
+
+        chmod +x ~/startcsgo.sh
+
+## Start the Server
+
+1.  Now that your server is installed and configured, it can be launched by running the `startcsgo.sh` script from your `steam` user's home directory.
+
+        cd ~ && ./startcsgo.sh
+
+1.  Review instructions for [detaching from or stopping SteamCMD](/docs/game-servers/install-steamcmd-for-a-steam-game-server/#exit-steamcmd) to exit the CS:GO server.
+
+## Join the Game
+
+1.  Launch Counter-Strike: Global Offensive.
+
+1.  Once launched, go to **Play** and click **Browse Community Servers**.
+
+1.  Click on the **Favorites** tab and then click **Add a Server** at the bottom.
+
+1.  Type in the IP address of your Linode and click **Add this address to favorites**.
+
+1.  You'll see your new Counter-Strike: Global Offensive server. Click **Connect** at the bottom right and start fragging away.
+
+## Game Settings
+
+### Game Modes and Types
+
+You can change the game type and mode options to start different types of servers:
+
+    Mode                   game_mode    game_type
+    Classic Casual             0            0
+    Classic Competitive        0            1
+    Arms Race                  1            0
+    Demolition                 1            1
+
+These settings are changed in the launch command.
+
+### RCON
+
+When logged into the server, you can open the RCON console with the backtick button (`` ` ``), or your mapped key. To log in type `rcon_password` followed by your password. For more information regarding RCON, click [here](/docs/game-servers/team-fortress2-on-debian-and-ubuntu/#rcon).


### PR DESCRIPTION
Updated these two guides:

1. Install SteamCMD for a Steam Game Server
    `/docs/game-servers/install-steamcmd-for-a-steam-game-server/`

    Updated in place.

1. Launch a Counter Strike: Global Offensive (CS:GO) server on Ubuntu 14.04
    `/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-14-04/`

    Created a new Ubuntu 18.04 guide at `/docs/game-servers/launch-a-counter-strike-global-offensive-server-on-ubuntu-18-04/` and set a deprecated link from the old guide.

The SteamCMD guide had some incorrect firewall rules. Here's what the output from netstat was when running the CS:GO game server:

```
sudo netstat -plntu
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 127.0.0.1:27015         0.0.0.0:*               LISTEN      1587/./srcds_linux
tcp        0      0 127.0.0.53:53           0.0.0.0:*               LISTEN      582/systemd-resolve
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      702/sshd
tcp6       0      0 :::22                   :::*                    LISTEN      702/sshd
udp        0      0 127.0.0.53:53           0.0.0.0:*                           582/systemd-resolve
udp        0      0 0.0.0.0:27005           0.0.0.0:*                           1587/./srcds_linux
udp        0      0 0.0.0.0:27015           0.0.0.0:*                           1587/./srcds_linux
udp        0      0 0.0.0.0:27020           0.0.0.0:*                           1587/./srcds_linux
```

The game server is listening on ports between 2700 and 27030. The old SteamCMD and CS:GO guides listed those ports as the source ports:

```
-A INPUT -p udp -m udp --sport 27000:27030 --dport 1025:65355 -j ACCEPT
-A INPUT -p udp -m udp --sport 4380 --dport 1025:65355 -j ACCEPT
```

Really, they should be the destination ports in the firewall. Trying to connect to the game server with the existing rules from the guides failed. Switching the rules to use the relevant ports as the destination ports succeeded.

This brings into question whether any other game guides that also link to the SteamCMD guide will work under either the old version of the guide or this new version. I will create a separate card/task for reviewing those guides.

In the meantime, these guide updates require another tech/copy edit from someone else.
