### PR TITLE
[Update]Enacting Access Control Lists (ACLs) and Bucket Policies with Linode Object Storage

### DIFF
--- a/docs/platform/object-storage/how-to-use-object-storage-acls-and-bucket-policies/index.md
+++ b/docs/platform/object-storage/how-to-use-object-storage-acls-and-bucket-policies/index.md
@@ -33,7 +33,7 @@ In this guide you will learn:
 - You'll also need the [*canonical ID*](#retrieve-a-user-s-canonical-id) of every user you wish to grant additional permissions to.
 
 {{< note >}}
-Currently, you can create a new canonical ID, only by creating a completely new Linode account. A canonical ID is not assigned to a limited access user on an existing Linode account.
+Currently, you can only create a new canonical ID by creating a completely new Linode account. A canonical ID is not assigned to a limited access user on an existing Linode account.
 {{< /note >}}
 
 ### Retrieve a User's Canonical ID

--- a/docs/platform/object-storage/how-to-use-object-storage-acls-and-bucket-policies/index.md
+++ b/docs/platform/object-storage/how-to-use-object-storage-acls-and-bucket-policies/index.md
@@ -32,6 +32,10 @@ In this guide you will learn:
 
 - You'll also need the [*canonical ID*](#retrieve-a-user-s-canonical-id) of every user you wish to grant additional permissions to.
 
+{{< note >}}
+Currently, you can create a new canonical ID, only by creating a completely new Linode account. A canonical ID is not assigned to a limited access user on an existing Linode account.
+{{< /note >}}
+
 ### Retrieve a User's Canonical ID
 
 Follow these steps to determine the canonical ID of the Object Storage users you want to share with:


### PR DESCRIPTION
Added the following note:

Currently, you can create a new canonical ID, only by creating a completely new Linode account. A canonical ID is not assigned to a limited access user on an existing Linode account.