### PR TITLE
Error creating a Linode DomainRecord: [400] [target] Invalid IPv4 or IPv6 address

### DIFF
--- a/docs/applications/configuration-management/deploy-a-wordpress-site-using-terraform-and-linode-stackscripts/index.md
+++ b/docs/applications/configuration-management/deploy-a-wordpress-site-using-terraform-and-linode-stackscripts/index.md
@@ -97,14 +97,14 @@ resource "linode_domain_record" "my_wordpress_domain_www_record" {
     domain_id = linode_domain.my_wordpress_domain.id
     name = "www"
     record_type = var.a_record
-    target = "linode_instance.my_wordpress_linode.ipv4"
+    target = linode_instance.my_wordpress_linode.ip_address
 }
 
 resource "linode_domain_record" "my_wordpress_domain_apex_record" {
     domain_id = linode_domain.my_wordpress_domain.id
     name = ""
     record_type = var.a_record
-    target = "linode_instance.my_wordpress_linode.ipv4"
+    target = linode_instance.my_wordpress_linode.ip_address
 }
 {{</ file >}}
 
@@ -196,14 +196,14 @@ resource "linode_domain_record" "my_wordpress_domain_www_record" {
     domain_id = linode_domain.my_wordpress_domain.id
     name = "www"
     record_type = var.a_record
-    target = "linode_instance.linode_id.ipv4"
+    target = linode_instance.my_wordpress_linode.ip_address
 }
 
 resource "linode_domain_record" "my_wordpress_domain_apex_record" {
     domain_id = linode_domain.my_wordpress_domain.id
     name = ""
     record_type = var.a_record
-    target = "linode_instance.my_wordpress_linode.ipv4"
+    target = linode_instance.my_wordpress_linode.ip_address
 }
 {{</ file >}}
 


### PR DESCRIPTION
* Applying the provided configuration the above error occurs. Here is an output:
```
% terraform apply -var-file="secrets.tfvars" -var-file="terraform.tfvars"

An execution plan has been generated and is shown below.
...
linode_instance.my_wordpress_linode: Still creating... [30s elapsed]
linode_instance.my_wordpress_linode: Creation complete after 38s [id=18440296]

Error: Error creating a Linode DomainRecord: [400] [target] Invalid IPv4 or IPv6 address
  on main.tf line 40, in resource "linode_domain_record" "my_wordpress_domain_www_record":
  40: resource "linode_domain_record" "my_wordpress_domain_www_record" {
Error: Error creating a Linode DomainRecord: [400] [target] Invalid IPv4 or IPv6 address
  on main.tf line 47, in resource "linode_domain_record" "my_wordpress_domain_apex_record":
  47: resource "linode_domain_record" "my_wordpress_domain_apex_record" {
```
* It seems it is due to **not interpolation** of the values in quotes `"linode_instance.my_wordpress_linode.ipv4"` - this quoted string precisely passed in the request to Linode API. If we remove quotes then an error of _"incorrect attribute value type"_ appears:
```
Error: Incorrect attribute value type
  on main.tf line 44, in resource "linode_domain_record" "my_wordpress_domain_www_record":
  44:     target = linode_instance.my_wordpress_linode.ipv4
Inappropriate value for attribute "target": string required.
```
* And this is due to the fact that _"ipv4"_ attribute of resource _"linode_instance"_ is of type **schema.TypeSet**, but _"target"_ attribute of resource _"linode_domain_record"_ is of type **schema.TypeString**. And starting from Terraform 0.12 and later we need to pass a set value to `tolist()` function to convert it to a _"list"_ value and then access list elements with `element()` function. 
* The following should work: 
```
target = element(tolist(linode_instance.linode01.ipv4), 1)
```
* See the following for the references:
    * [terraform-provider-linode/linode/resource_linode_instance.go](https://github.com/terraform-providers/terraform-provider-linode/blob/master/linode/resource_linode_instance.go)
    * [terraform-provider-linode/linode/resource_linode_domain_record.go](https://github.com/terraform-providers/terraform-provider-linode/blob/master/linode/resource_linode_domain_record.go)
    * [tolist Function](https://www.terraform.io/docs/configuration/functions/tolist.html)
* PS: We can also use _"ip_address"_ attribute of resource _"linode_instance"_ instead of _"ipv4"_ as it is of type **schema.TypeString** and it is _"Linode's Public IPv4 Address. If there are multiple public IPv4 addresses on this Instance, an arbitrary address will be used for this field."_
* PPS: Subject to Terraform v0.12.13 and Terraform v0.12.14 (and likely other ones):
```
Terraform v0.12.13
+ provider.linode v1.8.0
+ provider.random v2.2.1 
```
```
Terraform v0.12.14
+ provider.linode v1.8.0
+ provider.random v2.2.1
```