### PR TITLE
[Fix] Remove period from alias

### DIFF
--- a/docs/applications/remote-desktop/run-graphic-software-on-your-linode-with-xforwarding-on-ubuntu-12-04/index.md
+++ b/docs/applications/remote-desktop/run-graphic-software-on-your-linode-with-xforwarding-on-ubuntu-12-04/index.md
@@ -6,7 +6,7 @@ author:
 description: Forward the X11 Server Through SSH to Run GUI Applications from Your Linode
 keywords: ["x11", "x-forwarding", "ssh", "x over ssh", "ubuntu", " ubuntu 12.04"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['remote-desktops/x-forwarding-ubuntu-12-04/','applications/remote-desktop./running-graphic-software-on-your-linode-with-xforwarding-on-ubuntu-12-04']
+aliases: ['remote-desktops/x-forwarding-ubuntu-12-04/','applications/remote-desktop/running-graphic-software-on-your-linode-with-xforwarding-on-ubuntu-12-04']
 modified: 2014-04-25
 modified_by:
   name: Alex Fornuto


### PR DESCRIPTION
`$ hugo server -D`
`Building sites … ERROR 2019/02/18 16:13:04 Alias "applications/remote-desktop./running-graphic-software-on-your-linode-with-xforwarding-on-ubuntu-12-04" contains component with a trailing space or period, proble matic on Windows`
`Total in 565 ms`
`Error: Error building site: Cannot create "applications/remote-desktop./running-graphic-software-on-your-linode-with-xforwarding-on-ubuntu-12-04": Windows filename restriction`