### PR TITLE
[Update]Ubuntu Flask Doc: missed '-' in flask_app.conf section

### DIFF
--- a/docs/development/python/flask-and-gunicorn-on-ubuntu/index.md
+++ b/docs/development/python/flask-and-gunicorn-on-ubuntu/index.md
@@ -315,8 +315,8 @@ Restarted supervisord
     {{< note >}}
 Your application should now be accessible again via your Linode's IP. If you are unable to access your application or receive a bad gateway error, Gunicorn is likely not running. Check your log files to further investigate the issue.
 
-    cat /var/log/flaskapp/flaskapp.err.log
-    cat /var/log/flaskapp/flaskapp.out.log
+    cat /var/log/flask_app/flask_app.err.log
+    cat /var/log/flask_app/flask_app.out.log
     {{</ note >}}
 
     Your Flask application is now deployed to your production environment and available to anyone for viewing. You can follow a similar workflow to deploy any Flask application to a Linode.

--- a/docs/development/python/flask-and-gunicorn-on-ubuntu/index.md
+++ b/docs/development/python/flask-and-gunicorn-on-ubuntu/index.md
@@ -288,7 +288,7 @@ You can specify the amount of workers you want Gunicorn to use with the `--worke
     {{< file "/etc/supervisor/conf.d/flask_app.conf" supervisor >}}
 [program:flask_app]
 directory=/home/flask_app_project
-command=gunicorn3 -workers=3 flask_app:app
+command=gunicorn3 --workers=3 flask_app:app
 autostart=true
 autorestart=true
 stopasgroup=true


### PR DESCRIPTION
Found this while working on a Stackscript, the application will still install as the Doc stands, but rebooting the Linode will result in a 502 error. This will fix that.

https://www.linode.com/docs/development/python/flask-and-gunicorn-on-ubuntu/#install-and-configure-supervisor