### PR TITLE
Clarify cloned key section

### DIFF
--- a/docs/platform/longview/longview/index.md
+++ b/docs/platform/longview/longview/index.md
@@ -294,7 +294,9 @@ If you clone a Linode which has Longview installed, you may encounter the follow
 Multiple clients appear to be posting data with this API key. Please check your clients' configuration.
 {{< /output >}}
 
-This is caused by both Linodes posting data using the same Longview key. To resolve it, reinstall Longview on the cloned system using the instructions [above](#install-the-longview-client). This will give the new Linode's system a Longview API key independent from the system which it was cloned from.
+This is caused by both Linodes posting data using the same Longview key. To resolve it, uninstall & then reinstall Longview on the cloned system using the instructions [above](#install-the-longview-client). This will give the new Linode's system a Longview API key independent from the system which it was cloned from.
+
+NOTE, the GUID shown in the Linode Manager Longview installation URL is not the same as the Linode Longview key.  
 
 ### Contact Support
 

--- a/docs/platform/longview/longview/index.md
+++ b/docs/platform/longview/longview/index.md
@@ -296,7 +296,7 @@ Multiple clients appear to be posting data with this API key. Please check your 
 
 This is caused by both Linodes posting data using the same Longview key. To resolve it, uninstall & then reinstall Longview on the cloned system using the instructions [above](#install-the-longview-client). This will give the new Linode's system a Longview API key independent from the system which it was cloned from.
 
-NOTE, the GUID shown in the Linode Manager Longview installation URL is not the same as the Linode Longview key.  
+NOTE, the GUID shown in the Linode Manager Longview installation URL is not the same as the Linode Longview key.
 
 ### Contact Support
 


### PR DESCRIPTION
1.  I had a dupe Longview key issue but didn't get the error message shown.   Re-installing by itself doesn't seem to do anything either if the client is already up to date, so it seems one may need to first *uninstall* then re-install.  

2. I also assumed the GUID shown in the URL was the same as the Longview key, which does not seem to be the case so adding a note about this may help to clarify things.