### PR TITLE
[Update] Add `og_description` to default front matter

### DIFF
--- a/archetypes/content.md
+++ b/archetypes/content.md
@@ -10,6 +10,7 @@ published: {{ now.Format "2006-01-02" }}
 modified_by:
   name: Linode
 title: "{{ replace .TranslationBaseName "-" " " | title }}"
+h1_title: "h1 title displayed in the guide."
 contributor:
   name: Your Name
   link: Github/Twitter Link

--- a/archetypes/content.md
+++ b/archetypes/content.md
@@ -3,6 +3,7 @@ author:
   name: Linode Community
   email: docs@linode.com
 description: 'Two to three sentences describing your guide.'
+og_description: 'Two to three sentences describing your guide when shared on social media.'
 keywords: ['list','of','keywords','and key phrases']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: {{ now.Format "2006-01-02" }}

--- a/archetypes/section.md
+++ b/archetypes/section.md
@@ -3,6 +3,7 @@ author:
   name: Linode
   email: docs@linode.com
 description: "A text passage which will appear below the title of the section on the section's page."
+og_description: 'Two to three sentences describing your guide when shared on social media.'
 keywords: ["keyword1", "keyword2"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: {{ now.Format "2006-01-02" }}


### PR DESCRIPTION
* `content.md` archetype should have `og_description` as default front matter.