### PR TITLE
[Update] Kubernetes Reference Guide

### DIFF
--- a/docs/kubernetes-shortguide-definitions/calico-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/calico-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Calico
+### Calico
 
 [Calico](https://docs.projectcalico.org/v3.8/introduction/) is an implementation of Kubernetes' networking model, and it served as the original reference for the Kubernetes [NetworkPolicy API](https://kubernetes.io/docs/concepts/services-networking/network-policies/) during its development. Calico also provides advanced policy enforcement capabilities that extend beyond Kubernetes' NetworkPolicy API, and these can be used by administrators alongside that API. Calico uses BGP to distribute routes for Kubernetes Pods, without the need for overlays.

--- a/docs/kubernetes-shortguide-definitions/cluster-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/cluster-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Cluster
+### Cluster
 
 A group of servers containing at least one master node and one or more worker nodes.

--- a/docs/kubernetes-shortguide-definitions/container-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/container-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Container
+### Container
 
 Similar to virtual machines, containers are isolated runtimes that you can run your applications and services inside. Containers consume fewer resources than virtual machines, as they do not attempt to emulate a full operating system running on dedicated hardware. Instead, containers only bundle the files, environment variables, and libraries needed by the applications they run, and they share the other resources of the operating system that hosts them.

--- a/docs/kubernetes-shortguide-definitions/containerization-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/containerization-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Containerization
+### Containerization
 
 Containerization is a software architecture practice that organizes applications and their dependencies in containers. Containerizing an application requires a base image that can be used to create an instance of a container. Once an application’s image exists, you can push it to a centralized container registry. Docker, Kubernetes, and other orchestration tools can download images from a registry to deploy container instances.

--- a/docs/kubernetes-shortguide-definitions/control-plane-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/control-plane-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Control Plane
+### Control Plane
 
 kube-apiserver, kube-controller-manager, kube-scheduler, and etcd form what is known as the [Control Plane](https://kubernetes.io/docs/concepts/#kubernetes-control-plane) of a Kubernetes cluster. The Control Plane is responsible for keeping a record of the state of a cluster, making decisions about the cluster, and pushing the cluster towards new desired states.

--- a/docs/kubernetes-shortguide-definitions/controller-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/controller-definition-shortguide/index.md
@@ -13,7 +13,7 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Controller
+### Controller
 
 A Kubernetes Controller is a control loop that continuously watches the Kubernetes API and tries to manage the desired state of certain aspects of the cluster. Examples of different Controllers include:
 

--- a/docs/kubernetes-shortguide-definitions/csi-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/csi-definition-shortguide/index.md
@@ -13,7 +13,7 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Container Storage Interface
+### Container Storage Interface
 
 The [Container Storage Interface (CSI) specification](https://github.com/container-storage-interface/spec/blob/master/spec.md) provides a common storage interface for container orchestrators like Kubernetes (and others, like Mesos). The interface is used by an orchestrator to attach storage volumes to containers and to manage the lifecycle of those volumes.
 

--- a/docs/kubernetes-shortguide-definitions/deployment-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/deployment-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Deployment
+### Deployment
 
 A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) can manage a ReplicaSet, so it shares the ability to keep a defined number of replica Pods up and running. A Deployment can also update those Pods to resemble the desired state by means of rolling updates. For example, if you wanted to update a container image to a newer version, you would create a Deployment, and the Controller would update the container images one by one until the desired state is achieved. This ensures that there is no downtime when updating or altering your Pods.

--- a/docs/kubernetes-shortguide-definitions/docker-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/docker-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Docker
+### Docker
 
 [Docker](https://www.docker.com/) is a tool that allows quick deployment of apps in containers using operating system level virtualization. While Kubernetes supports several container runtimes, Docker is a very popular option.

--- a/docs/kubernetes-shortguide-definitions/docker-hub-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/docker-hub-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Docker Hub
+### Docker Hub
 
 [Docker Hub](https://hub.docker.com/) is a centralized container image registry that can host your images and make them available for sharing and deployment. You can also find and use official Docker images and vendor specific images. When combined with a remote version control service, like GitHub, Docker Hub can automate the build process for images and can trigger actions for further automation with other services and tooling.

--- a/docs/kubernetes-shortguide-definitions/dockerfile-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/dockerfile-definition-shortguide/index.md
@@ -13,7 +13,7 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Dockerfile
+### Dockerfile
 
 A [Dockerfile](https://docs.docker.com/engine/reference/builder/) contains all commands, in their required order of execution, needed to build a given Docker image. For example, a Dockerfile might contain instructions for:
 

--- a/docs/kubernetes-shortguide-definitions/etcd-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/etcd-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## etcd
+### etcd
 
 [etcd](https://kubernetes.io/docs/concepts/overview/components/#etcd) is a highly available key-value store that provides the backend database for Kubernetes.

--- a/docs/kubernetes-shortguide-definitions/flannel-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/flannel-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Flannel
+### Flannel
 
 [Flannel](https://github.com/coreos/flannel#flannel) is a networking overlay that meets the functionality of the Kubernetes. Flannel supplies a layer 3 network fabric and is relatively easy to set up.

--- a/docs/kubernetes-shortguide-definitions/helm-charts-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/helm-charts-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Helm Charts
+### Helm Charts
 
 The software packaging format for Helm. A [Helm chart](https://helm.sh/docs/topics/charts/) specifies a file and directory structure for packaging your Kubernetes manifests.

--- a/docs/kubernetes-shortguide-definitions/helm-client-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/helm-client-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Helm Client
+### Helm Client
 
 The Helm client software issues commands to your cluster that can install new applications, upgrade them, and delete them. You run the client software on your computer, in your CI/CD environment, or anywhere else you’d like.

--- a/docs/kubernetes-shortguide-definitions/helm-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/helm-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Helm
+### Helm
 
 [Helm](https://helm.sh) is a tool that assists with installing and managing applications on Kubernetes clusters. It is often referred to as “the package manager for Kubernetes,” and it provides functions that are similar to a package manager for an operating system.

--- a/docs/kubernetes-shortguide-definitions/helm-tiller-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/helm-tiller-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Helm Tiller
+### Helm Tiller
 
 A server component that runs on your cluster and receives commands from the Helm client software before its deprecation in [Helm 3](https://helm.sh/docs/faq/#removal-of-tiller). [Tiller](https://v2.helm.sh/docs/glossary/#tiller) has been removed in Helm 3. Tiller is responsible for directly interacting with the Kubernetes API (which the client software does not do). Tiller maintains the state for your Helm releases.

--- a/docs/kubernetes-shortguide-definitions/job-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/job-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Job
+### Job
 
 A [Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) is a Controller which manages Pods created for a single or a set of tasks. This is handy if you need to create a Pod that performs a single function, or calculates a value. The deletion of the Job will delete the Pod.

--- a/docs/kubernetes-shortguide-definitions/kube-apiserver-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kube-apiserver-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## kube-apiserver
+### kube-apiserver
 
 The [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) is the front end for the Kubernetes API server. Validates and configures data for Kubernetes' API objects including Pods, Services, Deployments, and more.

--- a/docs/kubernetes-shortguide-definitions/kube-controller-manager-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kube-controller-manager-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## kube-controller-manager
+### kube-controller-manager
 
 The [kube-controller-manager](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/) is a daemon that manages the Kubernetes control loop. It watches the shared state of the cluster through the Kubernetes API server.

--- a/docs/kubernetes-shortguide-definitions/kube-proxy-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kube-proxy-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## kube-proxy
+### kube-proxy
 
 The [kube-proxy](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) is a networking proxy that proxies the UDP, TCP, and SCTP networking of each node, and provides load balancing. This is only used to connect to Services.

--- a/docs/kubernetes-shortguide-definitions/kube-scheduler-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kube-scheduler-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## kube-scheduler
+### kube-scheduler
 
 The [kube-scheduler](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/) is a function that looks for newly created Pods that have no nodes. kube-scheduler assigns Pods to a nodes based on a host of requirements.

--- a/docs/kubernetes-shortguide-definitions/kubeadm-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kubeadm-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## kubeadm
+### kubeadm
 
 [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/) is a cloud provider-agnostic tool that automates many of the tasks required to get a cluster up and running. Users of kubeadm can run a few simple commands on individual servers to turn them into a Kubernetes cluster consisting of a master node and worker nodes.

--- a/docs/kubernetes-shortguide-definitions/kubectl-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kubectl-definition-shortguide/index.md
@@ -13,7 +13,7 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## kubectl
+### kubectl
 
 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) is a command line tool used to interact with the Kubernetes cluster. It offers a host of features, including:
 

--- a/docs/kubernetes-shortguide-definitions/kubelet-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kubelet-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## kubelet
+### kubelet
 
 [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) is an agent that receives descriptions of the desired state of a Pod from the API server and ensures the Pod is healthy and running on its node.

--- a/docs/kubernetes-shortguide-definitions/kubernetes-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kubernetes-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Kubernetes
+### Kubernetes
 
 [Kubernetes](https://kubernetes.io), often referred to as "k8s", is an open source container orchestration system that helps deploy and manage containerized applications. Developed by Google starting in 2014 and written in the Go language, Kubernetes is quickly becoming the standard way to architect horizontally-scalable applications.

--- a/docs/kubernetes-shortguide-definitions/kubernetes-manifests-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/kubernetes-manifests-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Kubernetes Manifests
+### Kubernetes Manifests
 
 Files, often written in YAML, used to create, modify, and delete Kubernetes resources such as Pods, Deployments, and Services.

--- a/docs/kubernetes-shortguide-definitions/linode-ccm-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/linode-ccm-definition-shortguide/index.md
@@ -13,7 +13,7 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Linode Cloud Controller Manager
+### Linode Cloud Controller Manager
 
 The [Linode Cloud Controller Manager (CCM)](https://github.com/linode/linode-cloud-controller-manager) creates a fully supported Kubernetes experience on Linode:
 

--- a/docs/kubernetes-shortguide-definitions/linode-k8s-cli-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/linode-k8s-cli-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Linode k8s-alpha CLI
+### Linode k8s-alpha CLI
 
 The [Linode k8s-alpha CLI](https://developers.linode.com/kubernetes/) is a plugin for the Linode CLI that offers quick, single-command deployments of Kubernetes clusters on your Linode account.

--- a/docs/kubernetes-shortguide-definitions/linode-nodebalancer-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/linode-nodebalancer-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Linode NodeBalancer
+### Linode NodeBalancer
 
 [NodeBalancers](https://www.linode.com/nodebalancers) are highly-available, managed, cloud based "load balancers as a service". They intelligently route incoming requests to backend Linodes to help your application cope with load, and to increase your application's availability.

--- a/docs/kubernetes-shortguide-definitions/master-server-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/master-server-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Master Server
+### Master Server
 
 The Kubernetes Master is normally a separate server in a Kubernetes cluster responsible for maintaining the desired state of the cluster. It does this by telling the nodes how many instances of your application it should run and where.

--- a/docs/kubernetes-shortguide-definitions/namespaces-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/namespaces-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Namespaces
+### Namespaces
 
 [Namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) are virtual clusters that exist within the Kubernetes cluster that help to group and organize Kubernetes API objects. Every cluster has at least three Namespaces: default, kube-system, and kube-public. When interacting with the cluster it is important to know which Namespace the object you are looking for is in, as many commands will default to only showing you what exists in the default Namespace. Resources created without an explicit Namespace will be added to the default Namespace.

--- a/docs/kubernetes-shortguide-definitions/orchestration-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/orchestration-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Orchestration
+### Orchestration
 
 Orchestration is the automated configuration, coordination, and management of computer systems, software, middleware, and services. It takes advantage of automated tasks to execute processes. The subject of orchestration is often discussed in reference to lifecycle management for containers, a practice known as container orchestration.

--- a/docs/kubernetes-shortguide-definitions/pod-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/pod-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Pod
+### Pod
 
 A [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod/) is the smallest deployable unit of computing in the Kubernetes architecture. A Pod is a group of one or more containers with shared resources and a specification for how to run these containers. Each Pod has its own IP address in the cluster. Pods are "mortal," which means that they are created and destroyed depending on the needs of the application

--- a/docs/kubernetes-shortguide-definitions/rancher-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/rancher-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Rancher
+### Rancher
 
 [Rancher](https://rancher.com) is a web application that provides a GUI interface for cluster creation and for the management of clusters. Rancher also provides easy interfaces for deploying and scaling apps on your clusters, and it has a built-in catalog of curated apps to choose from.

--- a/docs/kubernetes-shortguide-definitions/replicaset-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/replicaset-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## ReplicaSet
+### ReplicaSet
 
 A [ReplicaSet](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/) is one of the Controllers responsible for keeping a given number of replica Pods running. If one Pod goes down in a ReplicaSet, another will be created to replace it. In this way, Kubernetes is self-healing. However, for most use cases it is recommended to use a Deployment instead of a ReplicaSet.

--- a/docs/kubernetes-shortguide-definitions/rest-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/rest-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## REST
+### REST
 
 REST stands for REpresentational State Transfer. It is an architectural style for network based software that requires stateless, cacheable, client-server communication via a uniform interface between components. The HTTP protocol is most often used in RESTful applications.

--- a/docs/kubernetes-shortguide-definitions/services-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/services-definition-shortguide/index.md
@@ -13,7 +13,7 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Services
+### Services
 
 [Services](https://kubernetes.io/docs/concepts/services-networking/service/) group identical Pods together to provide a consistent means of accessing them. Each service is given an IP address and a corresponding DNS entry. Services exist across nodes. There are four types of Services:
 

--- a/docs/kubernetes-shortguide-definitions/terraform-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/terraform-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Terraform
+### Terraform
 
 [Terraform](https://www.terraform.io) by HashiCorp is a software tool that allows you to represent your Linode instances and other resources with declarative code inside configuration files, instead of manually creating those resources via the Linode Manager or API. This practice is referred to as *Infrastructure as Code*, and Terraform is a popular example of this methodology.

--- a/docs/kubernetes-shortguide-definitions/volumes-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/volumes-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Volumes
+### Volumes
 
 A [Volume](https://kubernetes.io/docs/concepts/storage/volumes/) in Kubernetes is a way to share file storage between containers in a Pod. Kubernetes Volumes differ from Docker volumes because they exist inside the Pod rather than inside the container.

--- a/docs/kubernetes-shortguide-definitions/worker-nodes-definition-shortguide/index.md
+++ b/docs/kubernetes-shortguide-definitions/worker-nodes-definition-shortguide/index.md
@@ -13,6 +13,6 @@ headless: true
 show_on_rss_feed: false
 ---
 
-## Worker Nodes
+### Worker Nodes
 
 Worker nodes in a Kubernetes cluster are servers that run your applications' Pods. The number of nodes in your cluster is determined by the cluster administrator.

--- a/docs/kubernetes/kubernetes-reference/index.md
+++ b/docs/kubernetes/kubernetes-reference/index.md
@@ -19,6 +19,9 @@ external_resources:
 aliases: ['applications/containers/kubernetes-reference/','applications/containers/kubernetes/kubernetes-reference/']
 ---
 
+## Introduction
+Kubernetes introduces a whole new dictionary of terms; this guide contains some of the basic terms and their definitions as a reference.
+
 {{< content "calico-definition-shortguide" >}}
 
 {{< content "cluster-definition-shortguide" >}}


### PR DESCRIPTION
adding a header to the main page fixed the no headers showing in TOC, downgraded all shortguides to h3