### PR TITLE
[New] Archetype for distribution installation guides

### DIFF
--- a/archetypes/content.md
+++ b/archetypes/content.md
@@ -9,6 +9,7 @@ published: {{ now.Format "2006-01-02" }}
 modified_by:
   name: Linode
 title: "{{ replace .TranslationBaseName "-" " " | title }}"
+h1_title:
 contributor:
   name: Your Name
   link: Github/Twitter Link

--- a/archetypes/distribution-install-guides/_index.md
+++ b/archetypes/distribution-install-guides/_index.md
@@ -1,0 +1,12 @@
+---
+author:
+  name: Linode
+  email: docs@linode.com
+description: "A text passage which will appear below the title of the section on the section's page."
+keywords: ["keyword1", "keyword2"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: {{ now.Format "2006-01-02" }}
+title: How to Install X
+show_in_lists: true
+---
+

--- a/archetypes/distribution-install-guides/how-to-install-x-on-centos/content.md
+++ b/archetypes/distribution-install-guides/how-to-install-x-on-centos/content.md
@@ -1,0 +1,50 @@
+---
+author:
+  name: Linode Community
+  email: docs@linode.com
+description: 'Two to three sentences describing your guide.'
+keywords: ['list','of','keywords','and key phrases']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: {{ now.Format "2006-01-02" }}
+modified_by:
+  name: Linode
+title: "How to Install x on CentOS 00.00"
+h1_title: "Install x on CentOS 00.00"
+contributor:
+  name: Your Name
+  link: Github/Twitter Link
+external_resources:
+- '[Link Title 1](http://www.example.com)'
+- '[Link Title 2](http://www.example.net)'
+---
+
+## Before You Begin
+
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
+
+2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services. Do **not** follow the Configure a Firewall section yet--this guide includes firewall rules specifically for an OpenVPN server.
+
+3.  Update your system:
+
+        sudo apt-get update && sudo apt-get upgrade
+
+<!-- Include one of the following notes if appropriate. --->
+
+{{< note >}}
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, see the [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
+{{< /note >}}
+
+{{< note >}}
+The steps in this guide require root privileges. Be sure to run the steps below as `root` or with the `sudo` prefix. For more information on privileges, see our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
+{{< /note >}}
+
+
+{{< caution >}}
+Highlight warnings that could adversely affect a user's system with the Caution style.
+{{< /caution >}}
+
+{{< file "/etc/hosts" aconf >}}
+192.0.2.0/24      # Sample IP addresses
+198.51.100.0/24
+203.0.113.0/24
+{{< /file >}}

--- a/archetypes/distribution-install-guides/how-to-install-x-on-debian/content.md
+++ b/archetypes/distribution-install-guides/how-to-install-x-on-debian/content.md
@@ -1,0 +1,50 @@
+---
+author:
+  name: Linode Community
+  email: docs@linode.com
+description: 'Two to three sentences describing your guide.'
+keywords: ['list','of','keywords','and key phrases']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: {{ now.Format "2006-01-02" }}
+modified_by:
+  name: Linode
+title: "How to Install x on Debian 00.00"
+h1_title: "Install x on Debian 00.00"
+contributor:
+  name: Your Name
+  link: Github/Twitter Link
+external_resources:
+- '[Link Title 1](http://www.example.com)'
+- '[Link Title 2](http://www.example.net)'
+---
+
+## Before You Begin
+
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
+
+2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services. Do **not** follow the Configure a Firewall section yet--this guide includes firewall rules specifically for an OpenVPN server.
+
+3.  Update your system:
+
+        sudo apt-get update && sudo apt-get upgrade
+
+<!-- Include one of the following notes if appropriate. --->
+
+{{< note >}}
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, see the [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
+{{< /note >}}
+
+{{< note >}}
+The steps in this guide require root privileges. Be sure to run the steps below as `root` or with the `sudo` prefix. For more information on privileges, see our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
+{{< /note >}}
+
+
+{{< caution >}}
+Highlight warnings that could adversely affect a user's system with the Caution style.
+{{< /caution >}}
+
+{{< file "/etc/hosts" aconf >}}
+192.0.2.0/24      # Sample IP addresses
+198.51.100.0/24
+203.0.113.0/24
+{{< /file >}}

--- a/archetypes/distribution-install-guides/how-to-install-x-on-ubuntu/content.md
+++ b/archetypes/distribution-install-guides/how-to-install-x-on-ubuntu/content.md
@@ -1,0 +1,50 @@
+---
+author:
+  name: Linode Community
+  email: docs@linode.com
+description: 'Two to three sentences describing your guide.'
+keywords: ['list','of','keywords','and key phrases']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: {{ now.Format "2006-01-02" }}
+modified_by:
+  name: Linode
+title: "How to Install x on Ubuntu 00.00"
+h1_title: "Install x on Ubuntu 00.00"
+contributor:
+  name: Your Name
+  link: Github/Twitter Link
+external_resources:
+- '[Link Title 1](http://www.example.com)'
+- '[Link Title 2](http://www.example.net)'
+---
+
+## Before You Begin
+
+1.  Familiarize yourself with our [Getting Started](/docs/getting-started/) guide and complete the steps for setting your Linode's hostname and timezone.
+
+2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server/) to create a standard user account, harden SSH access and remove unnecessary network services. Do **not** follow the Configure a Firewall section yet--this guide includes firewall rules specifically for an OpenVPN server.
+
+3.  Update your system:
+
+        sudo apt-get update && sudo apt-get upgrade
+
+<!-- Include one of the following notes if appropriate. --->
+
+{{< note >}}
+This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, see the [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
+{{< /note >}}
+
+{{< note >}}
+The steps in this guide require root privileges. Be sure to run the steps below as `root` or with the `sudo` prefix. For more information on privileges, see our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
+{{< /note >}}
+
+
+{{< caution >}}
+Highlight warnings that could adversely affect a user's system with the Caution style.
+{{< /caution >}}
+
+{{< file "/etc/hosts" aconf >}}
+192.0.2.0/24      # Sample IP addresses
+198.51.100.0/24
+203.0.113.0/24
+{{< /file >}}


### PR DESCRIPTION
* Creates new archetype `distribution-install-guides` that will create a parent content directory with three sub directories for CentOS, Ubuntu, and Debian. 
* Example:
  * Issue the following command to use this archetype (replace directory location with the directory of the new parent install section): `hugo new --kind distribution-install-guides applications/containers/how-to-install-docker`
* This command will create the following directories and files:
```
...
|── containers
        └── how-to-install-docker
                    |── _index.md
                    |── how-to-install-x-on-debian
                            └── content.md
                    |── how-to-install-x-on-ubuntu
                            └── content.md
                    |── how-to-install-x-on-centos
                            └── content.md
   
```