### PR TITLE
Remove expiryDate from Icinga guides

### DIFF
--- a/docs/uptime/monitoring/install-icinga2-monitoring-on-debian-9/index.md
+++ b/docs/uptime/monitoring/install-icinga2-monitoring-on-debian-9/index.md
@@ -11,7 +11,6 @@ modified: 2017-12-12
 modified_by:
   name: Linode
 title: 'Install Icinga 2 Monitoring on Debian 9'
-expiryDate: 2019-12-12
 contributor:
   name: Matt Vass
   link: mailto:linuxboxgo@gmail.com

--- a/docs/uptime/monitoring/monitor-remote-hosts-with-icinga/index.md
+++ b/docs/uptime/monitoring/monitor-remote-hosts-with-icinga/index.md
@@ -11,7 +11,6 @@ modified: 2017-12-19
 modified_by:
   name: Linode
 title: 'Monitor Remote Hosts with Icinga'
-expiryDate: 2019-12-28
 contributor:
   name: Matt Vass
   link: mailto:linuxboxgo@gmail.com


### PR DESCRIPTION
These guides expired/were about to expire, and causing issues for other guides when attempting to run docs404. Removed expiryDate from both of them.