### PR TITLE
Updated repo and references to MongoDB 4.2

### DIFF
--- a/docs/databases/mongodb/install-mongodb-on-centos-7/index.md
+++ b/docs/databases/mongodb/install-mongodb-on-centos-7/index.md
@@ -11,9 +11,9 @@ modified_by:
 published: 2016-12-30
 title: 'Install MongoDB on CentOS 7'
 external_resources:
- - '[Official MongoDB Documentation](https://docs.mongodb.org/v4.0/)'
+ - '[Official MongoDB Documentation](https://docs.mongodb.com/manual/)'
  - '[MongoDB Project](http://www.mongodb.org/)'
- - '[Language-Specific MongoDB Drivers](http://docs.mongodb.org/ecosystem/drivers/)'
+ - '[Language-Specific MongoDB Drivers](http://docs.mongodb.com/ecosystem/drivers/)'
 ---
 
 In this MongoDB tutorial, we explain how to install the database on CentOS 7, and then provide a short guide on some basic features and functions.
@@ -22,7 +22,7 @@ In this MongoDB tutorial, we explain how to install the database on CentOS 7, an
 
 MongoDB is a database engine that provides access to non-relational, document-oriented databases. It is part of the growing [NoSQL](https://en.wikipedia.org/wiki/NoSQL) movement, along with databases like Redis and Cassandra (although there are vast differences among the many non-relational databases).
 
-MongoDB seeks to provide an alternative to traditional relational database management systems (RDBMS). In addition to its schema-free design and scalable architecture, MongoDB provides a JSON output and specialized, language-specific bindings that make it particularly attractive for use in custom application development and rapid prototyping. MongoDB has been used in a number of large scale [production deployments](https://www.mongodb.org/community/deployments) and is currently one of the most popular database engines across all systems.
+MongoDB seeks to provide an alternative to traditional relational database management systems (RDBMS). In addition to its schema-free design and scalable architecture, MongoDB provides a JSON output and specialized, language-specific bindings that make it particularly attractive for use in custom application development and rapid prototyping. MongoDB has been used in a number of large scale [production deployments](https://www.mongodb.com/community/deployments) and is currently one of the most popular database engines across all systems.
 
 Since MongoDB can require a significant amount of RAM, we recommend using a [high memory Linode](https://www.linode.com/pricing#high-memory) with this guide.
 
@@ -42,17 +42,17 @@ This guide is written for a non-root user. Commands that require elevated privil
 
 ## Add the MongoDB Repository
 
-The most current stable version of MongoDB is 4.0 and, as of this writing, the default CentOS 7 repository does not contain a package for it. Instead, we'll need to use the MongoDB repository.
+The most current stable version of MongoDB is 4.2 and, as of this writing, the default CentOS 7 repository does not contain a package for it. Instead, we'll need to use the MongoDB repository.
 
-Create a new file, `/etc/yum.repos.d/mongodb-org-4.0.repo`, so that you can install the latest release using `yum`. Add the following contents to the file:
+Create a new file, `/etc/yum.repos.d/mongodb-org-4.2.repo`, so that you can install the latest release using `yum`. Add the following contents to the file:
 
-{{< file "/etc/yum.repos.d/mongodb-org-4.0.repo" >}}
-[mongodb-org-4.0]
+{{< file "/etc/yum.repos.d/mongodb-org-4.2.repo" >}}
+[mongodb-org-4.2]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.0/x86_64/
+baseurl=https://repo.mongodb.com/yum/redhat/$releasever/mongodb-org/4.2/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc
+gpgkey=https://www.mongodb.com/static/pgp/server-4.2.asc
 
 {{< /file >}}
 
@@ -113,7 +113,7 @@ Issue the following commands to increase your open file and process limits for M
     echo "mongod     soft    nofiles   64000" >> /etc/security/limits.conf
     echo "mongod     soft    nproc     64000" >> /etc/security/limits.conf
 
-These are the [recommended](https://docs.mongodb.com/v4.0/reference/ulimit/#recommended-ulimit-settings) settings, but you may need to adjust them depending upon your individual usage. See the [MongoDB Documentation](https://docs.mongodb.com/v4.0/reference/ulimit/) for more information.
+These are the [recommended](https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings) settings, but you may need to adjust them depending upon your individual usage. Please note that CentOS 6 and 7 enforce an additional, separate max process limitation `nproc` that must also be adjusted. See the [MongoDB Documentation](https://docs.mongodb.com/manual/reference/ulimit/#red-hat-linux-enterprise-server-and-centos) for more information about configuring these settings.
 
 ## Start and Stop MongoDB
 
@@ -183,11 +183,11 @@ If you enabled role-based access control in the [Configure MongoDB](#configure-m
 
         quit()
 
-For more information on access control and user management, as well as other tips on securing your databases, refer to the [MongoDB Security Documentation](https://docs.mongodb.org/v4.0/security).
+For more information on access control and user management, as well as other tips on securing your databases, refer to the [MongoDB Security Documentation](https://docs.mongodb.com/manual/security).
 
 ## Manage Data and Collections
 
-Much of MongoDB's popularity comes from its ease of integration. Interactions with databases are done via JavaScript methods, but [drivers for other languages](http://docs.mongodb.org/ecosystem/drivers/) are available. This section will demonstrate a few basic features, but we encourage you to do further research based on your specific use case.
+Much of MongoDB's popularity comes from its ease of integration. Interactions with databases are done via JavaScript methods, but [drivers for other languages](http://docs.mongodb.com/ecosystem/drivers/) are available. This section will demonstrate a few basic features, but we encourage you to do further research based on your specific use case.
 
 1.  Open the MongoDB shell using the `example-user` we created above:
 
@@ -197,7 +197,7 @@ Much of MongoDB's popularity comes from its ease of integration. Interactions wi
 
         use exampleDB
 
-    Make sure that this database name corresponds with the one for which the user has read and write permissions (we added these permissions in Step 7 of the previous section).
+    Make sure that this database name corresponds with the one for which the user has read and write permissions (we added these permissions in Step 7 of the previous section). Please also refer to MongoDB's [naming restrictions](https://docs.mongodb.com/manual/reference/limits/#naming-restrictions).
 
     To show the name of the current working database, run the `db` command.
 
@@ -205,7 +205,7 @@ Much of MongoDB's popularity comes from its ease of integration. Interactions wi
 
         db.createCollection("exampleCollection", {capped: false})
 
-    If you're not familiar with MongoDB terminology, you can think of a collection as analogous to a table in a relational database management system. For more information on creating new collections, see the MongoDB documentation on the [db.createCollection() method](https://docs.mongodb.com/v4.0/reference/method/db.createCollection/).
+    If you're not familiar with MongoDB terminology, you can think of a collection as analogous to a table in a relational database management system. For more information on creating new collections, see the MongoDB documentation on the [db.createCollection() method](https://docs.mongodb.com/manual/reference/method/db.createCollection/).
 
     {{< note >}}
 Collection names should not include certain punctuation such as hyphens. However, exceptions may not be raised until you attempt to use or modify the collection. For more information, refer to MongoDB's [naming restrictions](https://docs.mongodb.com/manual/reference/limits/#naming-restrictions).


### PR DESCRIPTION
Updated repo file and inline references to MongoDB 4.2, the current latest production release, and updated some links that were hardcoded to 4.0 docs. Clarified RHEL/CentOS-specific nproc settings and added a link to DB naming restrictions also.