### PR TITLE
Replace reference in dns-records guide to openspf.org which no longer exists

### DIFF
--- a/docs/networking/dns/dns-records-an-introduction/index.md
+++ b/docs/networking/dns/dns-records-an-introduction/index.md
@@ -219,7 +219,7 @@ In your SPF record, you should list all the mail servers from which you send mai
 If your Linode is the only mail server you use, you should be able to use the example record above. With this SPF record, the receiving server will check the IP addresses of both the sending server and the IP address of example.com. If the IPs match, the check passes. If not, the check will soft fail (i.e., the message will be marked but will not automatically be rejected for failing the SPF check).
 
 {{< note >}}
-Make sure your SPF records are not too strict. If you accidentally exclude a legitimate mail server, its messages could get marked as spam. We recommend visiting openspf.org to learn how SPF records work and how to construct one that works for your setup. Their [examples](http://www.openspf.org/FAQ/Examples) are also helpful.
+Make sure your SPF records are not too strict. If you accidentally exclude a legitimate mail server, its messages could get marked as spam. We recommend visiting [dmarcanalyzer.com](https://www.dmarcanalyzer.com/spf/how-to-create-an-spf-txt-record/) to learn how SPF records work and how to construct one that works for your setup
 {{< /note >}}
 
 ### SRV


### PR DESCRIPTION
I selected this link and found out that openspf.org has been dead since February 2019. In searching for something comparable that would serve a similar purpose, I found this page https://www.dmarcanalyzer.com/spf/how-to-create-an-spf-txt-record/. 

Though to be fair that page above belongs to a for-profit company, it may be a marketing decision if recommending a third-party tool such as this or mxtoolbox