### PR TITLE
Remove incorrect information about chgrp command

### DIFF
--- a/docs/tools-reference/linux-users-and-groups/index.md
+++ b/docs/tools-reference/linux-users-and-groups/index.md
@@ -153,9 +153,7 @@ Linux uses groups as a way to organize users. Groups organize collections of acc
 
     $ newgrp <marketing>
 
-If the user entering the above-referenced command is a member of the **marketing** group in the `/etc/group` file, then the current group membership will change. It is important to note that any files created will now be associated with the **marketing** group rather than the user's primary group. Users may also change their group by using the `chgrp` command. The syntax for the chgrp command is as follows:
-
-    $ chgrp <newgroup>
+If the user entering the above-referenced command is a member of the **marketing** group in the `/etc/group` file, then the current group membership will change. It is important to note that any files created will now be associated with the **marketing** group rather than the user's primary group.
 
 ### Creating and Removing Directories
 


### PR DESCRIPTION
The article says that the `chgrp` command functions in the same way as the `newgrp` command; that is, it is used to change a user's current group.

This is incorrect. `chgrp` is used to change the group ownership of an existing file, in the way that `chown` or `chmod` are used. Running the `chgrp` command as shown in the example in the article, without a file or directory argument to change the ownership of, results in an error:

    $ chgrp web
    chgrp: missing operand after ‘web’
    Try 'chgrp --help' for more information.

The man page for `chgrp` confirms this:

```
CHGRP(1)                           User Commands                          CHGRP(1)
NAME
       chgrp - change group ownership

SYNOPSIS
       chgrp [OPTION]... GROUP FILE...
       chgrp [OPTION]... --reference=RFILE FILE...

DESCRIPTION
       Change the group of each FILE to GROUP.  With --reference, change the group of
       each FILE to that of RFILE.
```