### PR TITLE
[Update] How to Deploy Microservices with Docker

### DIFF
--- a/docs/applications/containers/deploying-microservices-with-docker/index.md
+++ b/docs/applications/containers/deploying-microservices-with-docker/index.md
@@ -30,7 +30,17 @@ This guide shows how to build and deploy an example microservice using Docker an
 
 ## Before You Begin
 
-You will need a Linode with Docker and Docker Compose installed to complete this guide.
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
+
+2.  Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) guide to create a standard user account, harden SSH access and remove unnecessary network services.
+
+3.  Update your system.
+
+        sudo apt-get update && sudo apt-get upgrade
+
+{{< note >}}
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
+{{< /note >}}
 
 ### Install Docker
 
@@ -234,7 +244,7 @@ def resetcounter():
     {{< file "web/requirements.txt" text >}}
 flask
 gunicorn
-psycopg2
+psycopg2-binary
 redis
 {{</ file >}}
 

--- a/docs/applications/containers/install-docker-compose/index.md
+++ b/docs/applications/containers/install-docker-compose/index.md
@@ -15,9 +15,9 @@ headless: true
 
 <!--- Installation instructions for Docker Compose -->
 
-1. Download the latest version of Docker Compose. Check the [releases](https://github.com/docker/compose/releases) page and replace `1.21.2` in the command below with the version tagged as **Latest release**:
+1. Download the latest version of Docker Compose. Check the [releases](https://github.com/docker/compose/releases) page and replace `1.25.1` in the command below with the version tagged as **Latest release**:
 
-        sudo curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+        sudo curl -L https://github.com/docker/compose/releases/download/1.25.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 
 2. Set file permissions:
 


### PR DESCRIPTION
- added the Before you begin section
- updated the version of Docker Compose (1.25.1) in the command and instructions to install
- updated the requirement.txt with psycopg2-binary as a fix for https://github.com/linode/docs/issues/2587