### PR TITLE
[How to Create a Private Python Package Repository] setup.py Syntax Fix

### DIFF
--- a/docs/applications/project-management/how-to-create-a-private-python-package-repository/index.md
+++ b/docs/applications/project-management/how-to-create-a-private-python-package-repository/index.md
@@ -68,8 +68,8 @@ setup(
     description='Hello world enterprise edition',
     version='0.1',
     url='http://github.com/example/linode_example',
-    author='Linode'
-    author_email='docs@linode.com'
+    author='Linode',
+    author_email='docs@linode.com',
     keywords=['pip','linode','example']
     )
 


### PR DESCRIPTION
Added missing commas resulting in a syntax error when executing `setup.py`.

Article - https://www.linode.com/docs/applications/project-management/how-to-create-a-private-python-package-repository/