### PR TITLE
[Update] 4 Guides updating Markdown to pass new Travis rule re Object Storage guide

### DIFF
--- a/docs/applications/configuration-management/automate-a-static-site-deployment-with-salt/index.md
+++ b/docs/applications/configuration-management/automate-a-static-site-deployment-with-salt/index.md
@@ -34,7 +34,7 @@ Setting up these mechanisms offers an array of benefits:
 
 ## Development and Deployment Workflow
 
-The static site generator used in this guide is [Hugo](https://gohugo.io), a fast framework written in Go. Static site generators compile [markdown](https://en.wikipedia.org/wiki/Markdown) or other content files into HTML files. This guide can easily be adapted to other frameworks.
+The static site generator used in this guide is [Hugo](https://gohugo.io), a fast framework written in Go. Static site generators compile [Markdown](https://en.wikipedia.org/wiki/Markdown) or other content files into HTML files. This guide can easily be adapted to other frameworks.
 
 Two Git repositories will be created: one will track changes to the Hugo site, and the other will track Salt's configuration files. Remote repositories will be created for both on GitHub.
 
@@ -482,7 +482,7 @@ The Salt minion's formula needs to be updated in order to serve the Hugo site. S
 
 -   Install Git and clone the Hugo site repository from GitHub.
 
--   Install Hugo and build the HTML files from the markdown content.
+-   Install Hugo and build the HTML files from the Markdown content.
 
 -   Update the NGINX configuration to serve the built site.
 
@@ -993,7 +993,7 @@ Hook rules were not satisfied.⏎
 
         hugo new post/test-post.md
 
-1.  This command creates a new partially filled in markdown document in `content/post/`. Open this file in your editor, remove the `draft: true` line from the [*frontmatter*](https://gohugo.io/content-management/front-matter/), and add some body text:
+1.  This command creates a new partially filled in Markdown document in `content/post/`. Open this file in your editor, remove the `draft: true` line from the [*frontmatter*](https://gohugo.io/content-management/front-matter/), and add some body text:
 
     {{< file "example-hugo-site/content/post/test-post.md" >}}
 ---

--- a/docs/applications/project-management/how-to-create-a-private-python-package-repository/index.md
+++ b/docs/applications/project-management/how-to-create-a-private-python-package-repository/index.md
@@ -85,7 +85,7 @@ def hello_word():
 {{< /file >}}
 
 
-5.  The `setup.cfg` file lets PyPI know the README is a markdown file:
+5.  The `setup.cfg` file lets PyPI know the README is a Markdown file:
 
     {{< file "setup.cfg" >}}
 [metadata]

--- a/docs/applications/project-management/jupyter-notebook-on-jekyll/index.md
+++ b/docs/applications/project-management/jupyter-notebook-on-jekyll/index.md
@@ -140,7 +140,7 @@ The steps in this section can be completed from either your local machine or fro
 
 This section demonstrates some common features of a Jupyter Notebook that can be rendered as HTML on a Jekyll blog. There are four types of outputs from a Jupyter Notebook cell covered here: MathJex through LaTeX in Markdown, an HTML table, console output, and graphs from a plotting function. The Iris dataset will be used as an example to generate the output in this guide.
 
-1.  Open the notebook of interest, or use the code below to create an example notebook. Run all of the relevant cells so that the output you want to display on your Jekyll blog is visible on the page. Navigate to `File > Download As > Markdown (.md)`. The markdown file will save to the default `Downloads` folder of the browser.
+1.  Open the notebook of interest, or use the code below to create an example notebook. Run all of the relevant cells so that the output you want to display on your Jekyll blog is visible on the page. Navigate to `File > Download As > Markdown (.md)`. The Markdown file will save to the default `Downloads` folder of the browser.
 
     ![Jupyter Menu](jupyter_menu.png "Jupyter Menu")
 
@@ -175,11 +175,11 @@ sns.pairplot(x_vars=["petal-length"], y_vars=["petal-width"], data=iris, hue="cl
 {{< /file >}}
 
 
-3.  Inside the `_posts` folder of the Jekyll project, create a new markdown file called `YYYY-MM-DD-example-post.md`. If the date format is incorrect, the post may not be displayed on the blog:
+3.  Inside the `_posts` folder of the Jekyll project, create a new Markdown file called `YYYY-MM-DD-example-post.md`. If the date format is incorrect, the post may not be displayed on the blog:
 
         touch YYYY-MM-DD-example-post.md
 
-4.  The markdown file should begin with three dashes and contain headers which provide information for Jekyll to populate the post with the appropriate page data. The date must be in the format specified. The hours, minutes, seconds, and timezone adjustment are optional:
+4.  The Markdown file should begin with three dashes and contain headers which provide information for Jekyll to populate the post with the appropriate page data. The date must be in the format specified. The hours, minutes, seconds, and timezone adjustment are optional:
 
     {{< file "YYYY-MM-DD-example-post.md" yaml >}}
 ---
@@ -193,7 +193,7 @@ categories:
 {{< /file >}}
 
 
-5.  Copy the contents of the markdown file exported from Jupyter into the new post.
+5.  Copy the contents of the Markdown file exported from Jupyter into the new post.
 
     To do this from the command line, use:
 
@@ -253,11 +253,11 @@ margin-bottom: 0; }
 
 ### Add an Image in Jekyll
 
-Adding an image through markdown requires having the images stored in the project directory.
+Adding an image through Markdown requires having the images stored in the project directory.
 
 1.  Move all of the images exported from Jupyter into the `/assets/images` folder.
 
-2.  Modify the references to images within the markdown to the appropriate path. Wrap the path in two curly braces and double quotes.
+2.  Modify the references to images within the Markdown to the appropriate path. Wrap the path in two curly braces and double quotes.
 
     {{< file "YYYY-MM-DD-example-post.md" >}}
 ![png]({{ "/assets/images/example_notebook_5_0.png" }})

--- a/docs/linode-writers-formatting-guide/index.md
+++ b/docs/linode-writers-formatting-guide/index.md
@@ -28,7 +28,7 @@ We only accept new guides and authors through our guide submission process. To a
 
 ## General Layout
 
-Linode Guides & Tutorials are written in [Markdown](https://en.wikipedia.org/wiki/Markdown). Our documentation site uses [Hugo](https://gohugo.io), a static site generator. Hugo-specific markdown formatting notes are given [further below](#markdown-formatting).
+Linode Guides & Tutorials are written in [Markdown](https://en.wikipedia.org/wiki/Markdown). Our documentation site uses [Hugo](https://gohugo.io), a static site generator. Hugo-specific Markdown formatting notes are given [further below](#markdown-formatting).
 
 ### Header
 
@@ -209,7 +209,7 @@ If you wish to provide links to external sites for the user to review after goin
 
 ### Extend Markdown Using Shortguides
 
-Using shortcodes, it is possible to extend a markdown file with another. For common tasks such as basic software installation, consider using the `content` shortcode. This allows our library to maintain consistent and up to date installation instructions for frequently used tools such as Python, MySQL, and Docker.
+Using shortcodes, it is possible to extend a Markdown file with another. For common tasks such as basic software installation, consider using the `content` shortcode. This allows our library to maintain consistent and up to date installation instructions for frequently used tools such as Python, MySQL, and Docker.
 
 Markdown files intended to be inserted into multiple guides are called shortguides. To create a shortguide, create a directory with the name of your shortguide anywhere within `docs/`, and then create an index.md within the directory for your content (e.g. `example-shortguide-name/index.md`).
 
@@ -270,7 +270,7 @@ Adding `os: ["mac", "linux", "windows"]` to the front matter inserts a jQuery sc
 
 The shortcode should contain two parameters: filepath and operating system.
 
-For example, `{{</* content "how-to-install-git-mac" mac */>}}` will insert a markdown snippet that will only be visible when the Mac button is in the active state.
+For example, `{{</* content "how-to-install-git-mac" mac */>}}` will insert a Markdown snippet that will only be visible when the Mac button is in the active state.
 
 ### Files and File Excerpts
 


### PR DESCRIPTION
These guides broke with the new Markdown rule added with the Object Storage guide update in this PR: https://github.com/linode/docs/pull/2444

docs/applications/configuration-management/automate-a-static-site-deployment-with-salt/index.md

docs/applications/project-management/how-to-create-a-private-python-package-repository/index.md

docs/applications/project-management/jupyter-notebook-on-jekyll/index.md

docs/linode-writers-formatting-guide/index.md