### PR TITLE
Adding authorization hold information to Billing Guides

### DIFF
--- a/docs/platform/billing-and-support/billing-and-payments-classic-manager/index.md
+++ b/docs/platform/billing-and-support/billing-and-payments-classic-manager/index.md
@@ -166,6 +166,8 @@ Your credit card information will be updated.
  {{< note >}}
 If you have an outstanding balance, you will need to make a manual payment to bring your account up to date. See the [Making a Payment](#making-a-payment) section for more information.
 {{< /note >}}
+ {{< note >}}
+A $1.00 authorization hold may be placed on your credit card by your banking institution when our payment processor tests the validity of the card. This is normal behavior and does not result in a charge on your card.{{< /note >}}
 
 ## Removing Services
 

--- a/docs/platform/billing-and-support/billing-and-payments-classic-manager/index.md
+++ b/docs/platform/billing-and-support/billing-and-payments-classic-manager/index.md
@@ -167,7 +167,8 @@ Your credit card information will be updated.
 If you have an outstanding balance, you will need to make a manual payment to bring your account up to date. See the [Making a Payment](#making-a-payment) section for more information.
 {{< /note >}}
  {{< note >}}
-A $1.00 authorization hold may be placed on your credit card by your banking institution when our payment processor tests the validity of the card. This is normal behavior and does not result in a charge on your card.{{< /note >}}
+A $1.00 authorization hold may be placed on your credit card by your banking institution when our payment processor tests the validity of the card. This is normal behavior and does not result in a charge on your card.
+{{< /note >}}
 
 ## Removing Services
 

--- a/docs/platform/billing-and-support/billing-and-payments/index.md
+++ b/docs/platform/billing-and-support/billing-and-payments/index.md
@@ -166,6 +166,8 @@ Your credit card information will be updated.
  {{< note >}}
 If you have an outstanding balance, you will need to make a manual payment to bring your account up to date. See the [Making a Payment](#making-a-payment) section for more information.
 {{< /note >}}
+ {{< note >}}
+A $1.00 authorization hold may be placed on your credit card by your banking institution when our payment processor tests the validity of the card. This is normal behavior and does not result in a charge on your card.{{< /note >}}
 
 ## Removing Services
 

--- a/docs/platform/billing-and-support/billing-and-payments/index.md
+++ b/docs/platform/billing-and-support/billing-and-payments/index.md
@@ -167,7 +167,8 @@ Your credit card information will be updated.
 If you have an outstanding balance, you will need to make a manual payment to bring your account up to date. See the [Making a Payment](#making-a-payment) section for more information.
 {{< /note >}}
  {{< note >}}
-A $1.00 authorization hold may be placed on your credit card by your banking institution when our payment processor tests the validity of the card. This is normal behavior and does not result in a charge on your card.{{< /note >}}
+A $1.00 authorization hold may be placed on your credit card by your banking institution when our payment processor tests the validity of the card. This is normal behavior and does not result in a charge on your card.
+{{< /note >}}
 
 ## Removing Services
 


### PR DESCRIPTION
Hey all! I've been trying to get used to git/github and I thought this would be a solid way to do it! This change just adds information about the temporary authorization hold to the "Updating Credit Card Information" section of the Classic and Cloud Billing guides:

![Screen Shot 2019-07-25 at 11 27 23 AM](https://user-images.githubusercontent.com/52320976/61888202-1ed23000-aed1-11e9-80b0-1479f5a8c4f1.png)

Let me know if I should change anything :)