### PR TITLE
[update] Getting Started - Reworded the phrase about ipV6 address

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -246,7 +246,7 @@ The `hosts` file creates static associations between IP addresses and hostnames 
 203.0.113.10 hostname.example.com hostname
 {{< /file >}}
 
-You may also want to add an entry for your Linode's IPv6 address:
+Add an entry for your Linode's IPv6 address. Applications requiring IPv6 will not work without this entry:
 
   {{< file "/etc/hosts" conf >}}
 127.0.0.1 localhost.localdomain localhost


### PR DESCRIPTION
reworded "You may also want to add an entry for your Linode’s IPv6 address:" as " Add an entry for your Linode's IPv6 address. Applications requiring IPv6 will not work without this entry:"

Addresses: https://linode.com/docs/getting-started/#comment-4566207670