### PR TITLE
[update] Changed to click on advanced tab rather than settings tab

### DIFF
--- a/docs/platform/network-helper/index.md
+++ b/docs/platform/network-helper/index.md
@@ -57,7 +57,7 @@ When Network Helper is enabled globally, all new Linodes created on your account
 
     ![Navigate to the Linode's Settings page](network-helper-linode-settings-link.png)
 
-1.  In the **Advanced Configurations** panel, click on the **more options ellipsis** for your Disk Profile. From the menu, select **Edit**:
+1.  From the Linode's Dashboard screen, click the tab labeled **Advanced**.  Next, click on the **more options ellipsis** for your Disk Profile. From the menu, select **Edit**:
 
     [![Select the configuration profile Edit Menu](network-helper-linode-settings-page-small.png)](network-helper-linode-settings-page.png)
 


### PR DESCRIPTION
Currently is says to select settings and then select advanced from there.  However, the advanced settings must have been changed to their own tab.  Which I like as it does not bury the options so deep.  Anywho, the picture will also need to be changed so that you can see the advanced tab.