### PR TITLE
Update link to prevent 404 error

### DIFF
--- a/docs/websites/cms/how-to-install-ghost-cms-on-ubuntu-16-04/index.md
+++ b/docs/websites/cms/how-to-install-ghost-cms-on-ubuntu-16-04/index.md
@@ -116,7 +116,7 @@ Install Ghost 1.0.0 using the Ghost-CLI tool.
 
         ghost install
 
-6. Answer each question as prompted. For more information about each question, visit the [Ghost documentation](https://docs.ghost.org/docs/cli-install#section-prompts):
+6. Answer each question as prompted. For more information about each question, visit the [Ghost documentation](https://ghost.org/docs/install/ubuntu/#install-questions):
 
     {{< output >}}
 ? Enter your blog URL: https://example.com


### PR DESCRIPTION
I have swapped out the link to Ghost's own documentation on an Ubuntu install.  The current link is broken.  The new link is very informative and takes one exactly where one needs to go.