### PR TITLE
[update] adds dnssec section

### DIFF
--- a/docs/platform/manager/dns-manager/index.md
+++ b/docs/platform/manager/dns-manager/index.md
@@ -293,6 +293,10 @@ This generates a large amount of information about the domain. The basic informa
 
 For a web-based tool, you can also use [kloth.net](http://www.kloth.net/services/dig.php) for dig requests and [whois.net](http://whois.net/) for WHOIS requests. Note that since you're running these lookups from a third-party website, the information they find is not necessarily what your local computer has cached. There should be a difference only if you've made recent changes to your DNS information.
 
+## DNSSEC Limitations 
+
+The Linode DNS Manager does not support DNSSEC at this time. If you have DNSSEC enabled at your domains registrar it will cause name resolution failures such as `NXDOMAIN` when an attempt is made to access the DNS.
+
 ## Next Steps
 
 Now that you are familiar with Linode's DNS Manager, you should set up your [reverse DNS configuration](/docs/networking/dns/configure-your-linode-for-reverse-dns/), and consider reading through at our [Common DNS Configurations](/docs/networking/dns/common-dns-configurations/) guide.

--- a/docs/platform/manager/dns-manager/index.md
+++ b/docs/platform/manager/dns-manager/index.md
@@ -293,7 +293,7 @@ This generates a large amount of information about the domain. The basic informa
 
 For a web-based tool, you can also use [kloth.net](http://www.kloth.net/services/dig.php) for dig requests and [whois.net](http://whois.net/) for WHOIS requests. Note that since you're running these lookups from a third-party website, the information they find is not necessarily what your local computer has cached. There should be a difference only if you've made recent changes to your DNS information.
 
-## DNSSEC Limitations 
+## DNSSEC Limitations
 
 The Linode DNS Manager does not support DNSSEC at this time. If you have DNSSEC enabled at your domains registrar it will cause name resolution failures such as `NXDOMAIN` when an attempt is made to access the DNS.
 


### PR DESCRIPTION
this is simply to make explicit that the linode nameservers don't support dnssec and that it will break name resolution if they enable it at the registrar.