### PR TITLE
[Update] How to Deploy Kubernetes on Linode with Rancher 2.3

### DIFF
--- a/docs/kubernetes/how-to-deploy-kubernetes-on-linode-with-rancher-2-x/index.md
+++ b/docs/kubernetes/how-to-deploy-kubernetes-on-linode-with-rancher-2-x/index.md
@@ -265,12 +265,12 @@ Review Rancher's [Production Ready Cluster](https://rancher.com/docs/rancher/v2.
       pod_security_policy: false
       service_node_port_range: "30000-32767"
       extra_args:
-        feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,CSINodeInfo=true,CSIDriverRegistry=true,BlockVolume=true,CSIBlockVolume=true"
+        feature-gates: "PersistentLocalVolumes=true,CSINodeInfo=true,CSIDriverRegistry=true,BlockVolume=true,CSIBlockVolume=true"
     kubelet:
       fail_swap_on: false
       extra_args:
         cloud-provider: "external"
-        feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,CSINodeInfo=true,CSIDriverRegistry=true,BlockVolume=true,CSIBlockVolume=true"
+        feature-gates: "PersistentLocalVolumes=true,CSINodeInfo=true,CSIDriverRegistry=true,BlockVolume=true,CSIBlockVolume=true"
     kube-controller:
       extra_args:
         cloud-provider: "external"


### PR DESCRIPTION
- Reproduced the issue reported in https://github.com/linode/docs/issues/2979
<img width="1349" alt="Screenshot 2019-12-21 at 11 12 36 AM" src="https://user-images.githubusercontent.com/37059749/71309192-1acc1f00-242b-11ea-9ae0-07ac8ef4ed67.png">
 - Removed VolumeScheduling=true from the services snippet in step 12 of "Provision a Cluster"
- Validated the GA in https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features