### PR TITLE
[Update] Update Getting Started Guide to Suggest Ubuntu 18.04

### DIFF
--- a/docs/getting-started-new-manager/index.md
+++ b/docs/getting-started-new-manager/index.md
@@ -201,7 +201,7 @@ After running a sync, it may end with a message that you should upgrade Portage 
 
 ## Set the Hostname
 
-A hostname is used to identify your Linode using an easy-to-remember name. Your Linode's hostname doesn't necessarily associate with websites or email services hosted on the system, but see our guide on using the[hosts file](/docs/networking/dns/using-your-systems-hosts-file/)if you want to assign your Linode a fully qualified domain name.
+A hostname is used to identify your Linode using an easy-to-remember name. Your Linode's hostname doesn't necessarily associate with websites or email services hosted on the system, but see our guide on using the [hosts file](/docs/networking/dns/using-your-systems-hosts-file/) if you want to assign your Linode a fully qualified domain name.
 
  Your hostname should be something unique, and should not be *www* or anything too generic. Some people name their servers after planets, philosophers, or animals. After you've made the change below, you'll need to log out and back in again to see the terminal prompt change from `localhost` to your new hostname. The command `hostname` should also show it correctly.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -77,7 +77,7 @@ Once you've created a new Linode, click the name or **Dashboard** to open the Li
     * [Slackware](http://www.slackware.com/)
     * [Ubuntu](http://www.ubuntu.com/)
 
-    If you're new to the Linux operating system, consider selecting Ubuntu 16.04 LTS. Ubuntu is the most popular distribution among Linode customers and one of the most well-supported by online communities, so resolving any issues you may have should be simple.
+    If you're new to the Linux operating system, consider selecting Ubuntu 18.04 LTS. Ubuntu is the most popular distribution among Linode customers and one of the most well-supported by online communities, so resolving any issues you may have should be simple.
 
 3.  Enter a size for the disk in the **Deployment Disk Size** field. By default all of the available space is allocated, but you can set a lower size if you plan on cloning a disk or creating multiple configuration profiles. You can always create, resize, and delete disks later.
 


### PR DESCRIPTION
Update the Classic Getting Started guide to suggest a new customer use Ubuntu 18.04, which is what the Hosting a Website guide suggests. The relevant section does not exist in the Cloud Manager version of the guide.