### PR TITLE
[Update] Upgrade to the New Linode API

### DIFF
--- a/docs/platform/api/upgrade-to-linode-api-v4/index.md
+++ b/docs/platform/api/upgrade-to-linode-api-v4/index.md
@@ -9,6 +9,8 @@ modified: 2018-05-14
 modified_by:
   name: Linode
 title: 'Upgrade to the New Linode API'
+deprecated: true
+deprecated_link: 'platform/api/getting-started-with-the-linode-api/'
 published: 2018-05-14
 external_resources:
  - '[Linode API Documentation](https://developers.linode.com)'


### PR DESCRIPTION
* Deprecate: Upgrade to the New Linode API
* Linode API v3 has been deprecated. Guide now links to Getting Started with the Linode API (v4).