### PR TITLE
Updated the Package upgrades command for Gentoo

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -186,7 +186,7 @@ You may be prompted to make a menu selection when the Grub package is updated on
 
 After running a sync, it may end with a message that you should upgrade Portage using a `--oneshot` emerge command. If so, run the Portage update. Then update the rest of the system:
 
-    emerge --uDN @world
+    emerge -uDU --keep-going --with-bdeps=y @world
 
 ### OpenSUSE
 


### PR DESCRIPTION
Validated the command on a Gentoo Linode. The current command: emerge --uDN @world results in: emerge --uDN @world! '--uDN' is not a valid package atom.! Please check ebuild(5) for full details.
The command emerge -uDU --keep-going --with-bdeps=y @world llisted on The wiki https://wiki.gentoo.org/wiki/Gentoo_Cheat_Sheet#Package_upgrades works fine!