### PR TITLE
Updating Guide to reflect IP sharing Limitation

### DIFF
--- a/docs/platform/manager/remote-access/index.md
+++ b/docs/platform/manager/remote-access/index.md
@@ -72,7 +72,7 @@ The reverse DNS will be reset.
 ## Configuring IP Sharing
 
 {{< note >}}
-This feature is not yet supported in the Toronto data center.
+This feature is not yet supported in the Toronto or Sydney data centers.
 {{</ note >}}
 
 *IP sharing*, called IP failover in the Classic Manager, is the process by which an IP address is reassigned from one Linode to another in the event the first one fails or goes down. If you're using two Linodes to make a website [highly available](/docs/websites/introduction-to-high-availability/) with Keepalived or a similar service, you can use the Linode Manager to configure IP failover. Here's how:


### PR DESCRIPTION
IP sharing is not available in Sydney at this time.