### PR TITLE
[Update] Object Storage Cluster Definition

### DIFF
--- a/docs/platform/object-storage/host-static-site-object-storage/index.md
+++ b/docs/platform/object-storage/host-static-site-object-storage/index.md
@@ -241,6 +241,8 @@ Before proceeding with this section ensure that you have already created your Ob
 Buckets names must be unique within the Object Storage cluster. You might find the bucket name `my-bucket` is already in use by another Linode customer, in which case you will need to choose a new bucket name.
 {{</ note >}}
 
+    {{< content "object-storage-cluster-shortguide" >}}
+
 1. Initialize your Object Storage bucket as a website. You must tell your bucket which files to serve as the index page and the error page for your static site. This is done with the `--ws-index` and `--ws-error` options:
 
         s3cmd ws-create --ws-index=index.html --ws-error=404.html s3://my-bucket

--- a/docs/platform/object-storage/how-to-manage-objects-with-lifecycle-policies/index.md
+++ b/docs/platform/object-storage/how-to-manage-objects-with-lifecycle-policies/index.md
@@ -46,6 +46,8 @@ This guide will first describe [when policies are enforced](#when-policies-are-e
 
 Lifecycle policies are triggered starting at midnight of the Object Storage cluster's local time. This means that if you set a lifecycle policy of **one day**, the objects will be deleted **the midnight after they become 24 hours old**.
 
+{{< content "object-storage-cluster-shortguide" >}}
+
 For example, if an object is created at 5PM on January 1, it will reach 24 hours in age at 5PM on January 2. The policy will then be enforced on the object at 12AM on January 3.
 
 {{< note >}}

--- a/docs/platform/object-storage/how-to-use-object-storage-acls-and-bucket-policies/index.md
+++ b/docs/platform/object-storage/how-to-use-object-storage-acls-and-bucket-policies/index.md
@@ -71,6 +71,8 @@ ACL:       a0000000-000a-0000-0000-00d0ff0f0000: FULL_CONTROL
 
         curl other-users-bucket.us-east-1.linodeobjects.com
 
+    {{< content "object-storage-cluster-shortguide" >}}
+
 1. This will result in the following output:
 
         <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">

--- a/docs/platform/object-storage/how-to-use-object-storage/index.md
+++ b/docs/platform/object-storage/how-to-use-object-storage/index.md
@@ -135,6 +135,8 @@ Bucket labels need to be unique within the same cluster, including buckets on ot
 &nbsp;&nbsp;&nbsp;&bull;&nbsp;&nbsp;Cannot contain underscores (_), end with a dash (-) or period (.), have consecutive periods (.), or use dashes (-) adjacent to periods (.)
 {{< /note >}}
 
+    {{< content "object-storage-cluster-shortguide" >}}
+
 1.  Choose a cluster location for the bucket to reside in.
 
 1.  Click **Submit**. You are now ready to [upload objects to your bucket](#upload-objects-to-a-bucket).
@@ -259,6 +261,8 @@ Bucket labels need to be unique within the same cluster, including buckets on ot
 &nbsp;&nbsp;&nbsp;&bull;&nbsp;&nbsp;Must start with a lowercase letter or number</br>
 &nbsp;&nbsp;&nbsp;&bull;&nbsp;&nbsp;Cannot contain underscores (_), end with a dash (-) or period (.), have consecutive periods (.), or use dashes (-) adjacent to periods (.)
 {{< /note >}}
+
+{{< content "object-storage-cluster-shortguide" >}}
 
 To delete a bucket, issue the `rb` command:
 
@@ -415,6 +419,8 @@ Bucket labels need to be unique within the same cluster, including buckets on ot
 &nbsp;&nbsp;&nbsp;&bull;&nbsp;&nbsp;Cannot contain underscores (_), end with a dash (-) or period (.), have consecutive periods (.), or use dashes (-) adjacent to periods (.)
 {{< /note >}}
 
+{{< content "object-storage-cluster-shortguide" >}}
+
 To remove a bucket, you can use the `rb` command:
 
     s3cmd rb s3://my-example-bucket
@@ -561,6 +567,8 @@ Bucket labels need to be unique within the same cluster, including buckets on ot
 &nbsp;&nbsp;&nbsp;&bull;&nbsp;&nbsp;Must start with a lowercase letter or number</br>
 &nbsp;&nbsp;&nbsp;&bull;&nbsp;&nbsp;Cannot contain underscores (_), end with a dash (-) or period (.), have consecutive periods (.), or use dashes (-) adjacent to periods (.)
 {{< /note >}}
+
+    {{< content "object-storage-cluster-shortguide" >}}
 
 To delete the bucket using Cyberduck, right click on the bucket and select **Delete**.
 

--- a/docs/platform/object-storage/object-storage-cluster-shortguide/index.md
+++ b/docs/platform/object-storage/object-storage-cluster-shortguide/index.md
@@ -1,0 +1,19 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+description: 'Shortguide that displays the definition of object storage cluster.'
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+modified: 2020-01-10
+modified_by:
+  name: Heather Zoppetti
+published: 2020-01-10
+title: Object Storage Cluster Definiton
+keywords: []
+headless: true
+show_on_rss_feed: false
+---
+
+{{< note >}}
+A cluster is defined as all buckets hosted by a unique url. For example, `us-east-1.linodeobjects.com` or `us-east-2.linodeobjects.com`.
+{{</ note >}}

--- a/docs/platform/object-storage/pricing-and-limitations/index.md
+++ b/docs/platform/object-storage/pricing-and-limitations/index.md
@@ -33,6 +33,8 @@ For more information on enabling Object Storage, cancelling Object Storage, and 
 
 Currently, Object Storage accounts are limited to 50 terabytes of storage per cluster, or 50 million objects per cluster, whichever comes first. Separate clusters have separate limits, so it is possible to store 50 terabytes worth of objects in one cluster and 50 terabytes worth of objects in another.  In the future, individual clusters may have separate storage maximums, and this guide will be updated to include those limits. Accounts can have up to 1000 buckets per cluster.
 
+{{< content "object-storage-cluster-shortguide" >}}
+
 Individual object uploads are limited to a size of 5GB each, though larger object uploads can be facilitated with multipart uploads. [s3cmd](/docs/platform/object-storage/how-to-use-object-storage/#s3cmd) and [cyberduck](/docs/platform/object-storage/how-to-use-object-storage/#cyberduck) will do this for you automatically if a file exceeds this limit as part of the uploading process.
 
 {{< note >}}


### PR DESCRIPTION
added cluster definition short guide
Added short guide to the following guides:
- docs/platform/object-storage/host-static-site-object-storage
- docs/platform/object-storage/how-to-manage-objects-with-lifecycle-policies
- docs/platform/object-storage/how-to-use-object-storage-acls-and-bucket-policies
- docs/platform/object-storage/how-to-use-object-storage
- docs/platform/object-storage/pricing-and-limitations