### PR TITLE
[Hotfix] v0.31.1

### DIFF
--- a/docs/security/linode-manager-security-controls/index.md
+++ b/docs/security/linode-manager-security-controls/index.md
@@ -6,7 +6,7 @@ description: 'How to use two-factor authentication and other security controls i
 og_description: 'This guide describes the security features of the Linode Cloud Manager, including two-factor authentication, IP address whitelisting, API access controls, forced password expiration, and more.'
 keywords: ["two-factor authentication", "password", "security", "Linode Cloud Manager", "token"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['security/linode-manager-security-controls/','linode-manager-security/','security/linode-manager-security-controls-new-manager/','platform/manager/keep-your-linode-account-safe/' ]
+aliases: ['linode-manager-security/','security/linode-manager-security-controls-new-manager/','platform/manager/keep-your-linode-account-safe/']
 modified: 2019-01-08
 modified_by:
   name: Linode


### PR DESCRIPTION
[Update] Linode Cloud Manager Security Controls
Removing alias that is the same as the guide's directory path

Reported by Linode support:
This guide is currently redirecting to itself in an infinite loop:
https://www.linode.com/docs/security/linode-manager-security-controls/

I noticed that one of the aliases on the guide is `security/linode-manager-security-controls/`, which is the same as that guide's path. I logged into the production server and saw that Hugo had rendered a redirect page at that URL, instead of a normal page with content.

Proposed fix is to remove that alias. Some other weird things I noticed:
- The last time we touched this line in the file was ten months ago, and we didn't even add this problematic alias at that time: https://github.com/linode/docs/pull/2414/files
- The problem isn't appearing for me when running on the dev server on my Mac (Hugo version 0.52), nor does it appear in the Netlify preview from #2414 
- I  am pretty sure that this guide has worked for the last ten months, so I'm not sure why it came up now.