### PR TITLE
dpkg requires privileges used in other steps

### DIFF
--- a/docs/applications/configuration-management/install-a-chef-server-workstation-on-ubuntu-18-04/index.md
+++ b/docs/applications/configuration-management/install-a-chef-server-workstation-on-ubuntu-18-04/index.md
@@ -97,7 +97,7 @@ In this section, you will download and install the Chef Workstation package, whi
 
 1.  Install Chef Workstation:
 
-        dpkg -i chef-workstation_*.deb
+        sudo dpkg -i chef-workstation_*.deb
 
 1.  Remove the installation file:
 


### PR DESCRIPTION
Other steps use `sudo` before `dpkg` to get around the superuser privileges needed. Without this you get:

```bash
vagrant@stretch:~$ dpkg -i chef-workstation_*.deb
dpkg: error: requested operation requires superuser privilege
```