### PR TITLE
[Update] Unrestricted Email Note

### DIFF
--- a/docs/platform/manager/accounts-and-passwords/index.md
+++ b/docs/platform/manager/accounts-and-passwords/index.md
@@ -105,6 +105,10 @@ Linode uses the contact information on file in your account to notify and bill y
 
 Both the *Account & Billing* and *My Profile* pages have an email address field. The email addresses saved on these pages receive different notifications, as described in the following sections. If you are the only user, you should enter your email address on both webpages. If there are multiple users, verify that the primary account holder's email address is current on the *Account* webpage.
 
+{{< note >}}
+Only unrestricted users can receive threshold notification emails.
+{{</ note >}}
+
 ### Updating Contact Information
 
 Use the *Account & Billing* webpage to update the contact information for the Linode account. The email address saved on this webpage receives invoices, receipts, and credit card expiration warnings. Support tickets are *not* sent to this email address.

--- a/docs/platform/manager/what-are-the-cloud-manager-events-and-activity-feeds/index.md
+++ b/docs/platform/manager/what-are-the-cloud-manager-events-and-activity-feeds/index.md
@@ -41,6 +41,10 @@ Your account's [Events Page](https://cloud.linode.com/events) is a history, or a
 
 Email event notifications alert you when new events such as booting, shutting down, or updates to a Linode occur on your account. You can enable or disable email event notifications using the Cloud Manager.
 
+{{< note >}}
+Only unrestricted users can receive threshold notification emails.
+{{</ note >}}
+
 1. Click on your user icon at the top-right hand corner of the Cloud Manager and select [**My Profile**](https://cloud.linode.com/profile/display).
 
 1. Select the **Settings** tab. Under the **Notifications** section, toggle the **Email Alerts** button to your desired setting.


### PR DESCRIPTION
added note that only unrestricted users can receive threshold notification emails on these two guides:

- /platform/manager/accounts-and-passwords
- /platform/manager/what-are-the-cloud-manager-events-and-activity-feeds