### PR TITLE
Fixed** resize disk instructions for navigating Cloud Manager Tabs

### DIFF
--- a/docs/quick-answers/linode-platform/resize-a-linode-disk/index.md
+++ b/docs/quick-answers/linode-platform/resize-a-linode-disk/index.md
@@ -24,10 +24,8 @@ This Quick Answer will show you how to resize a disk on your Linode. See our [Di
 1. Power off the Linode. Watch the Linode's **Summary** section for confirmation that the Linode has powered off.
 
     ![Power off Linode](power-off.png "Power off your Linode")
-1. Navigate to the **Settings** tab and open the **Advanced Configurations** panel.
 
-    ![Linode advanced configurations](advanced-configurations.png "Linode advanced configurations")
-1. Under the **Disks** section, find the disk you would like to resize and choose the **Resize** option from the menu.
+1. Navigate to the **Advanced** tab and under the **Disks** section, find the disk you would like to resize and choose the **Resize** option from the menu.
 
     ![Resize the Linode disk](resize-linode.png "Resize the Linode Disk")
 


### PR DESCRIPTION
- **Advanced Tab** has been added to Cloud Manager so I updated the guide to reflect this.  It currently incorrectly directs the user to navigate to **Settings** to find **Disks** tab instead of **Advanced**.  I also removed the accompanying screenshot to avoid confusion.
- This change also allowed the removal of a step, consolidating two into one

- Further suggested updates would be new screenshots to reflect latest Cloud Manager