### PR TITLE
Updated the guides to reflect 4.0 version of MangoDB

### DIFF
--- a/docs/databases/mongodb/build-database-clusters-with-mongodb/index.md
+++ b/docs/databases/mongodb/build-database-clusters-with-mongodb/index.md
@@ -25,7 +25,7 @@ MongoDB is a leading non-relational database management system, and a prominent 
 
 There are two broad categories of scaling strategies for data. *Vertical scaling* involves adding more resources to a server so that it can handle larger datasets. The upside is that the process is usually as simple as migrating the database, but it often involves downtime and is difficult to automate. *Horizontal scaling* involves adding more servers to increase the resources, and is generally preferred in configurations that use fast-growing, dynamic datasets. Because it is based on the concept of adding more servers, not more resources on one server, datasets often need to be broken into parts and distributed across the servers. Sharding refers to the breaking up of data into subsets so that it can be stored on separate database servers (a sharded cluster).
 
-The commands and filepaths in this guide are based on those used in Ubuntu 16.04 (Xenial). However, the configuration is the same for any system running MongoDB 3.2. To use this guide with a Linode running CentOS 7, for example, simply adjust the distro-specific commands and configuration files accordingly.
+The commands and filepaths in this guide are based on those used in Ubuntu 16.04 (Xenial). However, the configuration is the same for any system running MongoDB 4.0. To use this guide with a Linode running CentOS 7, for example, simply adjust the distro-specific commands and configuration files accordingly.
 
 ## Before You Begin
 
@@ -80,7 +80,7 @@ You may also configure DNS records for each host rather than using hosts file en
 
 ## Set Up MongoDB Authentication
 
-In this section you'll create a key file that will be used to secure authentication between the members of your replica set. While in this example you'll be using a key file generated with `openssl`, MongoDB recommends using an [X.509 certificate](https://docs.mongodb.com/v3.2/core/security-x.509/) to secure connections between production systems.
+In this section you'll create a key file that will be used to secure authentication between the members of your replica set. While in this example you'll be using a key file generated with `openssl`, MongoDB recommends using an [X.509 certificate](https://docs.mongodb.com/v4.0/core/security-x.509/) to secure connections between production systems.
 
 ### Create an Administrative User
 
@@ -436,7 +436,7 @@ Before we enable sharding for a collection, we'll need to decide on a *sharding 
 
 **Hash-based sharding** distributes data by using a hash function on your shard key for a more even distribution of data among the shards. Suppose again that you have a collection of customers and addresses. In a hash-based sharding setup, you may choose a customer ID number, for example, as the shard key. This number is transformed by a hash function, and the results of the hashing are what determines which shard the data is stored on. Hash-based sharding is a good strategy in situations where your application will mostly perform write operations, or if your application needs only to run simple read queries like looking up only a few specific customers at a time.
 
-This is not intended to be a comprehensive guide to choosing a sharding strategy. Before making this decision for a production cluster, be sure to analyze your dataset, computing resources, and the queries your application will run. For more information, refer to [MongoDB's documentation on sharding](https://docs.mongodb.com/v3.2/sharding/).
+This is not intended to be a comprehensive guide to choosing a sharding strategy. Before making this decision for a production cluster, be sure to analyze your dataset, computing resources, and the queries your application will run. For more information, refer to [MongoDB's documentation on sharding](https://docs.mongodb.com/v4.0/sharding/).
 
 ### Enable Sharding at Collection Level
 

--- a/docs/databases/mongodb/create-a-mongodb-replica-set/index.md
+++ b/docs/databases/mongodb/create-a-mongodb-replica-set/index.md
@@ -78,7 +78,7 @@ These hostnames are only given as examples, but we'll use these names throughout
 
 ## Set Up MongoDB Authentication
 
-In this section you'll create a key file that will be used to secure authentication between the members of your replica set. While in this example you'll be using a key file generated with `openssl`, MongoDB recommends using an [X.509 certificate](https://docs.mongodb.com/v3.2/core/security-x.509/) to secure connections between production systems.
+In this section you'll create a key file that will be used to secure authentication between the members of your replica set. While in this example you'll be using a key file generated with `openssl`, MongoDB recommends using an [X.509 certificate](https://docs.mongodb.com/v4.0/core/security-x.509/) to secure connections between production systems.
 
 ### Generate a Key file
 
@@ -211,7 +211,7 @@ At this stage, your replica set is fully functional and ready to use. The steps 
 
     This command enables secondary member read operations on a per-connection basis, so be sure to disconnect before you deploy your replica set into production. By default, read queries are not allowed on secondary members to avoid problems with your application retrieving stale data. This can become an issue when your database is undergoing more complex queries at a higher load, but because of the relatively simple test data we wrote, this is not an issue here.
 
-    However, changing the overall read preference can have benefits in some cases. For more information, see the official [MongoDB documentation](https://docs.mongodb.com/v3.2/core/read-preference/).
+    However, changing the overall read preference can have benefits in some cases. For more information, see the official [MongoDB documentation](https://docs.mongodb.com/v4.0/core/read-preference/).
 
 4.  Before running the command in the previous step, any read operations, including simple ones like `show dbs` and `show collections` would fail with an error. Now that you've enabled reading, switch to the `exampleDB` database:
 

--- a/docs/databases/mongodb/install-mongodb-on-centos-7/index.md
+++ b/docs/databases/mongodb/install-mongodb-on-centos-7/index.md
@@ -11,7 +11,7 @@ modified_by:
 published: 2016-12-30
 title: 'Install MongoDB on CentOS 7'
 external_resources:
- - '[Official MongoDB Documentation](https://docs.mongodb.org/v3.2/)'
+ - '[Official MongoDB Documentation](https://docs.mongodb.org/v4.0/)'
  - '[MongoDB Project](http://www.mongodb.org/)'
  - '[Language-Specific MongoDB Drivers](http://docs.mongodb.org/ecosystem/drivers/)'
 ---
@@ -42,17 +42,17 @@ This guide is written for a non-root user. Commands that require elevated privil
 
 ## Add the MongoDB Repository
 
-The most current stable version of MongoDB is 3.2 and, as of this writing, the default CentOS 7 repository does not contain a package for it. Instead, we'll need to use the MongoDB repository.
+The most current stable version of MongoDB is 4.0 and, as of this writing, the default CentOS 7 repository does not contain a package for it. Instead, we'll need to use the MongoDB repository.
 
-Create a new file, `/etc/yum.repos.d/mongodb-org-3.2.repo`, so that you can install the latest release using `yum`. Add the following contents to the file:
+Create a new file, `/etc/yum.repos.d/mongodb-org-4.0.repo`, so that you can install the latest release using `yum`. Add the following contents to the file:
 
-{{< file "/etc/yum.repos.d/mongodb-org-3.2.repo" >}}
-[mongodb-org-3.2]
+{{< file "/etc/yum.repos.d/mongodb-org-4.0.repo" >}}
+[mongodb-org-4.0]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.0/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc
 
 {{< /file >}}
 
@@ -113,7 +113,7 @@ Issue the following commands to increase your open file and process limits for M
     echo "mongod     soft    nofiles   64000" >> /etc/security/limits.conf
     echo "mongod     soft    nproc     64000" >> /etc/security/limits.conf
 
-These are the [recommended](https://docs.mongodb.com/v3.2/reference/ulimit/#recommended-ulimit-settings) settings, but you may need to adjust them depending upon your individual usage. See the [MongoDB Documentation](https://docs.mongodb.com/v3.2/reference/ulimit/) for more information.
+These are the [recommended](https://docs.mongodb.com/v4.0/reference/ulimit/#recommended-ulimit-settings) settings, but you may need to adjust them depending upon your individual usage. See the [MongoDB Documentation](https://docs.mongodb.com/v4.0/reference/ulimit/) for more information.
 
 ## Start and Stop MongoDB
 
@@ -183,7 +183,7 @@ If you enabled role-based access control in the [Configure MongoDB](#configure-m
 
         quit()
 
-For more information on access control and user management, as well as other tips on securing your databases, refer to the [MongoDB Security Documentation](https://docs.mongodb.org/v3.2/security).
+For more information on access control and user management, as well as other tips on securing your databases, refer to the [MongoDB Security Documentation](https://docs.mongodb.org/v4.0/security).
 
 ## Manage Data and Collections
 
@@ -205,7 +205,7 @@ Much of MongoDB's popularity comes from its ease of integration. Interactions wi
 
         db.createCollection("exampleCollection", {capped: false})
 
-    If you're not familiar with MongoDB terminology, you can think of a collection as analogous to a table in a relational database management system. For more information on creating new collections, see the MongoDB documentation on the [db.createCollection() method](https://docs.mongodb.com/v3.2/reference/method/db.createCollection/).
+    If you're not familiar with MongoDB terminology, you can think of a collection as analogous to a table in a relational database management system. For more information on creating new collections, see the MongoDB documentation on the [db.createCollection() method](https://docs.mongodb.com/v4.0/reference/method/db.createCollection/).
 
     {{< note >}}
 Collection names should not include certain punctuation such as hyphens. However, exceptions may not be raised until you attempt to use or modify the collection. For more information, refer to MongoDB's [naming restrictions](https://docs.mongodb.com/manual/reference/limits/#naming-restrictions).

--- a/docs/databases/mongodb/install-mongodb-on-ubuntu-16-04/index.md
+++ b/docs/databases/mongodb/install-mongodb-on-ubuntu-16-04/index.md
@@ -11,7 +11,7 @@ modified_by:
 published: 2016-05-20
 title: 'Install MongoDB on Ubuntu 16.04 (Xenial)'
 external_resources:
- - '[Official MongoDB Documentation](https://docs.mongodb.org/v3.2/)'
+ - '[Official MongoDB Documentation](https://docs.mongodb.com/v4.0/)'
  - '[MongoDB Project](http://www.mongodb.org/)'
  - '[Language-Specific MongoDB Drivers](http://docs.mongodb.org/ecosystem/drivers/)'
 ---
@@ -42,17 +42,17 @@ This guide is written for a non-root user. Commands that require elevated privil
 
 ## Add the MongoDB Repository
 
-The `mongodb-server` package from the Ubuntu repository includes version 2.6. However, this version reached end of life in October 2016, so it should not be used in production environments. The most current version available is 3.2 and, as of this writing, the default Ubuntu repositories do not contain an updated package.
+The `mongodb-server` package from the Ubuntu repository includes version 2.6. However, this version reached end of life in October 2016, so it should not be used in production environments. The most current version available is 4.0 and, as of this writing, the default Ubuntu repositories do not contain an updated package.
 
 Because the Ubuntu repositories don't contain a current version, we'll need to use the MongoDB repository.
 
 1.  Import the MongoDB public GPG key for package signing:
 
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
 
 2.  Add the MongoDB repository to your `sources.list.d` directory:
 
-        echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+        echo "deb [ arch=amd64,arm64,ppc64el,s390x ] http://repo.mongodb.com/apt/ubuntu xenial/mongodb-enterprise/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
 3.  Update your repositories. This allows `apt` to read from the newly added MongoDB repo:
 
@@ -175,7 +175,7 @@ Successfully added user: {
 
         quit()
 
-For more information on access control and user management, as well as other tips on securing your databases, refer to the [MongoDB Security Documentation](https://docs.mongodb.org/v3.2/security).
+For more information on access control and user management, as well as other tips on securing your databases, refer to the [MongoDB Security Documentation](https://docs.mongodb.org/v4.0/security).
 
 ## Manage Data and Collections
 
@@ -197,7 +197,7 @@ Much of MongoDB's popularity comes from its ease of integration. Interactions wi
 
         db.createCollection("exampleCollection", {capped: false})
 
-    If you're not familiar with MongoDB terminology, you can think of a collection as analogous to a table in a relational database management system. For more information on creating new collections, see the MongoDB documentation on the [db.createCollection() method](https://docs.mongodb.com/v3.2/reference/method/db.createCollection/).
+    If you're not familiar with MongoDB terminology, you can think of a collection as analogous to a table in a relational database management system. For more information on creating new collections, see the MongoDB documentation on the [db.createCollection() method](https://docs.mongodb.com/v4.0/reference/method/db.createCollection/).
 
     {{< note >}}
 Collection names should not include certain punctuation such as hyphens. However, exceptions may not be raised until you attempt to use or modify the collection. For more information, refer to MongoDB's [naming restrictions](https://docs.mongodb.com/manual/reference/limits/#naming-restrictions).

--- a/docs/databases/mongodb/install-mongodb-on-ubuntu-16-04/index.md
+++ b/docs/databases/mongodb/install-mongodb-on-ubuntu-16-04/index.md
@@ -52,7 +52,7 @@ Because the Ubuntu repositories don't contain a current version, we'll need to u
 
 2.  Add the MongoDB repository to your `sources.list.d` directory:
 
-        echo "deb [ arch=amd64,arm64,ppc64el,s390x ] http://repo.mongodb.com/apt/ubuntu xenial/mongodb-enterprise/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+        echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
 
 3.  Update your repositories. This allows `apt` to read from the newly added MongoDB repo:
 


### PR DESCRIPTION
Fixes: https://github.com/linode/docs/issues/2581
Updated all references of MangoDB 3.2 to 4.0 and validated the commands against the official MangoDB documents.