### PR TITLE
[Update] How to Set Up a Streisand Gateway

### DIFF
--- a/docs/networking/vpn/set-up-a-streisand-gateway/index.md
+++ b/docs/networking/vpn/set-up-a-streisand-gateway/index.md
@@ -42,7 +42,7 @@ Streisand uses open-source platform [Ansible](https://www.ansible.com/) to autom
 
 4.  Click on **Add a Personal Access Token** and choose the access rights you want users authenticated with the new token to have.
 {{< note >}}
-Select **Read/Write** access when setting up a Streisand gateway because you will be creating a new Streisand Linode server.
+**Read/Write** access for Linodes and IPs is sufficient to set up a Streisand gateway because you will creating a new Streisand Linode server.
 {{< /note >}}
 
     ![Add a Personal Access Token](get-started-with-linode-api-new-token.png "Add a Personal Access Token")


### PR DESCRIPTION
 - updated the note to read as follows: Read/Write access for Linodes and IPs is sufficient to set up a Streisand gateway because you will creating a new Streisand Linode server.
- helpful for security in the event their token is compromised.
- Fixes https://github.com/linode/docs/issues/2959