### PR TITLE
[Update] Note About Email at Linode

### DIFF
--- a/docs/applications/messaging/install-mastodon-on-ubuntu-1604/index.md
+++ b/docs/applications/messaging/install-mastodon-on-ubuntu-1604/index.md
@@ -68,6 +68,8 @@ When Certbot is run, you generally pass a command with the [`--deploy-hook` opti
 
 1. Mastodon sends email notifications to users for different events, like when a user first signs up, or when someone else requests to follow them. You will need to supply an SMTP server which will be used to send these messages.
 
+    {{< content "email-warning-shortguide" >}}
+
     One option is to install your own mail server using the [Email with Postfix, Dovecot, and MySQL](/docs/email/postfix/email-with-postfix-dovecot-and-mysql/) guide. You can install such a mail server on the same Linode as your Mastodon server, or on a different one. If you follow this guide, be sure to create a `notifications@example.com` email address which you will later use for notifications. If you install your mail server on the same Linode as your Mastodon deployment, you can use your Let's Encrypt certificate in `/etc/letsencrypt/live/example.com/` for the mail server too.
 
     If you would rather not self-host an email server, you can use a third-party SMTP service. The instructions in this guide will also include settings for using [Mailgun](https://www.mailgun.com/) as your SMTP provider.

--- a/docs/development/version-control/how-to-unbundle-nginx-from-omnibus-gitlab-for-serving-multiple-websites/index.md
+++ b/docs/development/version-control/how-to-unbundle-nginx-from-omnibus-gitlab-for-serving-multiple-websites/index.md
@@ -55,6 +55,8 @@ Note that nginx cannot be disabled in older versions of GitLab Community Edition
 
 2.  While installing Postfix, you'll be asked to configure a few basic settings. On the first [ncurses](https://en.wikipedia.org/wiki/Ncurses) screen, select **Internet Site** as the mail configuration. On the second screen, enter your fully qualified domain name (FQDN). This will be used to send email to users when configuring new accounts and resetting passwords. The rest of the mail options will be configured automatically.
 
+    {{< content "email-warning-shortguide" >}}
+
 3.  Add the GitLab CE repository and install the `gitlab-ce` package:
 
         curl -sS https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.deb.sh | sudo bash

--- a/docs/development/version-control/install-gitlab-on-ubuntu-18-04/index.md
+++ b/docs/development/version-control/install-gitlab-on-ubuntu-18-04/index.md
@@ -56,6 +56,8 @@ Before installing GitLab you should consider how many users will collaborate on 
 
     When prompted, select *Internet Site* and press **Enter**. Use your server's external DNS for *mail name* and press **Enter**.
 
+    {{< content "email-warning-shortguide" >}}
+
 1. Add the GitLab package repository:
 
         curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | sudo bash

--- a/docs/email-warning-shortguide/index.md
+++ b/docs/email-warning-shortguide/index.md
@@ -16,6 +16,6 @@ show_on_rss_feed: false
 
 {{< disclosure-note "Note About Email at Linode" >}}
 
-This guide may involve or result in sending email. In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after $date. For more information, please see [Sending Email on Linode](/docs/email/running-a-mail-server/#sending-email-on-linode).
+This guide may involve or result in sending email. In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019. For more information, please see [Sending Email on Linode](/docs/email/running-a-mail-server/#sending-email-on-linode).
 
 {{< /disclosure-note >}}

--- a/docs/email-warning-shortguide/index.md
+++ b/docs/email-warning-shortguide/index.md
@@ -1,0 +1,21 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+description: 'Shortguide that displays the warning note that email ports are blocked on all new Linodes by default.'
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+modified: 2018-08-03
+modified_by:
+  name: Heather Zoppetti
+published: 2019-10-31
+title: Email Port Blocking Alert
+keywords: []
+headless: true
+show_on_rss_feed: false
+---
+
+{{< disclosure-note "Note About Email at Linode" >}}
+
+This guide may involve or result in sending email. In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after $date. For more information, please see [Sending Email on Linode](/docs/email/running-a-mail-server/#sending-email-on-linode).
+
+{{< /disclosure-note >}}

--- a/docs/email/_index.md
+++ b/docs/email/_index.md
@@ -4,7 +4,7 @@ author:
   email: docs@linode.com
 keywords: ["linux mail server", "email server", "Citadel", "Postfix", "Courier", "SMTP server"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-description: "Every organization needs email service. Whether you're running a personal blog or an entire company's web infrastructure on your Linodes, these guides will assist you in getting a stable mail/groupware server up and running quickly."
+description: "Every organization needs email service. Whether you're running a personal blog or an entire company's web infrastructure on your Linodes, these guides will assist you in getting a stable mail/groupware server up and running quickly. **Note:** These guides involve or result in sending email. In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after $date. For more information, please see [Sending Email on Linode](/docs/email/running-a-mail-server/#sending-email-on-linode)."
 title: Email Server Guides
 show_on_frontpage: true
 title_short: "Email"

--- a/docs/email/clients/install-roundcube-on-ubuntu/index.md
+++ b/docs/email/clients/install-roundcube-on-ubuntu/index.md
@@ -24,6 +24,8 @@ external_resources:
 
 Roundcube is a web-based IMAP email client that offers a user interface similar to Google’s Gmail. It is a server-side application written in PHP designed to access an email server or service. Email users interact with Roundcube using a web browser.
 
+{{< content "email-warning-shortguide" >}}
+
 ## Before You Begin
 
 1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.

--- a/docs/email/clients/install-squirrelmail-on-ubuntu-16-04-or-debian-8/index.md
+++ b/docs/email/clients/install-squirrelmail-on-ubuntu-16-04-or-debian-8/index.md
@@ -18,6 +18,8 @@ external_resources:
 
 SquirrelMail is a webmail package, written in PHP, which supports both SMTP and IMAP protocols, and features cross-platform compatibility. SquirrelMail requires a web server with PHP to run properly. For this guide we'll be using Apache 2. If you don't already have Apache and PHP installed, you can check our [LAMP Server on Ubuntu 16.04](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/) or [LAMP Server on Debian 8](/docs/web-servers/lamp/lamp-on-debian-8-jessie/) guide.
 
+{{< content "email-warning-shortguide" >}}
+
 {{< note >}}
 This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Privileges](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}

--- a/docs/email/how-to-create-an-email-server-with-mail-in-a-box/index.md
+++ b/docs/email/how-to-create-an-email-server-with-mail-in-a-box/index.md
@@ -37,6 +37,8 @@ If you chose to host your own email server, but after reading through [Running a
 
 The preconfigured box of software is also fairly security-conscious and you can read more about it here: [Security features enabled in Mail-in-a-Box](https://github.com/mail-in-a-box/mailinabox/blob/master/security.md)
 
+{{< content "email-warning-shortguide" >}}
+
 ## Before You Begin
 
 1. Make sure your domain name registrar allows you to use *custom nameservers* and set *glue records*.

--- a/docs/email/iredmail/install-iredmail-on-ubuntu/index.md
+++ b/docs/email/iredmail/install-iredmail-on-ubuntu/index.md
@@ -23,6 +23,8 @@ Running your own mail server has many benefits. It allows you to manage the size
 
 ![Installing iRedMail on your Linode](iredmail_tg.png "Installing iRedMail on your Linode")
 
+{{< content "email-warning-shortguide" >}}
+
 ## Prerequisites
 
 Before beginning this guide you should have:

--- a/docs/email/postfix/configure-postfix-to-send-mail-using-gmail-and-google-apps-on-debian-or-ubuntu/index.md
+++ b/docs/email/postfix/configure-postfix-to-send-mail-using-gmail-and-google-apps-on-debian-or-ubuntu/index.md
@@ -19,6 +19,8 @@ Postfix is a Mail Transfer Agent (MTA) that can act as an SMTP server or client 
 
 In this guide, you will learn how to install and configure a Postfix server on Debian or Ubuntu to send email through Gmail and Google Apps. For information on configuring Postfix with other external SMTP servers, see our [Configure Postfix to Send Mail Using an External SMTP Server](/docs/email/postfix/postfix-smtp-debian7/) guide.
 
+{{< content "email-warning-shortguide" >}}
+
 ## Before You Begin
 
 1.  Complete our [Getting Started](/docs/getting-started) and [Securing Your Server](/docs/securing-your-server) guides and ensure that the Linode's [hostname is set](/docs/getting-started#getting-started#setting-the-hostname).

--- a/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8/index.md
+++ b/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8/index.md
@@ -28,6 +28,8 @@ We have created a [new version of this guide](/docs/email/postfix/configure-spf-
 
 ![SPF and DKIM with Postfix](Configure_SPF_and_DKIM_with_Postfix_on_Debian_8_smg.jpg)
 
+{{< content "email-warning-shortguide" >}}
+
 [SPF (Sender Policy Framework)](http://www.openspf.org/) is a system that identifies to mail servers what hosts are allowed to send email for a given domain. Setting up SPF helps to prevent your email from being classified as spam.
 
 [DKIM (DomainKeys Identified Mail)](http://www.dkim.org/) is a system that lets your official mail servers add a signature to headers of outgoing email and identifies your domain's public key so other mail servers can verify the signature. As with SPF, DKIM helps keep your mail from being considered spam. It also lets mail servers detect when your mail has been tampered with in transit.

--- a/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-9/index.md
+++ b/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-9/index.md
@@ -23,6 +23,8 @@ external_resources:
 
 This guide will instruct you on how to set up SPF and DKIM with Postfix.
 
+{{< content "email-warning-shortguide" >}}
+
 [SPF (Sender Policy Framework)](http://www.openspf.org/) is a system that identifies to mail servers what hosts are allowed to send email for a given domain. Setting up SPF helps to prevent your email from being classified as spam.
 
 [DKIM (DomainKeys Identified Mail)](http://www.dkim.org/) is a system that lets your official mail servers add a signature to headers of outgoing email and identifies your domain's public key so other mail servers can verify the signature. As with SPF, DKIM helps keep your mail from being considered spam. It also lets mail servers detect when your mail has been tampered with in transit.

--- a/docs/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7/index.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7/index.md
@@ -24,6 +24,8 @@ In this guide, you'll learn how to set up a secure virtual user mail server with
 
 For a different Linux distribution or different mail server, review our [email tutorials](/docs/email/).
 
+{{< content "email-warning-shortguide" >}}
+
 ## Before You Begin
 
 1.  Set up the Linode as specified in the [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/security/securing-your-server/) guides.

--- a/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-6/index.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-6/index.md
@@ -23,6 +23,10 @@ external_resources:
 
 The Postfix Mail Transfer Agent (**MTA**) is a high performance open source e-mail server system. This guide will help you get Postfix running on your CentOS 6 Linode, using Dovecot for IMAP/POP3 service, and MySQL to store information on virtual domains and users.
 
+{{< content "email-warning-shortguide" >}}
+
+## Before You Begin
+
 Prior to using this guide, be sure you have followed the [getting started guide](/docs/getting-started/) and set your hostname.
 
 {{< note >}}

--- a/docs/email/postfix/email-with-postfix-dovecot-and-mysql/index.md
+++ b/docs/email/postfix/email-with-postfix-dovecot-and-mysql/index.md
@@ -23,6 +23,8 @@ In this guide, you'll learn how to set up a secure virtual user mail server with
 
 For a different Linux distribution or different mail server, review our [email tutorials](/docs/email/).
 
+{{< content "email-warning-shortguide" >}}
+
 ## Before You Begin
 
 1.  Set up the Linode as specified in the [Getting Started](/docs/getting-started/) and [Securing Your Server](/docs/security/securing-your-server/) guides.

--- a/docs/email/postfix/pflogsumm-for-postfix-monitoring-on-centos-6/index.md
+++ b/docs/email/postfix/pflogsumm-for-postfix-monitoring-on-centos-6/index.md
@@ -17,16 +17,16 @@ external_resources:
  - '[Pflogsumm](http://jimsun.linxnet.com/postfix_contrib.html)'
 ---
 
-
 ![banner_image](Pflogsumm_or_Postfix_Monitoring_on_CentOS_smg.jpg)
 
 Pflogsumm is a simple Perl script that monitors your [Postfix](/docs/email/postfix/) mail server's activity. This guide will show you how to install Pflogsumm on CentOS 6 and configure it to send you a daily email with your mail server stats.
 
- {{< note >}}
+{{< content "email-warning-shortguide" >}}
+
+## Before You Begin
+{{< note >}}
 This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
-
-## Prerequisites
 
 Make sure these prerequisites are installed:
 

--- a/docs/email/postfix/postfix-smtp-debian7/index.md
+++ b/docs/email/postfix/postfix-smtp-debian7/index.md
@@ -24,6 +24,7 @@ There are many reasons why you would want to configure Postfix to send email usi
 
 In this tutorial, you will learn how to install and configure a Postfix server to send email through Mandrill, or SendGrid.
 
+{{< content "email-warning-shortguide" >}}
 
 ## Updated Guide for Gmail and Google Apps
 

--- a/docs/email/postfix/troubleshooting-problems-with-postfix-dovecot-and-mysql/index.md
+++ b/docs/email/postfix/troubleshooting-problems-with-postfix-dovecot-and-mysql/index.md
@@ -19,6 +19,8 @@ This guide is a companion to the [Postfix, Dovecot, and MySQL](/docs/email/postf
 
 The first section, Troubleshooting Checklist, has a top-down approach to troubleshooting that will help you find specific errors for your mail server. The second section, Step-by-Step Configuration, uses a bottom-up approach that shows you how to get a basic mail server functioning and then gradually add more features.
 
+{{< content "email-warning-shortguide" >}}
+
 ## Troubleshooting Checklist
 
 Correctly diagnosing a problem is the first step in solving it. At first glance, many mail server errors can seem quite general. Usually the first sign of a problem is that you try to create a test mail account and can't connect. This section is a crash course in finding mail server errors. We recommend reading through the following sections in order, because they progress from general to more specific troubleshooting techniques.

--- a/docs/email/running-a-mail-server/index.md
+++ b/docs/email/running-a-mail-server/index.md
@@ -21,6 +21,17 @@ This guide offers an overview of installing a mail server on your Linode. It cov
 
 If you do, you'll have control over your domain's email, but you'll also have to deal with the hassles associated with setting up a complex environment of software. Using a third-party mail service is easier, but you'll sacrifice control and flexibility. In this section, we consider the benefits and drawbacks to running your own mail server, as well as how to choose an [external mail service](#external-mail-services), if you decide to go that route.
 
+### Sending Email on Linode
+
+In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after $date.
+
+If you have a need to send mail from your Linode, we ask that you first configure (1) [valid DNS A records](/docs/platform/manager/dns-manager/#add-dns-records) and (2) [rDNS records](/docs/networking/dns/configure-your-linode-for-reverse-dns/) for any Linodes that you plan to use to send mail. Then, [open a Support ticket](https://cloud.linode.com/support/tickets?type=closed&drawerOpen=true) from the Linode Manager – we’ll ask you to provide the following basic information:
+
+- Which Linode(s) will be used for mailing?
+- Do your mailing practices conform with 'Section 3. Prohibited Usage' of our [ToS](https://www.linode.com/tos/), and are they CAN-SPAM compliant?
+
+Once you’ve completed those steps and provided that information, our Support team will be happy to review your request.
+
 ### Benefits
 
 If you want or need full control of your email, running your own mail server might be ideal solution. Doing so allows you to store your own email, access the mail server's logs, and access the raw email files in a user's mailbox.

--- a/docs/email/running-a-mail-server/index.md
+++ b/docs/email/running-a-mail-server/index.md
@@ -23,7 +23,7 @@ If you do, you'll have control over your domain's email, but you'll also have to
 
 ### Sending Email on Linode
 
-In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after $date.
+In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019.
 
 If you have a need to send mail from your Linode, we ask that you first configure (1) [valid DNS A records](/docs/platform/manager/dns-manager/#add-dns-records) and (2) [rDNS records](/docs/networking/dns/configure-your-linode-for-reverse-dns/) for any Linodes that you plan to use to send mail. Then, [open a Support ticket](https://cloud.linode.com/support/tickets?type=closed&drawerOpen=true) from the Linode Manager – we’ll ask you to provide the following basic information:
 

--- a/docs/email/zimbra/zimbra-on-ubuntu-14-04/index.md
+++ b/docs/email/zimbra/zimbra-on-ubuntu-14-04/index.md
@@ -20,6 +20,8 @@ external_resources:
 
 [Zimbra](https://www.zimbra.com/) is a complete mail server that provides a configured Postfix with OpenDKIM, Amavis, ClamAV, and Nginx, ready to handle mail for one or more domains. Zimbra on a Linode is one of the quickest paths to an up-and-running mail server that you will find. This guide will take you through the Zimbra installation procedure.
 
+{{< content "email-warning-shortguide" >}}
+
 {{< note >}}
 The steps required in this guide require root privileges. Be sure to run the steps below as **root** or with the `sudo` prefix. For more information on privileges see our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}

--- a/docs/platform/billing-and-support/linode-beginners-guide/index.md
+++ b/docs/platform/billing-and-support/linode-beginners-guide/index.md
@@ -31,6 +31,8 @@ Since you have full root access to your Linode, you're free to choose between a 
 
 ## How can I send and receive email with my Linode?
 
+{{< content "email-warning-shortguide" >}}
+
 If you'd prefer to leave the management of your email to a third party, you may follow our [Google Apps guide](/docs/email/google-mail/). Those desiring to operate their own mail server will find these guides helpful:
 
 -   [Postfix Guides](/docs/email/postfix/) - Information on using the highly popular Postfix MTA (mail transfer agent).

--- a/docs/platform/one-click/deploy-gitlab-with-one-click-apps/index.md
+++ b/docs/platform/one-click/deploy-gitlab-with-one-click-apps/index.md
@@ -33,6 +33,8 @@ You can configure your GitLab App by providing values for the following fields:
 |:--------------|:------------|
 | **Domain** | Your GitLab site's domain name. This domain will also be used by Postfix to send mail. Setting a value for this field will not automatically set up DNS for your app, so be sure to follow the DNS instructions in the [Access your GitLab Site](#access-your-gitlab-site) section. If you do not have a domain name, you can leave this field blank and Postfix will use your Linode's default Reverse DNS to send email instead (i.e. `gitlab@li926-227.members.linode.com`).  *Advanced Configuration*. |
 
+{{< content "email-warning-shortguide" >}}
+
 ### Linode Options
 
 After providing the app specific options, provide configurations for your Linode server:

--- a/docs/platform/one-click/deploying-wordpress-with-one-click-apps/index.md
+++ b/docs/platform/one-click/deploying-wordpress-with-one-click-apps/index.md
@@ -100,3 +100,5 @@ The WordPress One-Click App will install the following required software on your
 | [**Apache HTTP Server**](https://httpd.apache.org/) | Web server used to serve the WordPress site. |
 | [**WordPress**](https://wordpress.org/) | Content management system. |
 | [**WP CLI**](https://wp-cli.org/) | The command line interface for WordPress. |
+
+{{< content "email-warning-shortguide" >}}

--- a/docs/platform/one-click/one-click-woocommerce/index.md
+++ b/docs/platform/one-click/one-click-woocommerce/index.md
@@ -107,3 +107,5 @@ Click on the **Run the Setup Wizard** button to visit this form and start your s
 | [**WordPress**](https://wordpress.org/) | Content management system. |
 | [**WP CLI**](https://wp-cli.org/) | The command line interface for WordPress. |
 | [**WooCommerce**](https://woocommerce.com/) | An online storefront plugin for WordPress. |
+
+{{< content "email-warning-shortguide" >}}

--- a/docs/security/using-fail2ban-for-security/index.md
+++ b/docs/security/using-fail2ban-for-security/index.md
@@ -1,6 +1,6 @@
 ---
 author:
-  name: Linode  
+  name: Linode
 description: 'This guide shows how to set up Fail2Ban, a log-parsing application, to monitor system logs and detect automated attacks on your Linode.'
 og_description: 'Fail2ban monitors system logs for symptoms of an automated attack, bans the IP and alerts you of the attach through email. This guide helps you set up Fail2ban to thwart automated system attacks and further secure your server.'
 keywords: ["fail2ban", "ip whitelisting", "jail.local"]
@@ -218,6 +218,8 @@ maxretry = 3
 -   `maxretry`: How many attempts can be made to access the server from a single IP before a ban is imposed. The default is set to 3.
 
 ### Email Alerts
+
+{{< content "email-warning-shortguide" >}}
 
 To receive email when fail2ban is triggered, adjust the email settings:
 

--- a/docs/tools-reference/linux-system-administration-basics/index.md
+++ b/docs/tools-reference/linux-system-administration-basics/index.md
@@ -677,6 +677,8 @@ Follow these steps to [create and host a sub-domain](/docs/networking/dns/common
 
 We provide a number of guides that cover [email-related topics](/docs/email/). In this section, we'll explain how to choose an email setup that fits your needs and how to configure your Linode to send email.
 
+{{< content "email-warning-shortguide" >}}
+
 ### Choose an Email Solution
 
 There are two major components that are required for email functionality. The most important part is the SMTP server or "Mail Transfer Agent." The MTA, as it is often called, sends mail from one server to another. The second part of an email system is a server that permits users to access and download that mail from the server to their own machine. Typically these servers use a protocol such as POP3 or IMAP to provide remote access to the mailbox.

--- a/docs/uptime/logs/use-logrotate-to-manage-log-files/index.md
+++ b/docs/uptime/logs/use-logrotate-to-manage-log-files/index.md
@@ -82,6 +82,8 @@ mail <username@example.com>
 
 Your system will need a functioning [Mail Transfer Agent](/docs/email/) to be able to send email.
 
+{{< content "email-warning-shortguide" >}}
+
 ## Configure Log Rotation Intervals
 
 To rotate logs every week, set the following configuration directive:

--- a/docs/uptime/monitoring/install-icinga2-monitoring-on-debian-9/index.md
+++ b/docs/uptime/monitoring/install-icinga2-monitoring-on-debian-9/index.md
@@ -29,6 +29,8 @@ Icinga 2 can be configured to monitor internal systems' state and check the load
 
 This guide shows how to install and configure the latest version of Icinga 2 web monitoring tool on Debian 9 to monitor network infrastructure.
 
+{{< content "email-warning-shortguide" >}}
+
 ## Before You Begin
 
 1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for creating a Linode with Debian 9, and setting your Linode's hostname and timezone.

--- a/docs/websites/ecommerce/how-to-install-prestashop-on-ubuntu-16-04/index.md
+++ b/docs/websites/ecommerce/how-to-install-prestashop-on-ubuntu-16-04/index.md
@@ -268,6 +268,8 @@ max_execution_time = 30
 
 ## Set Up Mail Delivery
 
+{{< content "email-warning-shortguide" >}}
+
 Setting up mail delivery in PrestaShop is vital because so much happens through email: customer account confirmations, subscriptions, delivery statuses, order confirmations, etc. Although an email server [like this one](/docs/email/postfix/email-with-postfix-dovecot-and-mysql/) can be hosted on a Linode, it can be complicated to set up and maintain.
 
 It's also possible to use an all-in-one solution like [Mail-in-a-Box](/docs/email/how-to-create-an-email-server-with-mail-in-a-box/), but the easiest approach is to use a dedicated solution like Google's [G Suite](https://gsuite.google.com/) or [Fastmail](https://www.fastmail.com/). This way you can focus on maintaining your store and get dependable email service without worrying about the technical details.


### PR DESCRIPTION
Added email-warning-shortguide which is a disclosure note
Added long email note to the main email guide: /docs/email/running-a-mail-server/
Updated header text on: /docs/email
Added short guide notes to additional guides:
- /docs/email/iredmail/install-iredmail-on-ubuntu/
- /docs/email/postfix/postfix-smtp-debian7/
- /docs/email/postfix/configure-postfix-to-send-mail-using-gmail-and-google-apps-on-debian-or-ubuntu/
- /docs/email/how-to-create-an-email-server-with-mail-in-a-box/
- /docs/email/postfix/email-with-postfix-dovecot-and-mysql/
- /docs/email/clients/install-squirrelmail-on-ubuntu-16-04-or-debian-8/
- /docs/email/zimbra/zimbra-on-ubuntu-14-04/
- /docs/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7/
- /docs/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-6/
- /docs/email/postfix/pflogsumm-for-postfix-monitoring-on-centos-6/
- /docs/tools-reference/linux-system-administration-basics/#smtp-servers-and-email-issues
- /docs/websites/ecommerce/how-to-install-prestashop-on-ubuntu-16-04/#set-up-mail-delivery
- /docs/platform/billing-and-support/linode-beginners-guide/#how-can-i-send-and-receive-email-with-my-linode
- /docs/email/clients/install-roundcube-on-ubuntu/

Also to the email appropriate sections in:
- /docs/applications/messaging/install-mastodon-on-ubuntu-1604/
- /docs/security/using-fail2ban-for-security/