### PR TITLE
[Update] How to Build Caddy From Source

### DIFF
--- a/docs/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/web-servers/caddy/compile-caddy-from-source/index.md
@@ -16,11 +16,12 @@ external_resources:
 
 [Caddy](https://caddyserver.com/) is a fast, open-source and security-focused web server written in [Go](https://golang.org/). Caddy includes modern features such as support for virtual hosts, minification of static files, and HTTP/2. Caddy is also the first web-server that can obtain and renew SSL/TLS certificates automatically using [Let's Encrypt](https://letsencrypt.org/).
 
-Caddy has recently updated their license, clearly defining what is considered personal or enterprise use. A commercial license is now required for commercial or enterprise use, including any installation that uses precompiled Caddy binaries. However, because the project is Apache licensed, by building it from source you have access to the original, [Apache-licensed web server.](https://twitter.com/mholt6/status/908041929438371840).
+Caddy has recently updated their license, clearly defining what is considered personal or enterprise use. A commercial license is now required for commercial or enterprise use, including any installation that uses precompiled Caddy binaries. However, because the project is Apache licensed, by building it from source you have access to the original, [Apache-licensed web server](https://twitter.com/mholt6/status/908041929438371840).
 
-## Build Caddy
+## Build Caddy from Source
+### Install Go
 
-You will need a current version of Go on your Linode. Read our guide on [installing Go](/docs/development/go/install-go-on-ubuntu/).
+1. You will need a current version of Go installed on your Linode. Complete the steps in our guide on [installing Go](/docs/development/go/install-go-on-ubuntu/).
 
 1. Print your Go installation's current `$GOPATH`:
 
@@ -31,41 +32,42 @@ You will need a current version of Go on your Linode. Read our guide on [install
         cd $GOPATH/src
         export GO111MODULE=on
 
+### Build Caddy
 
-1. Build Caddy:
-    * To build without plugins:
+* To build without plugins:
 
-               go get github.com/caddyserver/caddy/caddy
+        go get github.com/caddyserver/caddy/caddy
 
-    * To build custom Caddy with plugins:
-        1. Create a folder named `plugins` and add a `main.go` file with the following contents:
+* To build custom Caddy with plugins:
+    1. Create a folder named `plugins` and add a `main.go` file with the following contents:
+
         {{< file "$GOPATH/plugins/main.go" >}}
-        package main
+package main
 
-    import (
-    	"github.com/caddyserver/caddy/caddy/caddymain"
+import (
+  "github.com/caddyserver/caddy/caddy/caddymain"
 
-    	// plug in plugins here, for example:
-    	// _ "import/path/here"
-    )
+  // plug in plugins here, for example:
+  // _ "import/path/here"
+)
 
-    func main() {
-    	// optional: disable telemetry
-    	// caddymain.EnableTelemetry = false
-    	caddymain.Run()
-    }
+func main() {
+  // optional: disable telemetry
+  // caddymain.EnableTelemetry = false
+  caddymain.Run()
+}
     {{< /file >}}
-        2. Create a new go module for Caddy:
+    1. Create a new go module for Caddy:
 
-                   go mod init caddy
-        3. Download and save the packages in `$GOPATH/src/<import-path>`:
+            go mod init caddy
+    1. Download and save the packages in `$GOPATH/src/<import-path>`:
 
-                   go get github.com/caddyserver/caddy         
-        4. Install Caddy in `$GOPATH/bin`:
+            go get github.com/caddyserver/caddy
+    1. Install Caddy in `$GOPATH/bin`:
 
-                   go install
+            go install
 
-             {{< note >}} To install Caddy in the current directory you can run `go build`
-             {{< /note >}}          
+          {{< note >}} To install Caddy in the current directory you can run `go build`
+          {{< /note >}}
 
 Caddy is now installed on your Linode. Read our guide on [Installing and Configuring Caddy](/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7/) to learn more about Caddy.

--- a/docs/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/web-servers/caddy/compile-caddy-from-source/index.md
@@ -26,19 +26,46 @@ You will need a current version of Go on your Linode. Read our guide on [install
 
         go env GOPATH
 
-1. Pull Caddy from the source. Replace `$GOPATH` with the path retrieved in the previous step.
+1. Set the transitional environment variable for Go modules.
 
         cd $GOPATH/src
-        go get -u github.com/mholt/caddy
-        go get -u github.com/caddyserver/builds
+        export GO111MODULE=on
 
-2. Navigate to the Caddy directory and start the build:
 
-        cd $GOPATH/src/github.com/mholt/caddy/caddy
-        go run build.go -goos=linux -goarch=amd64
+1. Build Caddy:
+    * To build without plugins:
 
-3. When the build finishes you will have a Caddy binary in the current directory. Move the binary to `/usr/bin` so that Caddy can function correctly:
+               go get github.com/caddyserver/caddy/caddy
 
-        sudo cp caddy /usr/bin/
+    * To build custom Caddy with plugins:
+        1. Create a folder named `plugins` and add a `main.go` file with the following contents:
+        {{< file "$GOPATH/plugins/main.go" >}}
+        package main
+
+    import (
+    	"github.com/caddyserver/caddy/caddy/caddymain"
+
+    	// plug in plugins here, for example:
+    	// _ "import/path/here"
+    )
+
+    func main() {
+    	// optional: disable telemetry
+    	// caddymain.EnableTelemetry = false
+    	caddymain.Run()
+    }
+    {{< /file >}}
+        2. Create a new go module for Caddy:
+
+                   go mod init caddy
+        3. Download and save the packages in `$GOPATH/src/<import-path>`:
+
+                   go get github.com/caddyserver/caddy         
+        4. Install Caddy in `$GOPATH/bin`:
+
+                   go install
+
+             {{< note >}} To install Caddy in the current directory you can run `go build`
+             {{< /note >}}          
 
 Caddy is now installed on your Linode. Read our guide on [Installing and Configuring Caddy](/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7/) to learn more about Caddy.


### PR DESCRIPTION
- updated the guide based on : https://github.com/caddyserver/caddy#install
- fixes https://github.com/linode/docs/issues/2773