### PR TITLE
[Update] IPv6/billing obj clarification

### DIFF
--- a/docs/platform/object-storage/bucket-versioning/index.md
+++ b/docs/platform/object-storage/bucket-versioning/index.md
@@ -16,7 +16,7 @@ external_resources:
 ---
 
 {{< note >}}
-[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with the Object Storage service enabled on their account will be billed. For more information, see our [Object Storage Pricing and Limitations guide](/docs/platform/object-storage/pricing-and-limitations/)
+[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with the Object Storage service enabled on their account will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
 {{</ note >}}
 
 Linode Object Storage allows for bucket versioning so that you can retain different versions of your objects within buckets. This makes it easy to save older versions of objects, as well as quickly revert to an object's previous state.

--- a/docs/platform/object-storage/bucket-versioning/index.md
+++ b/docs/platform/object-storage/bucket-versioning/index.md
@@ -16,7 +16,7 @@ external_resources:
 ---
 
 {{< note >}}
-[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with objects stored in Object Storage buckets will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
+[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with the Object Storage service enabled on their account will be billed. For more information, see our [Object Storage Pricing and Limitations guide](/docs/platform/object-storage/pricing-and-limitations/)
 {{</ note >}}
 
 Linode Object Storage allows for bucket versioning so that you can retain different versions of your objects within buckets. This makes it easy to save older versions of objects, as well as quickly revert to an object's previous state.

--- a/docs/platform/object-storage/host-static-site-object-storage/index.md
+++ b/docs/platform/object-storage/host-static-site-object-storage/index.md
@@ -21,7 +21,7 @@ external_resources:
 ![Host a Static Site using Linode Object Storage](host-a-static-site-using-linode-object-storage.png "Host a Static Site using Linode Object Storage")
 
 {{< note >}}
-[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with objects stored in Object Storage buckets will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
+[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with the Object Storage service enabled on their account will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
 {{</ note >}}
 
 ## Why Host a Static Site on Object Storage?

--- a/docs/platform/object-storage/how-to-manage-objects-with-lifecycle-policies/index.md
+++ b/docs/platform/object-storage/how-to-manage-objects-with-lifecycle-policies/index.md
@@ -16,7 +16,7 @@ aliases: ['platform/object-storage/lifecycle-policies/']
 ---
 
 {{< note >}}
-[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with objects stored in Object Storage buckets will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
+[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with the Object Storage service enabled on their account will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
 {{</ note >}}
 
 While deleting a few objects in an Object Storage bucket might not take that long, when the objects number in the thousands or even millions the time required to complete the delete operations can easily become unmanageable. When deleting a substantial amount of objects, it's best to use *lifecycle policies*. These policies can be represented in XML; here's an (incomplete) snippet of an action that will delete objects after 1 day:

--- a/docs/platform/object-storage/how-to-use-object-storage/index.md
+++ b/docs/platform/object-storage/how-to-use-object-storage/index.md
@@ -44,7 +44,11 @@ In this guide you will learn:
 
 ## Enable Object Storage
 
-Object Storage is not enabled by default. All that is required to enable Object Storage is to create a bucket or an access key. To cancel Object Storage, see the [Cancel Object Storage](#cancel-object-storage) section.
+Object Storage is not enabled for a Linode account by default. All that is required to enable Object Storage is to create a bucket or an Object Storage access key. To cancel Object Storage, see the [Cancel Object Storage](#cancel-object-storage) section.
+
+{{< note >}}
+Billing for Object Storage will start when it is enabled on your account, **regardless of how it is enabled**. For example, if you enable the service by creating an access key, but you have not yet created a bucket, the $5 monthly flat rate (prorated) for Object Storage will be charged for your account. [Cancelling Object Storage](#cancel-object-storage) will stop billing for it.
+{{< /note >}}
 
 ## Object Storage Key Pair
 
@@ -607,7 +611,7 @@ To create a static site from your bucket:
 1.  To cancel Object Storage, you must first delete all of your buckets. To delete a bucket, the bucket must be empty. For buckets that contain large amounts of objects, consider employing [lifecycle policies](/docs/platform/object-storage/lifecycle-policies/) to delete the objects.
 
     {{< caution >}}
-Without active buckets, your account will still be billed at a prorated flat rate of $5 per month until the service itself is cancelled. Make sure that you complete each step of this section to fully cancel the Object Storage service to no longer be billed. For more information, see our [Pricing and Limitations Guide](/docs/platform/object-storage/pricing-and-limitations/).
+If you have removed all of your buckets, but you have not also cancelled the Object Storage service, your account will continued to be billed at a flat rate of $5 per month (prorated) for the service. Make sure that you complete each step of this section to fully cancel the Object Storage service and to stop billing for it. For more information, see our [Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
 {{< /caution >}}
 
 1.  Once you've deleted all of your buckets, navigate to the **Account** page in the left-hand navigation. Click on the *Settings* tab. In the menu, you should see a setting for Object Storage:

--- a/docs/platform/object-storage/how-to-use-object-storage/index.md
+++ b/docs/platform/object-storage/how-to-use-object-storage/index.md
@@ -19,7 +19,7 @@ external_resources:
 ![How to Use Linode Object Storage](how-to-use-linode-object-storage.png "How to Use Linode Object Storage")
 
 {{< note >}}
-[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with objects stored in Object Storage buckets will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
+[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with the Object Storage service enabled on their account will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
 {{</ note >}}
 
 Linode's Object Storage is a globally-available, S3-compatible method for storing and accessing data. Object Storage differs from traditional hierarchical data storage (as in a Linode's disk) and [Block Storage Volumes](https://www.linode.com/docs/platform/block-storage/). Under Object Storage, files (also called *objects*) are stored in flat data structures (referred to as *buckets*) alongside their own rich metadata.
@@ -605,6 +605,10 @@ To create a static site from your bucket:
 ## Cancel Object Storage
 
 1.  To cancel Object Storage, you must first delete all of your buckets. To delete a bucket, the bucket must be empty. For buckets that contain large amounts of objects, consider employing [lifecycle policies](/docs/platform/object-storage/lifecycle-policies/) to delete the objects.
+
+    {{< caution >}}
+Without active buckets, your account will still be billed at a prorated flat rate of $5 per month until the service itself is cancelled. Make sure that you complete each step of this section to fully cancel the Object Storage service to no longer be billed. For more information, see our [Pricing and Limitations Guide](/docs/platform/object-storage/pricing-and-limitations/).
+{{< /caution >}}
 
 1.  Once you've deleted all of your buckets, navigate to the **Account** page in the left-hand navigation. Click on the *Settings* tab. In the menu, you should see a setting for Object Storage:
 

--- a/docs/platform/object-storage/object-storage-use-cases/index.md
+++ b/docs/platform/object-storage/object-storage-use-cases/index.md
@@ -15,7 +15,7 @@ contributor:
 ---
 
 {{< note >}}
-[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with objects stored in Object Storage buckets will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
+[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with the Object Storage service enabled on their account will be billed. For more information, see our [Object Storage Pricing and Limitations](/docs/platform/object-storage/pricing-and-limitations/) guide.
 {{</ note >}}
 
 ## What is Object Storage?

--- a/docs/platform/object-storage/pricing-and-limitations/index.md
+++ b/docs/platform/object-storage/pricing-and-limitations/index.md
@@ -41,9 +41,9 @@ If you need to increase the storage limit, the object limit, or the bucket limit
 
 ## Transfer Quotas
 
-Object Storage adds 1 terabyte of outbound data transfer to your data transfer pool. This 1 terabyte of transfer data is prorated. If you use Object Storage for half of a month, only 500 gigabytes of transfer data will be added to your monthly transfer pool. At this time, all outbound data, including data transfer to a Linode in the same data center, is billable.
+Object Storage adds 1 terabyte of outbound data transfer to your data transfer pool. This 1 terabyte of transfer data is prorated. If you use Object Storage for half of a month, only 500 gigabytes of transfer data will be added to your monthly transfer pool. At this time, all outbound data, including data transfer from Object Storage to a Linode in the same data center, is billable.
 
-You are not charged for uploading objects (inbound traffic) to Object Storage, with a few exceptions. Uploading an object to Object Storage from a Linode is almost always billable, as that is considered outbound traffic from the origin Linode. However, uploading an object from a Linode to Object Storage over IPv6 will be free provided both the Linode and the bucket are hosted in the same data center.  Any further outbound data past your transfer quota is charged at a rate of $0.02 a gigabyte. For more information on network transfer pools, review our [Network Transfer Quota guide](https://linode.com/docs/platform/billing-and-support/network-transfer-quota/).
+You are not charged for uploading objects (inbound traffic) to Object Storage, with a few exceptions. Uploading an object to Object Storage from a Linode is almost always billable, as that is considered outbound traffic from the origin Linode. However, uploading an object from a Linode to Object Storage over IPv6 will be free, provided both the Linode and the bucket are hosted in the same data center.  Any further outbound data past your transfer quota is charged at a rate of $0.02 a gigabyte. For more information on network transfer pools, review our [Network Transfer Quota](https://linode.com/docs/platform/billing-and-support/network-transfer-quota/) guide.
 
 ## Rate Limiting
 

--- a/docs/platform/object-storage/pricing-and-limitations/index.md
+++ b/docs/platform/object-storage/pricing-and-limitations/index.md
@@ -23,7 +23,7 @@ Linode Object Storage offers affordable and full-featured cloud storage for unst
 
 Linode Object Storage costs a flat rate of $5 a month, and includes 250 gigabytes of storage. This flat rate is prorated, so if you use Object Storage for a fraction of the month you will be charged a fraction of the cost. For example, if you have Object Storage enabled for half of the month and use up to 250 gigabytes of storage you will be billed $2.50 at the end of the month. Each additional gigabyte of storage over the first 250 gigabytes will cost $0.02, and this usage is also prorated based on usage time.
 
-Object Storage can be viewed similarly to a subscription service. Once enabled, you will be billed at the flat rate regardless of whether or not there are active buckets on your account.
+Object Storage is similar to a subscription service. **Once enabled, you will be billed at the flat rate regardless of whether or not there are active buckets on your account.** [Cancelling Object Storage](/docs/platform/object-storage/how-to-use-object-storage/#cancel-object-storage) will stop billing for this flat rate.
 
 {{< note >}}
 For more information on enabling Object Storage, cancelling Object Storage, and more, see our [How To Guide](/docs/platform/object-storage/how-to-use-object-storage/#enable-object-storage).

--- a/docs/platform/object-storage/pricing-and-limitations/index.md
+++ b/docs/platform/object-storage/pricing-and-limitations/index.md
@@ -26,7 +26,7 @@ Linode Object Storage costs a flat rate of $5 a month, and includes 250 gigabyte
 Object Storage can be viewed similarly to a subscription service. Once enabled, you will be billed at the flat rate regardless of whether or not there are active buckets on your account.
 
 {{< note >}}
-For more information on enabling Object Storage, cancelling Object Storage, and more, see our [How To Guide](/docs/platform/object-storage/how-to-use-object-storage/#enable-object-storage)
+For more information on enabling Object Storage, cancelling Object Storage, and more, see our [How To Guide](/docs/platform/object-storage/how-to-use-object-storage/#enable-object-storage).
 {{< /note >}}
 
 ## Storage Limitations

--- a/docs/platform/object-storage/pricing-and-limitations/index.md
+++ b/docs/platform/object-storage/pricing-and-limitations/index.md
@@ -14,7 +14,7 @@ contributor:
 ---
 
 {{< note >}}
-[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with objects stored in Object Storage buckets will be billed.
+[Linode Object Storage](/docs/platform/object-storage/) is now available to the general public in the Newark data center! Starting November 1, 2019, all customers with the Object Storage service enabled on their account will be billed.
 {{</ note >}}
 
 Linode Object Storage offers affordable and full-featured cloud storage for unstructured data and static sites. This guide will outline Object Storage pricing, storage limitations, and data transfer quotas.
@@ -22,6 +22,12 @@ Linode Object Storage offers affordable and full-featured cloud storage for unst
 ## Pricing
 
 Linode Object Storage costs a flat rate of $5 a month, and includes 250 gigabytes of storage. This flat rate is prorated, so if you use Object Storage for a fraction of the month you will be charged a fraction of the cost. For example, if you have Object Storage enabled for half of the month and use up to 250 gigabytes of storage you will be billed $2.50 at the end of the month. Each additional gigabyte of storage over the first 250 gigabytes will cost $0.02, and this usage is also prorated based on usage time.
+
+Object Storage can be viewed similarly to a subscription service. Once enabled, you will be billed at the flat rate regardless of whether or not there are active buckets on your account.
+
+{{< note >}}
+For more information on enabling Object Storage, cancelling Object Storage, and more, see our [How To Guide](/docs/platform/object-storage/how-to-use-object-storage/#enable-object-storage)
+{{< /note >}}
 
 ## Storage Limitations
 
@@ -35,7 +41,9 @@ If you need to increase the storage limit, the object limit, or the bucket limit
 
 ## Transfer Quotas
 
-Object Storage adds 1 terabyte of outbound data transfer to your data transfer pool. This 1 terabyte of transfer data is prorated. If you use Object Storage for half of a month, only 500 gigabytes of transfer data will be added to your monthly transfer pool. At this time, all outbound data, including data transfer to a Linode in the same data center, is billable. You are not charged for uploading objects (inbound traffic) to Object Storage, with the exception that  uploading a object to Object Storage from a Linode over IPv4 is billable, as that is considered outbound traffic on your Linode. Any further outbound data is charged at a rate of $0.02 a gigabyte. For more information on network transfer pools, review our [Network Transfer Quota guide](https://linode.com/docs/platform/billing-and-support/network-transfer-quota/).
+Object Storage adds 1 terabyte of outbound data transfer to your data transfer pool. This 1 terabyte of transfer data is prorated. If you use Object Storage for half of a month, only 500 gigabytes of transfer data will be added to your monthly transfer pool. At this time, all outbound data, including data transfer to a Linode in the same data center, is billable.
+
+You are not charged for uploading objects (inbound traffic) to Object Storage, with a few exceptions. Uploading an object to Object Storage from a Linode is almost always billable, as that is considered outbound traffic from the origin Linode. However, uploading an object from a Linode to Object Storage over IPv6 will be free provided both the Linode and the bucket are hosted in the same data center.  Any further outbound data past your transfer quota is charged at a rate of $0.02 a gigabyte. For more information on network transfer pools, review our [Network Transfer Quota guide](https://linode.com/docs/platform/billing-and-support/network-transfer-quota/).
 
 ## Rate Limiting
 


### PR DESCRIPTION
Added information to clarify that OBJ is billed upon activation and must be completely cancelled as a service, and caveats regarding transfer with IPv6 in the same datacenter  