### PR TITLE
Change PerconaDB GPG Key to install Percona-XtraDB

### DIFF
--- a/docs/websites/host-a-website-with-high-availability/index.md
+++ b/docs/websites/host-a-website-with-high-availability/index.md
@@ -199,7 +199,7 @@ Install Galera and XtraDB on each Linode that will be in the database cluster.
     {{< note >}}
 When installing `Percona-XtraDB-Cluster-57` and `Percona-XtraDB-Cluster-shared-57`, you will be prompted to verify a GPG key from the Percona repository. Before running the third command, you can manually import the GPG key:
 
-    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage
+    wget https://repo.percona.com/yum/PERCONA-PACKAGING-KEY &&  rpm --import PERCONA-PACKAGING-KEY
 {{< /note >}}
 
 ### Add Firewall Rules


### PR DESCRIPTION
In the [linode high availability guide](https://www.linode.com/docs/websites/host-a-website-with-high-availability/#galera-with-xtradb), a change to Percona causes the user to not be able to install the percona packages due to a GPG error. 

Percona had a gpg key change on 15 Jan 2019, and all packages of Percona >= 0.1-6 and beyond (Current version is 0.1-7) use the new PERCONA-PACKAGING KEY. I've changed the instructions on how to install the new key.

Source: https://jira.percona.com/browse/ENG-37  (found while trying to install)