### PR TITLE
Make "volumes per linode" stand out more.

### DIFF
--- a/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/index.md
+++ b/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/index.md
@@ -13,7 +13,7 @@ aliases: ['platform/block-storage/how-to-use-block-storage-with-your-linode-new-
 title: How to Use Block Storage with Your Linode
 ---
 
-Linode’s Block Storage service allows you to attach additional storage Volumes to your Linode. A single Volume can range from 10 GiB to 10,000 GiB in size and costs $0.10/GiB per month. They can be partitioned however you like and can accommodate any filesystem type you choose. Up to eight Volumes can be attached to a single Linode, be it new or already existing, so you do not need to recreate your server to add a Block Storage Volume.
+Linode’s Block Storage service allows you to attach additional storage Volumes to your Linode. A single Volume can range from 10 GiB to 10,000 GiB in size and costs $0.10/GiB per month. They can be partitioned however you like and can accommodate any filesystem type you choose. You can attach up to 8 volumes per Linode. The volumes can be newly created or already existing, so you do not need to recreate your server to add a Block Storage Volume.
 
 The Block Storage service is currently available in the Dallas, Fremont, Frankfurt, London, Newark, Tokyo, Toronto, Mumbai, and Singapore data centers.
 


### PR DESCRIPTION
When doing capacity planning, it is common to ask: what is the maximum number of volumes I can have per Linode?

I have edited the text slightly to include the words "volumes per linode" so that finding this article via a Google search becomes easier. I also think this information should be on the main page about block storage here: https://www.linode.com/products/block-storage/