### PR TITLE
[NEW] Certificate Authority with OpenSSL series

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -193,6 +193,7 @@ com2sec
 comodo
 completekey
 conda
+confidental
 config
 configs
 configtest
@@ -312,6 +313,7 @@ dockerfile
 dockerfiles
 dockerize
 dockerized
+dogtag
 dokku
 domain1
 domain2

--- a/docs/security/ssl/certificate-authority-openssl-crl/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-crl/index.md
@@ -3,7 +3,7 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Revoke certificates by CRL'
-keywords: ['ssl','tls','certificate authority','ca','crl']
+keywords: ['ssl','tls','certificate authority','certificate revocation lists','crl']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2019-11-27
 modified: 2019-11-27

--- a/docs/security/ssl/certificate-authority-openssl-crl/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-crl/index.md
@@ -1,0 +1,115 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+description: 'Revoke certificates by CRL'
+keywords: ['ssl','tls','certificate authority','ca','crl']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2019-11-27
+modified: 2019-11-27
+modified_by:
+  name: Linode
+title: "Certificate Authority with OpenSSL - Part 4: Certificate Revocation Lists"
+contributor:
+  name: Bagas Sanjaya
+external_resources:
+- '[OpenSSL CA guide by Jamie Nguyen: CRL](https://jamielinux.com/docs/openssl-certificate-authority/certificate-revocation-lists.html)'
+- '[OpenSSL Manual Pages (master version)](https://www.openssl.org/docs/manmaster/)'
+---
+
+A [Certificate Revocation List (CRL)](https://en.wikipedia.org/wiki/Certificate_revocation_list) is a list of certificates that have been revoked by issuing CA before expiration date. Client applications (such as web browsers) can use CRL to check validity (revocation status) of certificates that are used. Once the certificate have been revoked and added into CRL, clients will issue *invalid certificate* warning.
+
+This guide, on part 4 of our *Certificate Authority with OpenSSL* series, will outline how to revoke certificates that have been signed by your CA by means of CRL. The other way to revoke certificate is using *Online Certificate Status Protocol*, which is explained on [Part 5](/docs/security/ssl/certificate-authority-openssl-ocsp/).
+
+## Before You Begin
+
+1.  You need to get list of certificates which you wish to revoke. This can be done by being contacted by your client who wants to revoke the certificate, or by party that report abuse of your signed certificate.
+
+2.  Switch to CA user:
+
+        # su - linode-ca
+
+## Generate CRL
+
+1.  In order for CRL location to be included into signed certificates, the corresponding configuration entry must be present. Append `crlDistributionPoints` to both `server_cert` and `usr_cert` extension sections of intermediate CA configuration (if you follow Part 4 guide, the configuration files are both `intermediate.cnf` and `intermediate.san.cnf`). Replace with URL you wish to publish the CRL:
+
+    {{< file "~/ca/intermediate/config/intermediate.cnf" ini >}}
+...
+[ usr_cert ]
+...
+crlDistributionPoints = URI:http://ca.linode.com/linode-ca.crl.pem
+
+...
+[ server_cert ]
+crlDistributionPoints = URI:http://ca.linode.com/linode-ca.crl.pem
+
+...
+{{< /file >}}
+
+2.  Generate the CRL file based on `index.txt` database. Give the validity of a day (because CRL is often updated with new certificate revocation):
+
+        $ cd ~/ca/intermediate
+        $ openssl ca -gencrl -crldays 1 -config config/intermediate.cnf -out crl/linode-ca.crl.pem
+
+3.  Check CRL contents by:
+
+        $ openssl crl -noout -text -in crl/linode-ca.crl.pem
+
+    Since no certificates are revoked yet, the output should contain `No Revoked Certificates`.
+
+    {{< note >}}
+Ideally, CRL should be generated shortly after revoking a certificate, in order for revocation to take effect.
+{{< /note >}}
+
+    {{< note >}}
+All certificates that had been signed prior to creating first CRL don't have CRL information embedded. You need to revoke and re-sign them to embed it.
+{{< /note >}}
+
+## Revoke Certificate
+
+1.  Create new directory to store revoked certificates:
+
+        $ mkdir certs/revoked
+
+2.  Place certificates that are about to be revoked in directory above. Replace with actual certificate file name:
+
+        $ mv certs/test-crl.cert.pem certs/revoked/
+
+3.  Revoke the certificate:
+
+    {{< note >}}
+You can optionally add `-crl_reason` argument to specify revocation reason. Refer to `ca(1ssl)` manual page for list of supported reasons.
+{{< /note >}}
+
+        $ openssl ca -config config/intermediate.cnf -revoke certs/revoked/test-crl.cert.pem
+
+    {{< output >}}
+Using configuration from config/intermediate.cnf
+Enter pass phrase for /home/linode-ca/ca/intermediate/private/linode-ca-intermediate.key.pem: phrase
+Revoking Certificate 1001.
+Data Base Updated
+{{< /output >}}
+
+4.  [Regenerate the CRL](#generate-crl).
+
+5.  **Verify** the contents of CRL by:
+
+        $ openssl crl -noout -text -in crl/linode-ca.crl.pem
+
+    The CRL now contains list of revoked certificates, like:
+
+    {{< output >}}
+...
+Revoked Certificates:
+    Serial Number: 1001
+        Revocation Date: Nov 28 11:52:44 2019 GMT
+...
+{{< /output >}}
+
+6.  Also verify that `index.txt` database contains entry for revoked certificate, which prefixed with `R`:
+
+    {{< file "~/ca/intermediate/index.txt" >}}
+...
+R       200306102615Z   191128115244Z   1001    unknown /C=US/ST=CA/L=Riverside/O=Test/OU=Test/CN=Test Certificate for CRL/emailAddress=test@test.io
+...
+{{< /file >}}

--- a/docs/security/ssl/certificate-authority-openssl-intermediate-pair/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-intermediate-pair/index.md
@@ -9,7 +9,7 @@ published: 2019-11-24
 contributor:
   name: Bagas Sanjaya
 description: 'Generating intermediate pair for signing certificates.'
-keywords: ["ssl", "tls", "certificate authority", "ca"]
+keywords: ["ssl", "tls", "certificate authority", "intermediate ca", "intermediate pair"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 title: 'Certificate Authority with OpenSSL - Part 2: Intermediate Pair'
 external_resources:

--- a/docs/security/ssl/certificate-authority-openssl-intermediate-pair/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-intermediate-pair/index.md
@@ -1,0 +1,294 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+modified: 2019-11-24
+modified_by:
+  name: Linode
+published: 2019-11-24
+contributor:
+  name: Bagas Sanjaya
+description: 'Generating intermediate pair for signing certificates.'
+keywords: ["ssl", "tls", "certificate authority", "ca"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+title: 'Certificate Authority with OpenSSL - Part 2: Intermediate Pair'
+external_resources:
+  - '[OpenSSL CA guide by Jamie Nguyen: Creating Intermediate Pair](https://jamielinux.com/docs/openssl-certificate-authority/create-the-intermediate-pair.html)'
+  - '[OpenSSL Manual Pages (master version)](https://www.openssl.org/docs/manmaster/)'
+---
+
+In this guide, we will generate intermediate pair (private key and CA certificate). Intermediate CA is an entity that can sign certificates on behalf of root CA. This is used primarily for security reasons, so if intermediate CA become compromised, it can be revoked by root CA and new intermediate pair can be generated and used instead.
+
+## Before You Begin
+
+-  This guide is Part 2 of our *Certificate Authority with OpenSSL* series. You will need a root pair (private key and CA certificate). Follow [Part 1](/docs/security/ssl/certificate-authority-openssl-introduction-root-pair/) if you don't already have one. It also contains excerpt of what CA is, how it worked, and benefits of having your own CA.
+
+-  Switch to CA user:
+
+        # su - linode-ca
+
+## Directory Structure and Configuration File Preparation
+
+1.  Create directory structures to store intermediate CA files:
+
+        $ mkdir ~/ca/intermediate
+        $ mkdir ~/ca/intermediate/{certs,config,crl,csr,newcerts,private}
+
+2.  Create database, serial and CRL number file:
+
+        $ touch ~/ca/intermediate/index.txt
+        $ echo 1000 | tee ~/ca/intermediate/serial ~/linode-ca/intermediate/crlnumber
+
+3.  Add intermediate CA configuration file, as below:
+
+    {{< file "~/ca/intermediate/config/intermediate.cnf" ini >}}
+[ ca ]
+# Intermediate CA configuration
+
+# See `man ca`
+default_ca = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir               = /home/linode-ca/ca/intermediate
+certs             = $dir/certs
+crl_dir           = $dir/crl
+new_certs_dir     = $dir/newcerts
+database          = $dir/index.txt
+serial            = $dir/serial
+RANDFILE          = $dir/private/.rand
+
+# The root key and root certificate.
+private_key       = $dir/private/linode-ca-intermediate.key.pem
+certificate       = $dir/certs/linode-ca-intermediate.cert.pem
+
+# For certificate revocation lists.
+crlnumber         = $dir/crlnumber
+crl               = $dir/crl/linode-ca-intermediate.crl.pem
+crl_extensions    = crl_ext
+default_crl_days  = 30
+
+# Use SHA-256 as default hashing method
+default_md        = sha256
+
+name_opt          = ca_default
+cert_opt          = ca_default
+default_days      = 375
+preserve          = no
+policy            = policy_loose
+
+[ policy_strict ]
+# The root CA should only sign intermediate certificates that match.
+# See the POLICY FORMAT section of `man ca`.
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ policy_loose ]
+# Allow the intermediate CA to sign a more diverse range of certificates.
+# See the POLICY FORMAT section of the `ca` man page.
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+# Options for the `req` tool (`man req`).
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+
+# SHA-1 is deprecated, so use SHA-2 instead.
+default_md          = sha256
+
+# Extension to add when the -x509 option is used.
+x509_extensions     = v3_ca
+
+[ req_distinguished_name ]
+# Text to display for Distinguished Name prompt
+countryName                     = Country Name (2 letter code)
+stateOrProvinceName             = State or Province Name
+localityName                    = Locality Name
+0.organizationName              = Organization Name
+organizationalUnitName          = Organizational Unit Name
+commonName                      = Common Name
+emailAddress                    = Email Address
+
+# Optionally, specify some defaults.
+countryName_default             = US
+stateOrProvinceName_default     = PA
+localityName_default            = Philadelphia
+0.organizationName_default      = Linode
+organizationalUnitName_default  =
+emailAddress_default            =
+
+[ v3_ca ]
+# Extensions for a typical CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ v3_intermediate_ca ]
+# Extensions for a typical intermediate CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true, pathlen:0
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ usr_cert ]
+# Extensions for client certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = client, email
+nsComment = "OpenSSL Generated Client Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+
+[ server_cert ]
+# Extensions for server certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = server
+nsComment = "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[ crl_ext ]
+# Extension for CRLs (`man x509v3_config`).
+authorityKeyIdentifier=keyid:always
+
+[ ocsp ]
+# Extension for OCSP signing certificates (`man ocsp`).
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, OCSPSigning
+{{< /file >}}
+
+## Make the Intermediate Pair
+
+1.  Generate the intermediate key. As in the root key, use RSA 4096-bit with AES-256 and a pass phrase. Replace `phrase` with your strong pass phrase. Then set the permission to read-only:
+
+        $ cd ~/ca/intermediate
+        $ openssl genrsa -aes256 -out private/linode-ca-intermediate.key.pem 4096
+
+    {{< output >}}
+Generating RSA private key, 4096 bit long modulus (2 primes)
+.......++++
+............++++
+e is 65537 (0x010001)
+Enter pass phrase for private/linode-ca-intermediate.key.pem: phrase
+Verifying - Enter pass phrase for private/linode-ca-intermediate.key.pem: phrase
+{{< /output >}}
+
+        $ chmod 400 private/linode-ca-intermediate.key.pem
+
+2.  Create *certificate signing request (CSR)* with intermediate key. Replace with DN information of your intermediate CA:
+
+    {{< note >}}
+DN information for intermediate CA should match the root CA counterpart, except that `Common Name` must be different.
+{{< /note >}}
+
+        $ openssl req -new -sha256 -config config/intermediate.cnf -key private/linode-ca-intermediate.key.pem -out csr/linode-ca-intermediate.csr.pem
+
+    {{< output >}}
+Enter pass phrase for private/linode-ca-intermediate.key.pem:
+You are about to be asked to enter information that will be incorporated
+into your certificate request.
+What you are about to enter is what is called a Distinguished Name or a DN.
+There are quite a few fields but you can leave some blank
+For some fields there will be a default value,
+If you enter '.', the field will be left blank.
+-----
+Country Name (2 letter code) [US]:US
+State or Province Name [PA]:PA
+Locality Name [Philadelphia]:Philadelphia
+Organization Name [Linode]:Linode
+Organizational Unit Name []:Linode CA
+Common Name []:Linode Intermediate CA
+Email Address []:ca@linode.com
+{{< /output >}}
+
+3.  Sign the intermediate CA's CSR with root CA. Apply `v3_intermediate_ca` extension. Validity of intermediate CA should be shorter than root CA, for example 3600 days:
+
+        $ openssl ca -config ../root/config/root.cnf -extensions v3_intermediate_ca -days 3600 -md sha256 -notext -in csr/linode-ca-intermediate.csr.pem -out certs/linode-ca-intermediate.cert.pem
+
+    {{< output >}}
+Using configuration from ../root/config/root.cnf
+Enter pass phrase for /home/linode-ca/ca/root/private/linode-ca-root.key.pem: phrase
+...
+Sign the certificate? [y/n]: y
+{{< /output >}}
+
+4.  **Verify** the newly-generated pair by:
+
+        $ openssl x509 -noout -text -in certs/linode-ca-intermediate.cert.pem
+
+    The output will be similar to below:
+
+    {{< output >}}
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4096 (0x1000)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = PA, L = Philadelphia, O = Linode, OU = Linode CA, CN = Linode Root CA, emailAddress = ca@linode.com
+        Validity
+            Not Before: Nov 23 10:44:28 2019 GMT
+            Not After : Oct  1 10:44:28 2029 GMT
+        Subject: C = US, ST = PA, O = Linode, OU = Linode CA, CN = Linode Intermediate CA, emailAddress = ca@linode.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                ...
+       X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                83:17:15:5E:8B:62:DE:BB:9E:EF:B1:A3:FF:D2:AA:7B:6D:1B:50:CF
+            X509v3 Authority Key Identifier:
+                keyid:5E:53:95:83:8C:06:66:E0:2F:CD:4E:A0:07:6D:3F:6F:3A:86:6C:A4
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+    Signature Algorithm: sha256WithRSAEncryption
+        ...
+{{< /output >}}
+
+    Note the `pathlen:0` entry in `X509v3 Basic Constraints`. This means that there aren't any further CA below this intermediate CA. Also, `Locality` information is omitted from `Subject` entry.
+
+5.  Also **verify** that chain of trust between intermediate and root CA is intact:
+
+        $ openssl verify -CAfile ../root/certs/linode-ca-root.cert.pem certs/linode-ca-intermediate.cert.pem
+
+    {{< output >}}
+certs/linode-ca-intermediate.cert.pem: OK
+{{< /output >}}
+
+6.  When a client tries verifying a certificate that is signed by intermediate CA, the intermediate CA must also be verified against root CA. To satisfy this requirement, concatenate **intermediate and root CA** (not vice versa) to create CA chain file:
+
+        $ cat certs/linode-ca-intermediate.cert.pem ../root/certs/linode-ca-root.cert.pem > certs/linode-ca.chain.cert.pem
+
+    {{< note >}}
+The CA chain includes both intermediate and root CA because the root CA is unknown yet to the clients.
+{{< /note >}}
+
+    In [Part 3](/docs/security/ssl/certificate-authority-openssl-signing-certificates/), this chain CA will be used to verify certificates signed by intermediate CA.
+
+7.  Change permissions on intermediate CA to read-only:
+
+        $ chmod 444 certs/linode-ca-intermediate.cert.pem
+
+## To be Continued on Part 3
+
+Now you have full CA chain (root and intermediate pairs), along with chain of trust. This enables you to sign certificate requests from your clients with intermediate CA, which in turns be verified and trusted by root CA. Continue to [Part 3](/docs/security/ssl/certificate-authority-openssl-signing-certificates/) of this series to sign certificates.

--- a/docs/security/ssl/certificate-authority-openssl-introduction-root-pair/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-introduction-root-pair/index.md
@@ -1,0 +1,311 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+modified: 2019-11-21
+published: 2019-11-21
+modified_by:
+  name: Linode
+contributor:
+  name: Bagas Sanjaya
+description: 'Introduction to Certificate Authority and generating root pair for your own CA.'
+keywords: ["ssl", "tls", "certificate authority", "ca"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+title: 'Certificate Authority with OpenSSL - Part 1: Introduction and Root Pair'
+external_resources:
+  - '[OpenSSL CA guide by Jamie Nguyen: Creating Root Pair](https://jamielinux.com/docs/openssl-certificate-authority/create-the-root-pair.html)'
+  - '[OpenSSL Manual Pages (master version)](https://www.openssl.org/docs/manmaster/)'
+---
+[OpenSSL](https://www.openssl.org) is a cryptographic and SSL/TLS library for [public-key infrastructure](https://en.wikipedia.org/wiki/Public_key_infrastructure). The tools provided by OpenSSL can be used to act as your own [certificate authority (CA)](https://en.wikipedia.org/wiki/Certificate_authority).
+
+This guide is the first of a five-part series. Part 1 and [2](/docs/security/ssl/certificate-authority-openssl-intermediate-pair/) will walk you through creating root and intermediate pairs respectively, which forms a CA chain. [Part 3](/docs/security/ssl/certificate-authority-openssl-signing-certificates/) deals with signing certificate requests from clients of your CA. [Part 4](/docs/security/ssl/certificate-authority-openssl-crl/) and [5](/docs/security/ssl/certificate-authority-openssl-ocsp/) discuss about revoking certificates by means of [Certificate Revocation Lists (CRL)](https://en.wikipedia.org/wiki/Certificate_revocation_list) and [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) respectively.
+
+## Introduction to Certificate Authority
+
+A certificate authority (CA) is an entity that issue digital certificates, which the certificate issued certifies ownership of a public key by named subject. Third-parties can thus rely upon signatures of private key that correspond to the certified public key. In this case, a CA is trusted third-party, both by subject (owner) of a public key and parties relied upon the certificate.
+
+CA issues digital certificates that contains public key of the subject, while the corresponding private key is kept secret by subject who generates the key pair. One of responsibility of CA is verifying credentials of an applicant (client), with variety of standards and tests. This ensures that public key contained in the certificate really belongs to the entity listed as subject.
+
+All CA have a root pair, that is a self-signed, most trustworthy pair that identifies a root CA. With this pair, intermediate pairs are signed, and inherited trustworthiness from root pair. Client certificates are signed using these intermediate pairs, and also trusted with respect to root CA. This forms [chain of trust](https://en.wikipedia.org/wiki/Chain_of_trust), in form of a tree structure.
+
+One of most popular use of CA is signing certificates used in [HTTPS](https://en.wikipedia.org/wiki/HTTPS). Certificates can also be used for encrypting or signing messages with [S/MIME](https://en.wikipedia.org/wiki/S/MIME) protocol, although its usage is beneficial mostly to verifying messages in public mailing lists.
+
+While you can instead [create and use self-signed certificate](/docs/security/ssl/create-a-self-signed-tls-certificate/), having a CA can be useful in following scenarios:
+
+1. You administer an intranet network, and you wish to have your own public-key infrastructure to manage your certificates.
+
+2. Large organizations and governments that need to pass confidental information to trusted recipients.
+
+3. You simply don't have registered domain name, but you want enabling HTTPS for your website, and web browsers need to trust the certificate used on it.
+
+4. You have clients that need to authenticate to your server, but you want to avoid high costs of commercial CA.
+
+{{< caution >}}
+Running a public CA requires you to adhere to [CA/Browser Forum Baseline Requirements](https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.6.6.pdf), including preventing fraudulent certificates and participating in [certificate transparency](https://en.wikipedia.org/wiki/Certificate_Transparency) initiative. If you run CA in intranet/private network, you still need to comply to policy of your organization.
+
+If you have public, Internet-faced servers, it is better to [obtain commercially-signed certificate](/docs/security/ssl/obtain-a-commercially-signed-tls-certificate/) from reputable CA. This way, clients don't get certificate warnings or errors when they connect to your server.
+{{< /caution >}}
+
+## Create User for CA (Recommended)
+
+Since we will deal with cryptographic pairs of private and public keys, we strongly recommended to create separate user for running CA.
+
+**Debian & Ubuntu**:
+
+    # addgroup linode-ca
+    # adduser --ingroup linode-ca linode-ca
+
+**Other Systems**:
+
+    # groupadd linode-ca
+    # useradd -g linode-ca
+
+Switch user to CA user. All commands will now be run as this user:
+
+    # su - linode-ca
+
+## Directory Structure and Configuration File Preparation
+
+1.  Create root directory, in which all certificates and key pairs are stored:
+
+        $ mkdir ~/ca
+
+2.  Create directory structure for root CA:
+
+        $ mkdir ~/ca/root
+        $ mkdir ~/ca/root/{certs,config,crl,newcerts,private}
+
+3.  Create database and serial number file:
+
+        $ touch ~/ca/root/index.txt
+        $ echo 1000 > ~/ca/root/serial
+
+4.  Add configuration file for root CA, as below:
+
+    {{< file "~/ca/root/config/root.cnf" ini >}}
+# Root CA configuration
+
+[ ca ]
+# See `man ca`
+default_ca = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir               = /home/linode-ca/ca/root
+certs             = $dir/certs
+crl_dir           = $dir/crl
+new_certs_dir     = $dir/newcerts
+database          = $dir/index.txt
+serial            = $dir/serial
+RANDFILE          = $dir/private/.rand
+
+# The root key and root certificate.
+private_key       = $dir/private/linode-ca-root.key.pem
+certificate       = $dir/certs/linode-ca-root.cert.pem
+
+# For certificate revocation lists.
+crlnumber         = $dir/crlnumber
+crl               = $dir/crl/linode-ca-root.crl.pem
+crl_extensions    = crl_ext
+default_crl_days  = 30
+
+# Use SHA-256 as default hashing method
+default_md        = sha256
+
+name_opt          = ca_default
+cert_opt          = ca_default
+default_days      = 375
+preserve          = no
+policy            = policy_strict
+
+[ policy_strict ]
+# The root CA should only sign intermediate certificates that match.
+# See the POLICY FORMAT section of `man ca`.
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ policy_loose ]
+# Allow the intermediate CA to sign a more diverse range of certificates.
+# See the POLICY FORMAT section of the `ca` man page.
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+# Options for the `req` tool (`man req`).
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+
+# SHA-1 is deprecated, so use SHA-2 instead.
+default_md          = sha256
+
+# Extension to add when the -x509 option is used.
+x509_extensions     = v3_ca
+
+[ req_distinguished_name ]
+# Text to display for Distinguished Name prompt
+countryName                     = Country Name (2 letter code)
+stateOrProvinceName             = State or Province Name
+localityName                    = Locality Name
+0.organizationName              = Organization Name
+organizationalUnitName          = Organizational Unit Name
+commonName                      = Common Name
+emailAddress                    = Email Address
+
+# Optionally, specify some defaults.
+countryName_default             = US
+stateOrProvinceName_default     = PA
+localityName_default            = Philadelphia
+0.organizationName_default      = Linode
+organizationalUnitName_default  =
+emailAddress_default            =
+
+[ v3_ca ]
+# Extensions for a typical CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ v3_intermediate_ca ]
+# Extensions for a typical intermediate CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true, pathlen:0
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ usr_cert ]
+# Extensions for client certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = client, email
+nsComment = "OpenSSL Generated Client Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+
+[ server_cert ]
+# Extensions for server certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = server
+nsComment = "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[ crl_ext ]
+# Extension for CRLs (`man x509v3_config`).
+authorityKeyIdentifier=keyid:always
+
+[ ocsp ]
+# Extension for OCSP signing certificates (`man ocsp`).
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, OCSPSigning
+{{< /file >}}
+
+## Make the Root Pair
+
+1.  Generate RSA 4096-bit root key. Encrypt with AES-256 and a pass phrase (replace `phrase` with your strong pass phrase). Set permission on root key to read-only:
+
+        $ cd ~/ca/root
+        $ openssl genrsa -aes256 -out private/linode-ca-root.key.pem
+
+    {{< output >}}
+Generating RSA private key, 4096 bit long modulus (2 primes)
+.............................++++
+.......................................................................++++
+e is 65537 (0x010001)
+Enter pass phrase for private/linode-ca-root.key.pem: phrase
+Verifying - Enter pass phrase for private/linode-ca-root.key.pem: phrase
+{{< /output >}}
+
+        $ chmod 400 private/linode-ca-root.key.pem
+
+2.  Use the root key to generate root certificate, with long expiry date (for example, 7200 days). The `-x509` switch is used to create self-signed certificate, with `v3_ca` extensions applied:
+
+        $ openssl req -config config/root.cnf -key private/linode-ca-root.key.pem -x509 -new -sha256 -extensions v3_ca -days 7200 -out certs/linode-ca-root.cert.pem
+
+    You will see prompt which asked for details of your root certificate. Such information are called *Distinguished Name (DN)*. These will be embedded to the certificate, so double check your input before you press enter. Replace with DN information of your root CA:
+
+    {{< output >}}
+Enter pass phrase for private/linode-ca-root.key.pem: phrase
+You are about to be asked to enter information that will be incorporated
+into your certificate request.
+What you are about to enter is what is called a Distinguished Name or a DN.
+There are quite a few fields but you can leave some blank
+For some fields there will be a default value,
+If you enter '.', the field will be left blank.
+-----
+Country Name (2 letter code) [US]:US
+State or Province Name [PA]:PA
+Locality Name [Philadelphia]:Philadelphia
+Organization Name [Linode]:Linode
+Organizational Unit Name []:Linode CA
+Common Name []:Linode Root CA
+Email Address []:ca@linode.com
+{{< /output >}}
+
+3.  Now the root pair have been generated, **verify it** by:
+
+        $ openssl x509 -noout -text -in certs/linode-ca-root.cert.pem
+
+    This will output text version of root certificate. This will look like below. Note that `Modulus` hashes have been omitted for the sake of privacy:
+
+    {{< output >}}
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            16:f7:f2:dd:f9:29:51:6f:0b:83:0d:80:27:24:15:ff:f0:9a:d9:ed
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = PA, L = Philadelphia, O = Linode, OU = Linode CA, CN = Linode Root CA, emailAddress = ca@linode.com
+        Validity
+            Not Before: Nov 20 10:36:34 2019 GMT
+            Not After : Aug  7 10:36:34 2039 GMT
+        Subject: C = US, ST = PA, L = Philadelphia, O = Linode, OU = Linode CA, CN = Linode Root CA, emailAddress = ca@linode.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                ...
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                5E:53:95:83:8C:06:66:E0:2F:CD:4E:A0:07:6D:3F:6F:3A:86:6C:A4
+            X509v3 Authority Key Identifier:
+                keyid:5E:53:95:83:8C:06:66:E0:2F:CD:4E:A0:07:6D:3F:6F:3A:86:6C:A4
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+    Signature Algorithm: sha256WithRSAEncryption
+        ...
+{{< /output >}}
+
+    Some points for the output above:
+
+    -  `Validity` entries (`Not Before` and `Not After`) determine valid range date for the certificate. The former refers to the date the certificate was created (and signed in case of self-signed certificate), and the latter refers to actual expiration date.
+
+    -  `X509v3` extensions entry contains `CA:TRUE` basic constraint. This is required for root CA to be able to sign intermediate CA, in addition to `Digital Signature`, `Certificate Sign`, and `CRL Sign` key usage.
+
+    - `Issuer` is the entity that issue the certificate, while `Subject` is the entity which the certificate is issued to. Since this certificate is self-signed, both entries are identical.
+
+4.  Since the certificate contains sensitive information, protect it by changing permissions to read only:
+
+        $ chmod 444 certs/linode-ca-root.cert.pem
+
+## To be Continued on Part 2
+
+By now you should have a root pair (root private key and CA certificate). While on some guides on the Internet use this certificate to directly sign certificates from clients, we recommend to use intermediate CA instead. To generate intermediate CA, see [Part 2](/docs/security/ssl/certificate-authority-openssl-intermediate-pair/) of this series.

--- a/docs/security/ssl/certificate-authority-openssl-introduction-root-pair/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-introduction-root-pair/index.md
@@ -9,7 +9,7 @@ modified_by:
 contributor:
   name: Bagas Sanjaya
 description: 'Introduction to Certificate Authority and generating root pair for your own CA.'
-keywords: ["ssl", "tls", "certificate authority", "ca"]
+keywords: ["ssl", "tls", "certificate authority", "root ca", "root pair"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 title: 'Certificate Authority with OpenSSL - Part 1: Introduction and Root Pair'
 external_resources:

--- a/docs/security/ssl/certificate-authority-openssl-ocsp/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-ocsp/index.md
@@ -1,0 +1,239 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+description: 'Revoke certificates with Online Certificate Status Protocol.'
+keywords: ['ssl', 'tls', 'certificate authority', 'ca', 'ocsp']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2019-12-04
+modified: 2019-12-04
+modified_by:
+  name: Linode
+title: "Certificate Authority with OpenSSL - Part 5: Online Certificate Status Protocol"
+contributor:
+  name: Bagas Sanjaya
+external_resources:
+  - '[OpenSSL CA guide by Jamie Nguyen: OCSP](https://jamielinux.com/docs/openssl-certificate-authority/online-certificate-status-protocol.html)'
+  - '[OpenSSL Manual Pages (master version)](https://www.openssl.org/docs/manmaster/)'
+---
+
+[Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) is an Internet protocol used for obtaining validity status of certificate. It was created as an alternative to CRL.
+
+When client applications (such as web browser) try to validate the certificate, a query will be sent to OCSP server (responder) which its address is specified in the certificate. The responder then listen to the query and return the status of certificate.
+
+This guide is the final part of *Certificate Authority with OpenSSL* series. Here we will generate OCSP pair for use on built-in responder by OpenSSL, then revoke the certificate to see OCSP in action.
+
+## Before You Begin
+
+-  As in [Part 4 (CRL)](/docs/security/ssl/certificate-authority-openssl-crl/), you need list of certificates which will be revoked, which can be obtained from your client who wants to revoke the certificated, or being informed by third-party that reports certificate abuse.
+
+-  Switch to CA user:
+
+        # su - linode-ca
+
+## Generate OCSP Pair
+
+The OCSP responder requires separate pair for signing responses to requesting clients, and it must be signed by same CA that also sign the being checked certificate.
+
+1.  In order to use OCSP, the responder URI must be encoded into certificates signed by CA. Append `authorityInfoAccess` directive to both `server_cert` and `usr_cert` extension section of intermediate CA configuration (both `intermediate.cnf` and `intermediate.san.cnf`). Replace with domain you wish to serve the responder:
+
+    {{< file "~/ca/intermediate/config/intermediate.cnf" ini >}}
+...
+[ usr_cert ]
+...
+authorityInfoAccess = OCSP;URI:http://ocsp.ca.linode.com
+
+...
+[ server_cert ]
+...
+authorityInfoAccess = OCSP;URI:http://ocsp.ca.linode.com
+
+...
+{{< /file >}}
+
+2.  Generate 4096-bit RSA private key, encrypted with AES-256 algorithm and a pass phrase. Replace `phrase` with your chosen strong pass phrase:
+
+        $ cd ~/ca/intermediate
+        $ openssl genrsa -aes256 -out private/linode-ca-ocsp.key.pem 4096
+
+    {{< output >}}
+Generating RSA private key, 4096 bit long modulus (2 primes)
+..........................................................................................................................................................++++
+................................................................................................................................................................................................................................................................................................++++
+e is 65537 (0x010001)
+Enter pass phrase for private/linode-ca-ocsp.key.pem: phrase
+Verifying - Enter pass phrase for private/linode-ca-ocsp.key.pem: phrase
+{{< /output >}}
+
+3.  Create the CSR request. Replace with DN information of your CA:
+
+    {{< caution >}}
+The DN should match the signing CA, but `Common Name` must be fully-qualified domain (FQDN) for OCSP responder.
+{{< /caution >}}
+
+        $ openssl req -new -sha 256 -config config/intermediate.cnf -key private/linode-ca-ocsp.key.pem -out csr/linode-ca-ocsp.csr.pem
+
+    {{< output >}}
+Enter pass phrase for private/linode-ca-ocsp.key.pem: phrase
+You are about to be asked to enter information that will be incorporated
+into your certificate request.
+What you are about to enter is what is called a Distinguished Name or a DN.
+There are quite a few fields but you can leave some blank
+For some fields there will be a default value,
+If you enter '.', the field will be left blank.
+-----
+Country Name (2 letter code) [US]:US
+State or Province Name [PA]:PA
+Locality Name [Philadelphia]:Philadelphia
+Organization Name [Linode]:Linode
+Organizational Unit Name []:Linode CA
+Common Name []:ocsp.ca.linode.com
+Email Address []:ca@linode.com
+{{< /output >}}
+
+4.  Use intermediate CA to sign CSR of OCSP responder. Apply `ocsp` extension and give validity period of a year plus few days:
+
+        $ openssl ca -config config/intermediate.cnf -extensions ocsp -days 375 -notext -md sha256 -in csr/linode-ca-ocsp.csr.pem -out certs/linode-ca-ocsp.cert.pem
+
+    {{< output >}}
+Using configuration from config/intermediate.cnf
+Enter pass phrase for /home/linode-ca/ca/intermediate/private/linode-ca-intermediate.key.pem: phrase
+...
+Sign the certificate? [y/n]:y
+1 out of 1 certificate requests certified, commit? [y/n]y
+Write out database with 1 new entries
+Data Base Updated
+{{< /output >}}
+
+5.  **Verify** that the OCSP responder certificate has proper extension applied:
+
+        $ openssl x509 -noout -text -in certs/linode-ca-ocsp.cert.pem
+
+    The output should contain `OCSP Signing` extended key usage:
+
+    {{< output >}}
+...
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                77:AF:19:28:A6:DA:64:FD:B1:27:F8:C9:08:CE:37:5F:F5:9F:F8:D9
+            X509v3 Authority Key Identifier:
+                keyid:83:17:15:5E:8B:62:DE:BB:9E:EF:B1:A3:FF:D2:AA:7B:6D:1B:50:CF
+
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: critical
+                OCSP Signing
+...
+{{< /output >}}
+
+    {{< note >}}
+All certificates that have been signed prior to this point (signing OCSP certificate) don't have OCSP information embedded. You need to revoke and re-sign them to include it.
+{{< /note >}}
+
+## Run the Responder and Revoke Certificate
+
+1.  Create directory to store revoked certificates:
+
+        $ mkdir certs/revoked
+
+2.  Place certificate that is about to be revoked into revoked directory, replace `test-ocsp.cert.pem` with actual certificate file name:
+
+        $ mv certs/test-ocsp.cert.pem certs/revoked
+
+3.  Run the responder on `localhost` with arbitrary port (here we choose 2560). Use chained file of intermediate CA, and specify the OCSP pair for response signage. Instead of storing to CRL, the OCSP responder directly reads `index.txt` database. For security reasons, limit request count to only one per responder invocation:
+
+    {{< caution >}}
+Order of arguments passed to `ocsp` are important. See `ocsp(1ssl)` manual page for full, proper syntax.
+{{< /caution >}}
+
+        $ openssl ocsp -port 2560 -index index.txt -CA certs/linode-ca.chain.cert.pem -rkey private/linode-ca-ocsp.key.pem -rsigner certs/linode-ca-ocsp.cert.pem -nrequest 1
+
+4.  On the other terminal session, send query to the responder at `localhost`. `-issuer` option points to intermediate CA certificate (not the bundle), while `-cert` specify the certificate which will be queried. Hash the response with SHA-256 algorithm:
+
+        $ openssl ocsp -resp_text -url http://127.0.0.1:2560 -CAfile certs/linode-ca.chain.cert.pem -issuer certs/linode-ca-intermediate.cert.pem -sha256 -cert certs/revoked/test-ocsp.cert.pem
+
+    The output will look like:
+
+    {{< output >}}
+OCSP Response Data:
+    OCSP Response Status: successful (0x0)
+    Response Type: Basic OCSP Response
+    Version: 1 (0x0)
+    Responder Id: C = US, ST = PA, L = Philadelphia, O = Linode, OU = Linode CA, CN = ocsp.ca.linode.com, emailAddress = ca@linode.com
+    Produced At: Dec  2 10:54:02 2019 GMT
+    Responses:
+    Certificate ID:
+      Hash Algorithm: sha256
+      Issuer Name Hash: 3F1F9F8697CC6358598009B2CF50B299272C91CBC77AD5FF8FE7F57491810EDC
+      Issuer Key Hash: 41F10858B1527EBE6FBF7120E52708EBDD01D91B9CE9CE99C12F58438DF57E25
+      Serial Number: 1003
+    Cert Status: good
+    This Update: Dec  2 10:54:02 2019 GMT
+
+    Response Extensions:
+        OCSP Nonce:
+            0410EBC4B322DBAD52F75FC2C2996D9F3648
+    Signature Algorithm: sha256WithRSAEncryption
+    ...
+Response verify OK
+certs/revoked/test-ocsp.cert.pem: good
+        This Update: Dec  2 10:54:02 2019 GMT
+{{< /output >}}
+
+    Note from the output:
+
+    -  `OCSP Response Status` of `successful` indicates that the response have been successfully received.
+    -  `Responder ID` refers to DN information of OCSP certificate.
+    -  `Cert Status` determines revocation status of queried certificate. Since it haven't been revoke yet, the output would be `good`.
+    -  `Certificate ID`  refers to the queried certificate and its issuer. Note that `Issuer Name Hash` and `Issuer Key Hash` will be different than those displayed here depending on your CA and creation time of certificates.
+
+5.  Now revoke the certificate:
+
+    {{< note >}}
+You can optionally specify revocation reason with `-crl_reason`. Refer to `ca(1ssl)` manual page for supported reasons.
+{{< /note >}}
+
+        $ openssl ca -config config/intermediate.cnf -revoke certs/revoked/test-ocsp.cert.pem
+
+    {{< output >}}
+Using configuration from config/intermediate.cnf
+Enter pass phrase for /home/linode-ca/ca/intermediate/private/linode-ca-intermediate.key.pem: phrase
+Revoking Certificate 1003.
+Data Base Updated
+{{< /output >}}
+
+6.  Re-run step 3 and 4. The output now reflect the revoked status of certificate with its `Revocation Time`:
+
+    {{< output >}}
+OCSP Response Data:
+    OCSP Response Status: successful (0x0)
+    Response Type: Basic OCSP Response
+    Version: 1 (0x0)
+    Responder Id: C = US, ST = PA, L = Philadelphia, O = Linode, OU = Linode CA, CN = ocsp.ca.linode.com, emailAddress = ca@linode.com
+    Produced At: Dec  3 08:50:36 2019 GMT
+    Responses:
+    Certificate ID:
+      Hash Algorithm: sha256
+      Issuer Name Hash: 3F1F9F8697CC6358598009B2CF50B299272C91CBC77AD5FF8FE7F57491810EDC
+      Issuer Key Hash: 41F10858B1527EBE6FBF7120E52708EBDD01D91B9CE9CE99C12F58438DF57E25
+      Serial Number: 1003
+    Cert Status: revoked
+    Revocation Time: Dec  3 08:40:49 2019 GMT
+    This Update: Dec  3 08:50:36 2019 GMT
+
+    Response Extensions:
+        OCSP Nonce:
+            04104F0AC4B0E13F5F31E2569250CA9810B9
+    Signature Algorithm: sha256WithRSAEncryption
+    ...
+Response verify OK
+certs/revoked/test-ocsp.cert.pem: revoked
+        This Update: Dec  3 08:50:36 2019 GMT
+        Revocation Time: Dec  3 08:40:49 2019 GMT
+{{< /output >}}
+
+## Conclusion
+
+This concludes *Certificate Authority with OpenSSL* series. You should now run and manage your own CA with OpenSSL tools. Those tools are basic and minimal, however. If you need polished, production ready certificate system, have a look at [Dogtag](https://www.dogtagpki.org).

--- a/docs/security/ssl/certificate-authority-openssl-ocsp/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-ocsp/index.md
@@ -3,7 +3,7 @@ author:
   name: Linode
   email: docs@linode.com
 description: 'Revoke certificates with Online Certificate Status Protocol.'
-keywords: ['ssl', 'tls', 'certificate authority', 'ca', 'ocsp']
+keywords: ['ssl', 'tls', 'certificate authority', 'online certificate status protocol', 'ocsp']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2019-12-04
 modified: 2019-12-04

--- a/docs/security/ssl/certificate-authority-openssl-signing-certificates/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-signing-certificates/index.md
@@ -1,0 +1,204 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+modified: 2019-11-26
+modified_by:
+  name: Linode
+published: 2019-11-26
+contributor:
+  name: Bagas Sanjaya
+description: 'Signing certificates with your CA.'
+keywords: ["ssl", "tls", "certificate authority", "ca"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+title: 'Certificate Authority with OpenSSL - Part 3: Signing Certificates'
+external_resources:
+  - '[OpenSSL CA guide by Jamie Nguyen: Sign Certificates](https://jamielinux.com/docs/openssl-certificate-authority/sign-server-and-client-certificates.html)'
+  - '[OpenSSL Manual Pages (master version)](https://www.openssl.org/docs/manmaster/)'
+---
+
+This guide, in Part 3 of *Certificate Authority with OpenSSL* series, will deal with signing both server and client certificate requests. The signage will be done using intermediate CA generated in Part 2.
+
+## Before You Begin
+
+-  Follow Part 2 guide if you don't already have intermediate CA.
+
+-  You need certificate requests (CSRs) submitted from third-parties, be it yourself (if you act as internal CA) or external entities (if you act as public CA). See [Obtain a Commercially Signed TLS Certificate](/docs/security/ssl/obtain-a-commercially-signed-tls-certificate/) guide for instructions to generate CSR for submission to your CA.
+
+-  Switch to CA user:
+
+        # su - linode-ca
+
+## Sign Certificates
+
+1.  Place all CSR requests on `~/linode-ca/intermediate/csr` directory.
+
+2.  Copy intermediate CA configuration file to same file, but with `.san.cnf` extension. The latter will be used for signing CSR with Subject Alternative Name (SAN):
+
+        $ cd ~/linode-ca/intermediate
+        $ cp config/intermediate.cnf config/intermediate.san.cnf
+
+3.  Add `subjectAltName` entry to `server_cert` and `usr_cert` extension section. It reads SAN from environment variable:
+
+    {{< file "~/ca/intermediate/config/intermediate.san.cnf" ini >}}
+...
+[ usr_cert ]
+...
+subjectAltName = ${ENV::SAN}
+...
+
+[ server_cert ]
+...
+subjectAltName = ${ENV::SAN}
+{{< /file >}}
+
+4.  Determine SAN entries to be included to the signed certificate, by examining the CSR:
+
+        $ openssl req -noout -text -in csr/others.csr.pem
+
+    If the CSR contains SAN, the output contains `X509v3 Subject Alternative Name` entry, which looks like:
+
+    {{< output >}}
+        Requested Extensions:
+            X509v3 Subject Alternative Name:
+                DNS:www.others.io, DNS:*.others.io
+{{< /output >}}
+
+    If the entry above doesn't exist, SAN isn't available in the CSR, and you can skip step 5 below.
+
+5.  Export SAN entries to the environment variable. Replace with SAN from previous step:
+
+        $ export SAN="DNS:www.others.io, DNS:*.others.io"
+
+6.  Sign the CSR with your intermediate CA. Either apply `server_cert` extension (for use on servers) or `usr_cert` extension (for user and client authentication). Give a year of validity plus few days as grace period if the requester don't yet renew. Use `intermediate.cnf` (for CSR without SAN) or `intermediate.san.cnf` (for CSR with SAN):
+
+        $ openssl ca -config config/intermediate.san.cnf -extensions server_cert -days 375 -notext -md sha256 -in csr/others.csr.pem -out certs/others.cert.pem
+
+    {{< output >}}
+Using configuration from config/intermediate.san.cnf
+Enter pass phrase for /home/linode-ca/ca/intermediate/private/linode-ca-intermediate.key.pem: phrase
+...
+Sign the certificate? [y/n]:y
+1 out of 1 certificate requests certified, commit? [y/n]y
+{{< /output >}}
+
+7.  **Verify** the newly-signed certificate by:
+
+        $ openssl x509 -noout -text -in cert/others.cert.pem
+
+    The output looks like:
+
+    {{< output >}}
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4096 (0x1000)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = PA, O = Linode, OU = Linode CA, CN = Linode Intermediate CA, emailAddress = ca@linode.com
+        Validity
+            Not Before: Nov 25 10:58:37 2019 GMT
+            Not After : Dec  4 10:58:37 2020 GMT
+        Subject: C = US, ST = CA, L = Stockton, O = Others, OU = Other Party, CN = others.io, emailAddress = contact@others.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                ...
+               Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            Netscape Cert Type:
+                SSL Server
+            Netscape Comment:
+                OpenSSL Generated Server Certificate
+            X509v3 Subject Key Identifier:
+                5D:5A:C5:62:2F:6D:C0:C5:CB:E2:8F:73:3C:BB:CA:16:5B:B2:F8:62
+            X509v3 Authority Key Identifier:
+                keyid:83:17:15:5E:8B:62:DE:BB:9E:EF:B1:A3:FF:D2:AA:7B:6D:1B:50:CF
+                DirName:/C=US/ST=PA/L=Philadelphia/O=Linode/OU=Linode CA/CN=Linode Root CA/emailAddress=ca@linode.com
+                serial:10:00
+
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage:
+                TLS Web Server Authentication
+            X509v3 Subject Alternative Name:
+                DNS:www.others.io, DNS:*.others.io
+    Signature Algorithm: sha256WithRSAEncryption
+        ...
+{{< /output >}}
+
+    Some points from the output above:
+
+    -  The `Issuer` refers to intermediate CA, and `Subject` refers to the entity listed in the CSR.
+
+    -  Depending whether you applied `server_cert` or `usr_cert` extension during signing the certificate, the corresponding entry options added are reflected in the output.
+
+    - `CA:FALSE` in `X509v3 Basic Constraints` entry indicated that the certificate cannot be used as CA, thus called *leaf certificate*.
+
+    - `X509v3 Subject Alternative Name` contains SAN entries which are valid for the certificate. Those should match with SAN from the CSR.
+
+8.  Also verify chain of trust. `OK` indicates that certificate trust is valid:
+
+        $ openssl verify -CAfile certs/linode-ca.chain.cert.pem
+
+    {{< output >}}
+certs/others.cert.pem: OK
+{{< /output >}}
+
+9.  Verify that `index.txt` database contain a line mentioning the certificate, similar to:
+
+    {{< file "~/ca/intermediate/index.txt" txt >}}
+V       201204105837Z           1000    unknown /C=US/ST=CA/L=Stockton/O=Others/OU=Other Party/CN=others.io/emailAddress=contact@others.io
+{{< /file >}}
+
+## Deploy Certificate
+
+Send the signed certificate and CA chain file back to the requester for deployment to server and client machines.
+
+When deploying certificate, also add CA file to key store of each systems, depending on the application:
+
+1.  To add into system-wide key store (for use by most applications):
+
+       **Debian & Ubuntu**:
+
+       1.  Place CA chain file (`linode-ca.chain.cert.pem`) into key store directory:
+
+            # cp /path/to/linode-ca.chain.cert.pem /usr/share/ca-certificates/linode-ca.crt
+
+       2.  Append to `ca-certificate.conf`:
+
+        {{< file "/etc/ca-certificate.conf" ini >}}
+...
+linode-ca.crt
+{{< /file >}}
+
+       3.  Update the key store:
+
+            # update-ca-certificates
+
+       **CentOS**:
+
+       1.  Place CA chain file into key store source directory:
+
+            # cp /path/to/linode-ca.chain.cert.pem /etc/pki/ca-trust/source/anchors
+
+       2.  Update the key store:
+
+            # update-ca-trust
+
+2.  If you have PHP applications, add certificate key store bundle that is updated from step 1 to PHP configuration:
+
+    {{< file "/etc/php.ini" ini >}}
+...
+openssl.cafile="/path/to/ca-certificates.crt"
+...
+{{< /file >}}
+
+3.  Browsers (such as Firefox and Chrome) use their own key store. Please refer to documentation of each browser for instructions to add the trusted CA.
+
+4.  For Java applications, refer to [Java documentation](https://docs.oracle.com/en/java/javase/11/tools/keytool.html) for using `keytool` to import CA certificates.
+
+## To be Continued
+
+From this guide, you had signed certificates using your CA, including certificates with Subject Alternative Name. Over time, you may noticed that the certificates you issued have been abused. Head to [Part 4](/docs/security/ssl/certificate-authority-openssl-crl/) for revoking certificates with Certificate Revoking Lists (CRL) or [Part 5](/docs/security/ssl/certificate-authority-openssl-ocsp/) for revoking with Online Certificate Status Protocol (OCSP).

--- a/docs/security/ssl/certificate-authority-openssl-signing-certificates/index.md
+++ b/docs/security/ssl/certificate-authority-openssl-signing-certificates/index.md
@@ -9,7 +9,7 @@ published: 2019-11-26
 contributor:
   name: Bagas Sanjaya
 description: 'Signing certificates with your CA.'
-keywords: ["ssl", "tls", "certificate authority", "ca"]
+keywords: ["ssl", "tls", "certificate authority", "signing certificates"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 title: 'Certificate Authority with OpenSSL - Part 3: Signing Certificates'
 external_resources:


### PR DESCRIPTION
This series is based on [Jamie Nguyen's guide](https://jamielinux.com/docs/openssl-certificate-authority/), but with modifications to include signing certificates with SAN and also `ocsp` edits.