### PR TITLE
Fix bad ingress.tls docs / values

### DIFF
--- a/docs/kubernetes/how-to-setup-a-private-docker-registry-with-lke-and-object-storage/index.md
+++ b/docs/kubernetes/how-to-setup-a-private-docker-registry-with-lke-and-object-storage/index.md
@@ -308,7 +308,7 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "6000"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
   tls:
-    - secretName: docker-registry-prod
+    - secretName: letsencrypt-secret-prod
       hosts:
       - registry.example.com
 storage: s3

--- a/docs/kubernetes/how-to-setup-a-private-docker-registry-with-lke-and-object-storage/index.md
+++ b/docs/kubernetes/how-to-setup-a-private-docker-registry-with-lke-and-object-storage/index.md
@@ -290,8 +290,8 @@ If you have not yet [generated an Object Storage key pair](/docs/platform/object
 
 1. Create a new file named `docker-configs.yaml` using the example configurations. Ensure you replace the following values in your file:
       - `ingress.hosts` with your own Docker registry's domain
-      - `ingress.tls.secretName` with the secret name you used when [creating your ClusterIssuer](#create-a-clusterissuer-resource)
-      - `ingress.tls.secretName.hosts` with the domain for which you wish to secure with your TLS certificate.
+      - `ingress.tls.secretName` with the name you used when [creating your Certificate](#create-a-certificate-resource)
+      - `ingress.tls.hosts` with the domain for which you wish to secure with your TLS certificate.
       - `secrets.s3.accessKey` with the value of your [Object Storage account's access key](/docs/platform/object-storage/how-to-use-object-storage/#object-storage-key-pair) and `secrets.s3.secretKey` with the corresponding secret key.
       - `secrets.htpasswd` with the value returned when you view the contents of your `my_docker_pass` file. However, ensure you do not remove the `|-` characters. This ensures that your YAML is properly formatted. See step 4 in the [Enable Basic Authentication](#enable-basic-authentication) section for details on viewing the contents of your password file.
       - `s3.region` with your Object Storage bucket's cluster region, `s3.regionEndpoint` with your Object Storage bucket's region endpoint, and `s3.bucket` with your registry's Object Storage bucket name.
@@ -308,7 +308,7 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "6000"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
   tls:
-    - secretName: letsencrypt-secret-prod
+    - secretName: docker-registry-prod
       hosts:
       - registry.example.com
 storage: s3


### PR DESCRIPTION
1. `hosts` is not a subkey of `secretName`.
2. `secretName` should be the name of the associated certificate, not the name of the issuer secret