### PR TITLE
Remove LKE Beta notice from guides

### DIFF
--- a/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/index.md
+++ b/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/index.md
@@ -18,11 +18,6 @@ external_resources:
  - '[Overview of kubectl](https://kubernetes.io/docs/reference/kubectl/overview/)'
 aliases: ['applications/containers/kubernetes/how-to-deploy-a-cluster-with-lke/','applications/containers/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/']
 ---
-{{< note >}}
-Linode Kubernetes Engine (LKE) is currently in Private Beta, and you may not have access to LKE through the Cloud Manager or other tools. To request access to the Private Beta, [sign up here](https://welcome.linode.com/lkebeta/). Beta access awards you $100/month in free credits for the duration of the beta, which is automatically applied to your account when an LKE cluster is in use. Additionally, you will have access to the `Linode Green Light` community, a new program connecting beta users with our product and engineering teams.
-
-Additionally, because LKE is in Beta, there may be breaking changes to how you access and manage LKE. This guide will be updated to reflect these changes if and when they occur.
-{{< /note >}}
 
 ## What is the Linode Kubernetes Engine (LKE)
 The Linode Kubernetes Engine (LKE) is a fully-managed container orchestration engine for deploying and managing containerized applications and workloads. LKE combines Linode’s ease of use and [simple pricing](https://www.linode.com/pricing/) with the infrastructure efficiency of Kubernetes. When you deploy an LKE cluster, you receive a Kubernetes Master at no additional cost; you only pay for the Linodes (worker nodes), [NodeBalancers](/docs/platform/nodebalancer/getting-started-with-nodebalancers/) (load balancers), and [Block Storage Volumes](/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/). Your LKE cluster’s Master node runs the Kubernetes control plane processes – including the API, scheduler, and resource controllers.

--- a/docs/kubernetes/deploy-and-manage-lke-cluster-with-api-a-tutorial/index.md
+++ b/docs/kubernetes/deploy-and-manage-lke-cluster-with-api-a-tutorial/index.md
@@ -16,12 +16,6 @@ contributor:
 aliases: ['applications/containers/kubernetes/deploy-and-manage-lke-cluster-with-api-a-tutorial/']
 ---
 
-{{< note >}}
-Linode Kubernetes Engine (LKE) is currently in Private Beta, and you may not have access to LKE through the Cloud Manager or other tools. To request access to the Private Beta, [sign up here](https://welcome.linode.com/lkebeta/). Beta access awards you $100/month in free credits for the duration of the beta, which is automatically applied to your account when an LKE cluster is in use. Additionally, you will have access to the `Linode Green Light` community, a new program connecting beta users with our product and engineering teams.
-
-Additionally, because LKE is in Beta, there may be breaking changes to how you access and manage LKE. This guide will be updated to reflect these changes if and when they occur.
-{{< /note >}}
-
 ## What is the Linode Kubernetes Engine (LKE)?
 
 The Linode Kubernetes Engine (LKE) is a fully-managed container orchestration engine for deploying and managing containerized applications and workloads. LKE combines Linode’s ease of use and [simple pricing](/docs/platform/billing-and-support/billing-and-payments/#linode-cloud-hosting-and-backups) with the infrastructure efficiency of Kubernetes. When you deploy a LKE cluster, you receive a Kubernetes Master at no additional cost; you only pay for the Linodes (worker nodes), [NodeBalancers](/docs/platform/nodebalancer/getting-started-with-nodebalancers/) (load balancers), and [Block Storage Volumes](/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/). Your LKE Cluster's Master node runs the Kubernetes control plane processes – including the API, scheduler, and resource controllers.

--- a/docs/kubernetes/getting-started-with-kubernetes/index.md
+++ b/docs/kubernetes/getting-started-with-kubernetes/index.md
@@ -29,7 +29,7 @@ This guide's example instructions will result in the creation of three billable 
 
 While kubeadm automates several cluster-provisioning tasks, there are other even faster methods for creating a cluster, all of which are great options for production ready deployments:
 
-- The [Linode Kubernetes Engine](https://www.linode.com/products/kubernetes/), currently in beta, allows you to spin up a Kubernetes cluster from the [Cloud Manager](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/) or the [Linode API](/docs/kubernetes/deploy-and-manage-lke-cluster-with-api-a-tutorial/), and Linode will handle the management and maintenance of your control plane. To register for the beta, [please complete our signup form](https://welcome.linode.com/lkebeta/).
+- The [Linode Kubernetes Engine](https://www.linode.com/products/kubernetes/), allows you to spin up a Kubernetes cluster from the [Cloud Manager](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/) or the [Linode API](/docs/kubernetes/deploy-and-manage-lke-cluster-with-api-a-tutorial/), and Linode will handle the management and maintenance of your control plane.
 
 - If you prefer a full featured GUI, [Linode's Rancher integration](/docs/kubernetes/how-to-deploy-kubernetes-on-linode-with-rancher-2-x/) enables you to deploy and manage Kubernetes clusters with a simple web interface.
 

--- a/docs/kubernetes/how-to-deploy-a-static-site-on-linode-kubernetes-engine/index.md
+++ b/docs/kubernetes/how-to-deploy-a-static-site-on-linode-kubernetes-engine/index.md
@@ -18,12 +18,6 @@ external_resources:
 aliases: ['applications/containers/kubernetes/static-site-linode-kubernetes-engine/','applications/containers/kubernetes/how-to-deploy-a-static-site-on-linode-kubernetes-engine/']
 ---
 
-{{< note >}}
-Linode Kubernetes Engine (LKE) is currently in Private Beta, and you may not have access to LKE through the Cloud Manager or other tools. To request access to the Private Beta, [sign up here](https://welcome.linode.com/lkebeta/). Beta access awards you $100/month in free credits for the duration of the beta, which is automatically applied to your account when an LKE cluster is in use. Additionally, you will have access to the `Linode Green Light` community, a new program connecting beta users with our product and engineering teams.
-
-Because LKE is in Beta, there may be breaking changes to how you access and manage LKE. This guide will be updated to reflect these changes if and when they occur.
-{{< /note >}}
-
 *Linode Kubernetes Engine (LKE)* allows you to easily create, scale, and manage Kubernetes clusters to meet your application's demands, reducing the often complicated cluster set-up process to just a few clicks. Linode manages your Kubernetes master node, and you select how many Linodes you want to add as worker nodes to your cluster.
 
 Deploying a static site using an LKE cluster is a great example to follow when learning Kubernetes. A [container](/docs/kubernetes/kubernetes-reference/#container) image for a static site can be written in less than ten lines, and only one container image is needed, so it's less complicated to deploy a static site on Kubernetes than some other applications that require multiple components.

--- a/docs/kubernetes/how-to-install-apps-on-kubernetes-with-helm-3/index.md
+++ b/docs/kubernetes/how-to-install-apps-on-kubernetes-with-helm-3/index.md
@@ -96,10 +96,6 @@ The Helm client software issues commands to your cluster. You run the client sof
 
 ## Before You Begin
 
-{{< note >}}
-The Linode Kubernetes Engine (LKE) is now in Private Beta. If you are in the beta, you can use LKE to stand up your Kubernetes cluster if you wish. Sign up for the beta [here](https://welcome.linode.com/lkebeta/).
-{{</ note >}}
-
 1.   [Install the Kubernetes CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (`kubectl`) on your computer, if it is not already.
 
 1.   You should have a Kubernetes cluster running prior to starting this guide. One quick way to get a cluster up is with Linode's [`k8s-alpha` CLI command](https://developers.linode.com/kubernetes/). This guide's examples only require a cluster with one worker node. We recommend that you create cluster nodes that are at the Linode 4GB tier (g6-standard-2) or higher.


### PR DESCRIPTION
Remove LKE Beta notice from the LKE guides:

- Deploy a Static Site on Linode Kubernetes Engine
- A Tutorial for Deploying and Managing a Cluster with Linode Kubernetes Engine and the Linode API
- A Tutorial for Deploying and Managing a Cluster with Linode Kubernetes Engine
- Getting Started with Kubernetes
- How to Install Apps on Kubernetes with Helm 3