### PR TITLE
Add |Linode to title in theme

### DIFF
--- a/themes/docsmith/layouts/_default/baseof.html
+++ b/themes/docsmith/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>{{ .Title }}</title>
+        <title>{{ .Title }} | Linode</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         {{ if eq (getenv "HUGO_ENV") "prod" }}
         <!-- Google Tag Manager -->


### PR DESCRIPTION
* Theme rebuild to add `| Linode` to title tag in theme's head.
* Hercules PR: https://github.com/linode/hercules/pull/150