### PR TITLE
[Update] Troubleshooting Problems with Postfix, Dovecot, and MySQL: Remove Backslash on Disabling Plaintext Authentication

### DIFF
--- a/docs/email/postfix/troubleshooting-problems-with-postfix-dovecot-and-mysql/index.md
+++ b/docs/email/postfix/troubleshooting-problems-with-postfix-dovecot-and-mysql/index.md
@@ -734,7 +734,7 @@ ssl_key = </etc/ssl/private/dovecot.pem
 4.  Disable plain-text authentication. In `/etc/dovecot/conf.d/10-auth.conf`, set the following line:
 
     {{< file "/etc/dovecot/conf.d/10-auth.conf" >}}
-disable\_plaintext\_auth = yes
+disable_plaintext_auth = yes
 
 {{< /file >}}
 


### PR DESCRIPTION
This small PR remove backslash on `disable_plaintext_auth` option on `10-auth.conf` Dovecot conf.

This will close #2975 