### PR TITLE
Updating "What is Longview?" guide

### DIFF
--- a/docs/platform/longview/what-is-longview/index.md
+++ b/docs/platform/longview/what-is-longview/index.md
@@ -134,7 +134,7 @@ It’s also possible to manually install Longview for CentOS, Debian, and Ubuntu
 
     > **CentOS**:
     >
->    Using the text editor of your choice, like [nano](https://www.linode.com/docs/quick-answers/linux/use-nano-to-edit-files-in-linux/), create a `.repo` file and copy the contents of the example file below. Replace `REV` in the repository URL with your CentOS version (e.g., 8). If unsure, you can find your CentOS version number with `cat /etc/redhat-release`.
+>    Using the text editor of your choice, like [nano](https://www.linode.com/docs/quick-answers/linux/use-nano-to-edit-files-in-linux/), create a `.repo` file and copy the contents of the example file below. Replace `REV` in the repository URL with your CentOS version (e.g., 7). If unsure, you can find your CentOS version number with `cat /etc/redhat-release`.
 >    {{< file "/etc/yum.repos.d/longview.repo" config >}}
 [longview]
 name=Longview Repo


### PR DESCRIPTION
CentOS 8 is not supported by Longview as mentioned in the note at the beginning of the doc. Changing the reference to CentOS 8 later in the doc to CentOS 7 to minimize customer confusion.