### PR TITLE
[Update] How to Keep Your Linode Account Safe

### DIFF
--- a/docs/platform/manager/keep-your-linode-account-safe-classic-manager/index.md
+++ b/docs/platform/manager/keep-your-linode-account-safe-classic-manager/index.md
@@ -154,7 +154,3 @@ This is useful for groups that need to grant all team members access to the Clas
 The [Linode API](https://www.linode.com/api/) is a programmatic interface for many of the features available in the Classic Manager. For this reason, the Classic Manager provides two security controls for your account's API key. First, you can generate a new API key if you suspect that your existing key has been compromised. And if you're not using the API key, you can remove access to it altogether.
 
 See the [API Key](/docs/platform/api/api-key/) article for details.
-
-### Force Password Expirations
-
-Your company's policy may require users to change their passwords after a fixed interval of time. The Classic Manager can be configured to require password resets every 1, 3, 6, or 12 months. For more information, see the documentation on [Passwords in the Classic Manager](/docs/platform/accounts-and-passwords/#passwords).

--- a/docs/security/linode-manager-security-controls/index.md
+++ b/docs/security/linode-manager-security-controls/index.md
@@ -251,7 +251,3 @@ If you've completed this guide, you've proactively taken steps to protect your L
 ### Configure User Accounts
 
 Organizations that have multiple individuals accessing the same Cloud Manager account should create separate *user accounts* for each individual. Once you've created the accounts, you can assign permissions to restrict access to certain areas of the control panel. This is useful for groups that need to grant all team members access to the Cloud Manager, or organizations that just want their billing department to have a separate account to receive invoices and billing information. For more information, see our guide on [Accounts and Passwords](/docs/platform/accounts-and-passwords).
-
-### Force Password Expirations
-
-Some organizations have policies that require users to change their passwords every so often. The Linode Cloud Manager can be configured to force users to change their passwords every 1, 3, 6, or 12 months.


### PR DESCRIPTION
- removed https://www.linode.com/docs/platform/manager/keep-your-linode-account-safe-classic-manager/#force-password-expirations and https://www.linode.com/docs/security/linode-manager-security-controls/#force-password-expirations- because it is a bad security practice and it is recommend to use a password manager or other users on the account.