### PR TITLE
[Update]Getting Started with Kubernetes: Use kubeadm to Deploy a Cluster on Linode

### DIFF
--- a/docs/kubernetes/getting-started-with-kubernetes/index.md
+++ b/docs/kubernetes/getting-started-with-kubernetes/index.md
@@ -68,12 +68,12 @@ A Kubernetes cluster consists of a master node and worker nodes. The master node
 The following table provides a list of the Kubernetes tooling you will need to install on your master and worker nodes in order to meet the minimum requirements for a functioning Kubernetes cluster as described above.
 
 | Tool | Master Node | Worker Nodes |
- | --------- | :---------: | :----------: |
- | <abbr title="This tool provides a simple way to create a Kubernetes cluster by automating the tasks required to get a cluster up and running. New Kubernetes users with access to a cloud hosting provider, like Linode, can use kubeadm to build out a playground cluster. kubeadm is also used as a foundation to create more mature Kubernetes deployment tooling.">kubeadm</abbr>| x | x |
- | <abbr title="A container runtime is responsible for running the containers that make up a cluster's pods. This guide will use Docker as the container runtime.">Container Runtime</abbr> | x | x |
- | <abbr title="kubelet ensures that all pod containers running on a node are healthy and meet the specifications for a pod's desired behavior.">kubelet</abbr> | x | x |
- | <abbr title="A command line tool used to manage a Kubernetes cluster.">kubectl</abbr>| x | x |
- | <abbr title="The Control Plane is responsible for keeping a record of the state of a cluster, making decisions about the cluster, and pushing the cluster towards new desired states.">Control Plane</abbr>| x |  |
+| --------- | :---------: | :----------: |
+| <abbr title="This tool provides a simple way to create a Kubernetes cluster by automating the tasks required to get a cluster up and running. New Kubernetes users with access to a cloud hosting provider, like Linode, can use kubeadm to build out a playground cluster. kubeadm is also used as a foundation to create more mature Kubernetes deployment tooling.">kubeadm</abbr>| x | x |
+| <abbr title="A container runtime is responsible for running the containers that make up a cluster's pods. This guide will use Docker as the container runtime.">Container Runtime</abbr> | x | x |
+| <abbr title="kubelet ensures that all pod containers running on a node are healthy and meet the specifications for a pod's desired behavior.">kubelet</abbr> | x | x |
+| <abbr title="A command line tool used to manage a Kubernetes cluster.">kubectl</abbr>| x | x |
+| <abbr title="The Control Plane is responsible for keeping a record of the state of a cluster, making decisions about the cluster, and pushing the cluster towards new desired states.">Control Plane</abbr>| x |  |
 
  {{< note >}}
  A series of services that form Kubernetes master structure that allow it to control the cluster. The kubeadm tool allows the control plane services to run as containers on the master node. The control plane will be created when you initialize kubeadm later in this guide.

--- a/docs/kubernetes/getting-started-with-kubernetes/index.md
+++ b/docs/kubernetes/getting-started-with-kubernetes/index.md
@@ -76,7 +76,7 @@ The following table provides a list of the Kubernetes tooling you will need to i
  | <abbr title="The Control Plane is responsible for keeping a record of the state of a cluster, making decisions about the cluster, and pushing the cluster towards new desired states.">Control Plane</abbr>| x |  |
 
  {{< note >}}
- A series of services that form Kubernetes master structure that allow it to control the cluster. Kubeadm allows the control plane services to run as containers on the master node. The control plane will be created when you initialize kubeadm later in this guide.
+ A series of services that form Kubernetes master structure that allow it to control the cluster. The kubeadm tool allows the control plane services to run as containers on the master node. The control plane will be created when you initialize kubeadm later in this guide.
  {{< /note >}}
 
 ### Install the Container Runtime: Docker

--- a/docs/kubernetes/getting-started-with-kubernetes/index.md
+++ b/docs/kubernetes/getting-started-with-kubernetes/index.md
@@ -19,9 +19,7 @@ external_resources:
 - '[Kubernetes: Securing a Cluster](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/)'
 ---
 
-One of the cloud provider agnostic tool that automates many of the tasks required to get a cluster up and running is [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/). Users of kubeadm can run a few simple commands on individual servers to turn them into a Kubernetes cluster consisting of a master node and worker nodes.
-
-This guide will walk you through installing kubeadm and using it to deploy a Kubernetes cluster on Linode. While the kubeadm approach requires more manual steps than other Kubernetes cluster creation pathways offered by Linode, this solution will be covered as way to dive deeper into the various components that make up a Kubernetes cluster and the ways in which they interact with each other to provide a scalable and reliable container orchestration mechanism.
+You can use <abbr title="kubeadm is a cloud provider agnostic tool that automates many of the tasks required to get a cluster up and running.">kubeadm</abbr> to run a few simple commands on individual servers to turn them into a Kubernetes cluster consisting of a <abbr title="A separate server in a Kubernetes cluster responsible for maintaining the desired state of the cluster.">master node</abbr> and <abbr title="Worker nodes in a Kubernetes cluster are servers that run your applications’ Pods.">worker nodes</abbr>. This guide will walk you through installing kubeadm and using it to deploy a Kubernetes cluster on Linode. While the kubeadm approach requires more manual steps than other Kubernetes cluster creation pathways offered by Linode, this solution will be covered as way to dive deeper into the various components that make up a Kubernetes cluster and the ways in which they interact with each other to provide a scalable and reliable container orchestration mechanism.
 
 {{< note >}}
 This guide's example instructions will result in the creation of three billable Linodes. Information on how to tear down the Linodes are provided at the end of the guide. Interacting with the Linodes via the command line will provide the most opportunity for learning, however, this guide is written so that users can also benefit by reading along.
@@ -42,7 +40,7 @@ While kubeadm automates several cluster-provisioning tasks, there are other even
 1. Deploy three Linodes running Ubuntu 18.04 with the following system requirements:
 
     - One Linode to use as the master Node with 4GB RAM and 2 CPU cores.
-    - Two Linodes to use as the Worker Nodes each with 1GB RAM and 1 CPU core.
+    - Two Linodes to use as the worker Nodes each with 1GB RAM and 1 CPU core.
 
 1. Follow the [Getting Started](/docs/getting-started) and the [Securing Your Server](/docs/security/securing-your-server/) guides for instructions on setting up your Linodes. The steps in this guide assume the use of a limited user account with sudo privileges.
 
@@ -50,7 +48,7 @@ While kubeadm automates several cluster-provisioning tasks, there are other even
 When following the [Getting Started](/docs/getting-started) guide, make sure that each Linode is using a different hostname. Not following this guideline will leave you unable to join some or all nodes to the cluster in a later step.
 {{< /note >}}
 
-1. Disable swap memory on your Linodes. Kubernetes requires that you disable swap memory on any cluster nodes to prevent the Kubernetes scheduler (kube-scheduler) from ever sending a Pod to a node that has run out of CPU/memory or reached its designated CPU/memory limit.
+1. Disable swap memory on your Linodes. Kubernetes requires that you disable swap memory on any cluster nodes to prevent the <abbr title="The kube-scheduler is a function that looks for newly created Pods that have no nodes.">kube-scheduler</abbr> from assigning a Pod to a node that has run out of CPU/memory or reached its designated CPU/memory limit.
 
         sudo swapoff -a
 
@@ -65,21 +63,25 @@ When following the [Getting Started](/docs/getting-started) guide, make sure tha
 ## Build a Kubernetes Cluster
 ### Kubernetes Cluster Architecture
 
-A Kubernetes cluster consists of a master node and worker nodes. The master node hosts the *control plane*, which is the combination of all the components that provide it the ability to maintain the desired cluster state. This cluster state is defined by manifest files and the kubectl tool. While the control plane components can be run on any cluster node, it is a best practice to isolate the control plane on its own node and to run any application containers on a separate worker node. A cluster can have a single worker node or up to 5000. Each worker node must be able to maintain running containers in a Pod and be able to communicate with the master node's control plane.
+A Kubernetes cluster consists of a master node and worker nodes. The master node hosts the *control plane*, which is the combination of all the components that provide it the ability to maintain the desired cluster state. This cluster state is defined by manifest files and the <abbr title="kubectl is a command line tool used to interact with the Kubernetes cluster.">kubectl</abbr> tool. While the control plane components can be run on any cluster node, it is a best practice to isolate the control plane on its own node and to run any application containers on a separate worker node. A cluster can have a single worker node or up to 5000. Each worker node must be able to maintain running containers in a Pod and be able to communicate with the master node's control plane.
 
-The table below provides a list of the Kubernetes tooling you will need to install on your master and worker nodes in order to meet the minimum requirements for a functioning Kubernetes cluster as described above.
+The following table provides a list of the Kubernetes tooling you will need to install on your master and worker nodes in order to meet the minimum requirements for a functioning Kubernetes cluster as described above.
 
-| Tool | Description | Master Node | Worker Nodes |
-| --------- | ----------- | :---------: | :----------: |
-| **kubeadm** | This tool provides a simple way to create a Kubernetes cluster by automating the tasks required to get a cluster up and running. New Kubernetes users with access to a cloud hosting provider, like Linode, can use kubeadm to build out a playground cluster. kubeadm is also used as a foundation to create more mature Kubernetes deployment tooling. | x | x |
-| **Container Runtime** | A container runtime is responsible for running the containers that make up a cluster's Pods. This guide will use Docker as the container runtime. | x | x |
-| **kubelet** | kubelet ensures that all Pod containers running on a node are healthy and meet the specifications for a Pod's desired behavior. | x | x |
-| **kubectl** | A command line tool used to manage a Kubernetes cluster.  | x | x |
-| **Control Plane** | Series of services that form Kubernetes master structure that allow it to control the cluster. kubeadm allows the control plane services to run as containers on the master node. The control plane will be created when you initialize kubeadm later in this guide. | x |  |
+| Tool | Master Node | Worker Nodes |
+ | --------- | :---------: | :----------: |
+ | <abbr title="This tool provides a simple way to create a Kubernetes cluster by automating the tasks required to get a cluster up and running. New Kubernetes users with access to a cloud hosting provider, like Linode, can use kubeadm to build out a playground cluster. kubeadm is also used as a foundation to create more mature Kubernetes deployment tooling.">kubeadm</abbr>| x | x |
+ | <abbr title="A container runtime is responsible for running the containers that make up a cluster's pods. This guide will use Docker as the container runtime.">Container Runtime</abbr> | x | x |
+ | <abbr title="kubelet ensures that all pod containers running on a node are healthy and meet the specifications for a pod's desired behavior.">kubelet</abbr> | x | x |
+ | <abbr title="A command line tool used to manage a Kubernetes cluster.">kubectl</abbr>| x | x |
+ | <abbr title="The Control Plane is responsible for keeping a record of the state of a cluster, making decisions about the cluster, and pushing the cluster towards new desired states.">Control Plane</abbr>| x |  |
+
+ {{< note >}}
+ A series of services that form Kubernetes master structure that allow it to control the cluster. Kubeadm allows the control plane services to run as containers on the master node. The control plane will be created when you initialize kubeadm later in this guide.
+ {{< /note >}}
 
 ### Install the Container Runtime: Docker
 
-Docker is the software responsible for running the Pod containers on each node. You can use other container runtime software with Kubernetes, such as [Containerd](https://containerd.io/) and [CRI-O](https://cri-o.io/). You will need to install Docker on all three Linodes.
+Docker is the software responsible for running the Pods on each node. You can use other container runtime software with Kubernetes, such as [Containerd](https://containerd.io/) and [CRI-O](https://cri-o.io/). You will need to install Docker on all three Linodes.
 
 These steps install Docker Community Edition (CE) using the official Ubuntu repositories. To install on another distribution, see the official [installation page](https://docs.docker.com/install/).
 
@@ -129,7 +131,7 @@ After entering the `usermod` command, you will need to close your SSH session an
 
         sudo docker run hello-world
 
-1. Setup the Docker daemon to use [systemd](/docs/quick-answers/linux-essentials/what-is-systemd/) as the cgroup driver, instead of the default cgroupfs. This is a recommended step so that kubelet and Docker are both using the same cgroup manager. This will make it easier for Kubernetes to know which resources are available on your cluster's nodes.
+1. Setup the Docker daemon to use <abbr title="systemd is a Linux initialization system and service manager that includes features like on-demand starting of daemons, mount and automount point maintenance, snapshot support, and processes tracking using Linux control groups.">systemd </abbr> as the cgroup driver, instead of the default cgroupfs. This is a recommended step so that kubelet and Docker are both using the same cgroup manager. This will make it easier for Kubernetes to know which resources are available on your cluster's nodes.
 
         sudo bash -c 'cat > /etc/docker/daemon.json <<EOF
         {
@@ -185,7 +187,7 @@ Complete the steps outlined in this section on all three Linodes.
 
 After installing the Kubernetes related tooling on all your Linodes, you are ready to set up the Kubernetes control plane on the master node. The control plane is responsible for allocating resources to your cluster, maintaining the health of your cluster, and ensuring that it meets the minimum requirements you designate for the cluster.
 
-The primary components of the control plane are the kube-apiserver, kube-controller-manager, kube-scheduler, and etcd. kubeadm provides a way to easily initialize the Kubernetes master node with all the necessary control plane components. For more information on each of control plane component see the [Beginner's Guide to Kubernetes](/docs/kubernetes/beginners-guide-to-kubernetes/).
+The primary components of the control plane are the <abbr title="The kube-apiserver is the front end for the Kubernetes API server. Validates and configures data for Kubernetes’ API objects including Pods, Services, Deployments, and more.">kube-apiserver</abbr>, <abbr title="The kube-controller-manager is a daemon that manages the Kubernetes control loop. It watches the shared state of the cluster through the Kubernetes API server.">kube-controller-manager</abbr>, kube-scheduler, and etcd. You can easily initialize the Kubernetes master node with all the necessary control plane components using kubeadm. For more information on each of control plane component see the [Beginner's Guide to Kubernetes](/docs/kubernetes/beginners-guide-to-kubernetes/).
 
 In addition to the baseline control plane components, there are several *addons*, that can be installed on the master node to access additional cluster features. You will need to install a networking and network policy provider add on that will implement [Kubernetes' network model](https://kubernetes.io/docs/concepts/cluster-administration/networking/) on the cluster's Pod network.
 
@@ -347,4 +349,4 @@ Now that you have a Kubernetes cluster up and running, you can begin experimenti
 
 ## Tear Down Your Cluster
 
-If you are done experimenting with your Kubernetes Cluster, be sure to remove the Linodes you have running in order to avoid being further billed for them. See the [Removing Services](/docs/platform/billing-and-support/billing-and-payments/#removing-services) section of the [Billing and Payments](/docs/platform/billing-and-support/billing-and-payments/) guide.
+If you are done experimenting with your Kubernetes cluster, be sure to remove the Linodes you have running in order to avoid being further billed for them. See the [Removing Services](/docs/platform/billing-and-support/billing-and-payments/#removing-services) section of the [Billing and Payments](/docs/platform/billing-and-support/billing-and-payments/) guide.

--- a/docs/kubernetes/getting-started-with-kubernetes/index.md
+++ b/docs/kubernetes/getting-started-with-kubernetes/index.md
@@ -73,10 +73,10 @@ The following table provides a list of the Kubernetes tooling you will need to i
 | <abbr title="A container runtime is responsible for running the containers that make up a cluster's pods. This guide will use Docker as the container runtime.">Container Runtime</abbr> | x | x |
 | <abbr title="kubelet ensures that all pod containers running on a node are healthy and meet the specifications for a pod's desired behavior.">kubelet</abbr> | x | x |
 | <abbr title="A command line tool used to manage a Kubernetes cluster.">kubectl</abbr>| x | x |
-| <abbr title="The Control Plane is responsible for keeping a record of the state of a cluster, making decisions about the cluster, and pushing the cluster towards new desired states.">Control Plane</abbr>| x |  |
+| <abbr title="The control plane is responsible for keeping a record of the state of a cluster, making decisions about the cluster, and pushing the cluster towards new desired states.">Control Plane</abbr>| x |  |
 
  {{< note >}}
- A series of services that form Kubernetes master structure that allow it to control the cluster. The kubeadm tool allows the control plane services to run as containers on the master node. The control plane will be created when you initialize kubeadm later in this guide.
+ The control plane is a series of services that form Kubernetes master structure that allow it to control the cluster. The kubeadm tool allows the control plane services to run as containers on the master node. The control plane will be created when you initialize kubeadm later in this guide.
  {{< /note >}}
 
 ### Install the Container Runtime: Docker
@@ -187,7 +187,7 @@ Complete the steps outlined in this section on all three Linodes.
 
 After installing the Kubernetes related tooling on all your Linodes, you are ready to set up the Kubernetes control plane on the master node. The control plane is responsible for allocating resources to your cluster, maintaining the health of your cluster, and ensuring that it meets the minimum requirements you designate for the cluster.
 
-The primary components of the control plane are the <abbr title="The kube-apiserver is the front end for the Kubernetes API server. Validates and configures data for Kubernetes’ API objects including Pods, Services, Deployments, and more.">kube-apiserver</abbr>, <abbr title="The kube-controller-manager is a daemon that manages the Kubernetes control loop. It watches the shared state of the cluster through the Kubernetes API server.">kube-controller-manager</abbr>, kube-scheduler, and etcd. You can easily initialize the Kubernetes master node with all the necessary control plane components using kubeadm. For more information on each of control plane component see the [Beginner's Guide to Kubernetes](/docs/kubernetes/beginners-guide-to-kubernetes/).
+The primary components of the control plane are the <abbr title="The kube-apiserver is the front end for the Kubernetes API server. It validates and configures data for Kubernetes’ API objects including Pods, Services, Deployments, and more.">kube-apiserver</abbr>, <abbr title="The kube-controller-manager is a daemon that manages the Kubernetes control loop. It watches the shared state of the cluster through the Kubernetes API server.">kube-controller-manager</abbr>, kube-scheduler, and etcd. You can easily initialize the Kubernetes master node with all the necessary control plane components using kubeadm. For more information on each of control plane component see the [Beginner's Guide to Kubernetes](/docs/kubernetes/beginners-guide-to-kubernetes/).
 
 In addition to the baseline control plane components, there are several *addons*, that can be installed on the master node to access additional cluster features. You will need to install a networking and network policy provider add on that will implement [Kubernetes' network model](https://kubernetes.io/docs/concepts/cluster-administration/networking/) on the cluster's Pod network.
 


### PR DESCRIPTION
- added tool tips for first occurrences of Kubernetes and Linux terms
- fixed the table descriptions
- all references of pods changes to Pod
- maintained consistency in using kubeadm, kubectl, kube-scheduler, and other terms
- fixed the numbering issue in Before you begin section