### PR TITLE
[Update] Install a Chef Server Workstation on Ubuntu 18.04

### DIFF
--- a/docs/applications/configuration-management/install-a-chef-server-workstation-on-ubuntu-18-04/index.md
+++ b/docs/applications/configuration-management/install-a-chef-server-workstation-on-ubuntu-18-04/index.md
@@ -9,7 +9,8 @@ published: 2018-08-06
 modified: 2019-01-17
 modified_by:
   name: Linode
-title: 'Install a Chef Server Workstation on Ubuntu 18.04'
+title: 'How To Install a Chef Server Workstation on Ubuntu 18.04'
+h1_title: 'Installing a Chef Server Workstation on Ubuntu 18.04'
 ---
 
 [Chef](http://www.chef.io) is a Ruby based configuration management tool used to define infrastructure as code. This enables users to automate the management of many *nodes* and maintain consistency across those nodes. *Recipes* declare the desired state for managed nodes and are created on a user's *workstation* using the *Chef Workstation* package. Your recipes are distributed across nodes via a *Chef server*. A *Chef client*, installed on each node, is in charge of applying the recipe to its corresponding node.

--- a/docs/applications/configuration-management/install-a-chef-server-workstation-on-ubuntu-18-04/index.md
+++ b/docs/applications/configuration-management/install-a-chef-server-workstation-on-ubuntu-18-04/index.md
@@ -183,10 +183,6 @@ The workstation is used to create, download, and edit cookbooks and other relate
 1. Generate a new Chef cookbook:
 
         chef generate cookbook my_cookbook
-1.  Generate the `chef-repo` and move into the newly-created directory:
-
-        chef generate app chef-repo
-        cd chef-repo
 
 ### Configure Knife
 


### PR DESCRIPTION
You do not need to generate the chef-repo twice, this removes the redundant step. This is in response to https://github.com/linode/docs/issues/2917