### PR TITLE
[Update] Drush _index.md

### DIFF
--- a/docs/websites/cms/drupal/drush-drupal/_index.md
+++ b/docs/websites/cms/drupal/drush-drupal/_index.md
@@ -10,5 +10,6 @@ modified: 2014-11-21
 modified_by:
     name: Linode
 published: 2014-11-21
+show_in_lists: true
 title: Drush
 ---


### PR DESCRIPTION
The Drush section wasnt showing up in the Drupal section page,
because show_in_lists wasnt set on the Drupal section _index.md.
This adds that frontmatter.