### PR TITLE
Add Vale test for kubcetl typo

### DIFF
--- a/ci/vale/styles/Linode/Terms.yml
+++ b/ci/vale/styles/Linode/Terms.yml
@@ -17,6 +17,7 @@ swap:
   fedora: Fedora
   gentoo: Gentoo
   homebrew: Homebrew
+  kubcetl: kubectl
   linode cli: Linode CLI
   linode manager: Linode Manager
   linode: Linode


### PR DESCRIPTION
This isn't checking for spelling errors in commands or output shortcodes, so it shouldn't be merged yet