### PR TITLE
Update links for Cloud Manager

### DIFF
--- a/docs/applications/cloud-storage/tahoe-lafs-on-debian-9/index.md
+++ b/docs/applications/cloud-storage/tahoe-lafs-on-debian-9/index.md
@@ -222,7 +222,7 @@ To confirm each successful setup instead of launching all instances before verif
 This StackScript relies on *icanhazip.com* to retrieve each Linode's external IP address. While the site has redundant servers, there is a chance it may unavailable at times.
 {{< /note >}}
 
-1.  [Familiarize yourself with StackScripts](/docs/platform/stackscripts), then navigate to the [StackScripts page](https://manager.linode.com/stackscripts/index) to add a new StackScript.
+1.  [Familiarize yourself with StackScripts](/docs/platform/stackscripts), then navigate to the [StackScripts page](https://cloud.linode.com/stackscripts/index) to add a new StackScript.
 
 2.  Select Debian 9 as the distribution and paste the following in the **Script** section:
 

--- a/docs/platform/api/_index.md
+++ b/docs/platform/api/_index.md
@@ -2,7 +2,7 @@
 author:
   name: Linode
   email: docs@linode.com
-description: "The Linode API is a programmatic interface that allows you to interact with many of the [Linode Manager's](https://manager.linode.com/) features.<br/>To learn more, please visit the Linode API web page:<br/><https://developers.linode.com/api/v4>"
+description: "The Linode API is a programmatic interface that allows you to interact with many of the [Linode Manager's](https://cloud.linode.com/) features.<br/>To learn more, please visit the Linode API web page:<br/><https://developers.linode.com/api/v4>"
 keywords: ["linode api", " api key", " key"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['api/']

--- a/docs/platform/api/api-key/index.md
+++ b/docs/platform/api/api-key/index.md
@@ -23,7 +23,7 @@ Learn how to generate and remove your Linode API keys for use with the [Linode A
 
 Follow the steps below to generate an API key for your Linode account. This will enable access to the Linode API for this user.
 
-1.  Log in to the [Linode Manager](https://manager.linode.com/).
+1.  Log in to the [Linode Manager](https://cloud.linode.com/).
 2.  Select the **my profile** link.
 3.  Enter your password and click **Authenticate**.
 4.  Select the **API Keys** tab.

--- a/docs/platform/create-limited-developer-account/index.md
+++ b/docs/platform/create-limited-developer-account/index.md
@@ -53,9 +53,9 @@ Useful *Global Grants* for a limited access user might include the ability to:
 
 1.  If you suspect that the user may have access to the Linode Manager password, [change that first](/docs/platform/manager/accounts-and-passwords/#changing-your-linode-manager-password).
 
-1.  Log in to the [Linode Manager](https://manager.linode.com/) and click [**Users and Permissions**](https://manager.linode.com/user/index/) in the **Account** tab. You may be prompted to reauthenticate your password.
+1.  Log in to the [Linode Manager](https://cloud.linode.com/) and click [**Users and Permissions**](https://cloud.linode.com/account/users) in the **Account** tab. You may be prompted to reauthenticate your password.
 
-1.  Locate the user in the Username column, and click **Remove** at the end of the row. Click **Yes. Delete!** to confirm deletion.
+1.  Locate the user in the Username column, and click the three dots and select **Delete** to remove the user. Click **Delete** to confirm deletion.
 
 ## SSH Logins
 

--- a/docs/platform/create-limited-developer-account/index.md
+++ b/docs/platform/create-limited-developer-account/index.md
@@ -32,7 +32,7 @@ Access to the Linode Manager provides high-level methods for controlling your Li
 
 ### Who Has Access to My Linode Account?
 
-Log in to the Linode Manager and navigate to the [**Users and Permissions**](https://manager.linode.com/user/index/) section of the **Account** tab. You may be prompted to reauthenticate your password. This section will display all of your Linode account's users.
+Log in to the Linode Manager and navigate to the [**Users and Permissions**](https://cloud.linode.com/account/users) section of the **Account** tab. You may be prompted to reauthenticate your password. This section will display all of your Linode account's users.
 
 If you're not sure whether you're logged in as the account administrator, look for a `No` in the **Restricted** column of your username's row in the User Manager.
 

--- a/docs/platform/disk-images/disk-images-and-configuration-profiles/index.md
+++ b/docs/platform/disk-images/disk-images-and-configuration-profiles/index.md
@@ -119,7 +119,7 @@ Duplicating a disk is not yet available in the Cloud Manager, but this feature i
 
 You can create an exact copy of a disk by duplicating it. This is an effective way to back up your server or clone an existing Linode to a new Linode. (To clone a disk, see [Cloning disks and Configuration Profiles](#cloning-disks-and-configuration-profiles).) Here's how to duplicate a disk:
 
-1.  Log in to the [Linode Manager](https://manager.linode.com).
+1.  Log in to the [Linode Manager](https://cloud.linode.com).
 1.  Click the **Linodes** tab.
 1.  Select a Linode. The Linode's dashboard appears.
 1.  Click **Shut down** to turn your Linode off. Watch the *Host Job Queue* for confirmation that the Linode has shut down.
@@ -211,7 +211,7 @@ You have successfully selected and booted your Linode from a configuration profi
 
 You can remove a configuration profile from the Linode Cloud Manager at any time. Here's how:
 
-1.  Log in to the [Linode Cloud Manager](https://manager.linode.com).
+1.  Log in to the [Linode Cloud Manager](https://cloud.linode.com).
 2.  Click the **Linodes** link from the sidebar.
 3.  Select a Linode. The Linode's detail page appears.
 4.  Click on the **Disks/Configs** tab.
@@ -230,7 +230,7 @@ To clone an entire Linode, see our [Clone Your Linode guide](/docs/platform/disk
 We recommend that you power off your Linode first, and keep it powered off until your disks have completed the cloning process.
 {{< /note >}}
 
-1.  Log in to the [Linode Cloud Manager](https://manager.linode.com).
+1.  Log in to the [Linode Cloud Manager](https://cloud.linode.com).
 
 1.  Click the **Linodes** link from the sidebar.
 

--- a/docs/platform/disk-images/migrating-a-server-to-your-linode/index.md
+++ b/docs/platform/disk-images/migrating-a-server-to-your-linode/index.md
@@ -38,7 +38,7 @@ Create two disks: one for the files on your existing server, and another for a s
 We assume that your existing server has a single root partition. If you have multiple partitions set up, you'll need to add extra disks to accommodate each partition.
 {{< /note >}}
 
-1.  Log in to the [Linode Manager](https://manager.linode.com).
+1.  Log in to the [Linode Manager](https://cloud.linode.com).
 2.  Click the **Linodes** tab.
 3.  Select a Linode. The Linode's dashboard appears.
 4.  Create a disk to hold the files from the existing server. Select **Create a new Disk**. The webpage shown below appears.
@@ -63,7 +63,7 @@ You have successfully created the disks.
 
 You'll need a configuration profile to boot your existing server after you upload the files. Here's how to create the configuration profile:
 
-1.  In the [Linode Manager](https://manager.linode.com), select the Linode's dashboard.
+1.  In the [Linode Manager](https://cloud.linode.com), select the Linode's dashboard.
 2.  Select **Create a new Configuration Profile**. The webpage shown below appears.
 
     [![Creating a configuration profile](migrate-configuration-profile-small.png)](migrate-configuration-profile.png)
@@ -234,7 +234,7 @@ You have successfully fixed persistent rules.
 
 Now it's time to boot your Linode from the new disks. All you have to do is select the new configuration profile you created and then restart the Linode. Here's how:
 
-1.  Log in to the [Linode Manager](https://manager.linode.com).
+1.  Log in to the [Linode Manager](https://cloud.linode.com).
 2.  Click the **Linodes** tab.
 3.  Select a Linode. The Linode's dashboard appears.
 4.  Select the configuration profile you created earlier, as shown below.

--- a/docs/platform/longview/longview-app-for-mysql-classic/index.md
+++ b/docs/platform/longview/longview-app-for-mysql-classic/index.md
@@ -84,7 +84,7 @@ You should now be able to see Longview data for MySQL. If that's not the case, p
 
 To see the output for the Longview MySQL App:
 
-1.  Log in to the [Linode Manager](https://manager.linode.com/).
+1.  Log in to the [Linode Manager](https://cloud.linode.com/).
 2.  Select the **Longview** tab.
 3.  Select the **MySQL** tab.
 

--- a/docs/platform/longview/longview-app-for-nginx-classic/index.md
+++ b/docs/platform/longview/longview-app-for-nginx-classic/index.md
@@ -109,7 +109,7 @@ You should now be able to see Longview data for NGINX. If that's not the case, p
 
 To see the output for the Longview Nginx App:
 
-1.  Log in to the [Linode Manager](https://manager.linode.com/).
+1.  Log in to the [Linode Manager](https://cloud.linode.com/).
 2.  Select the **Longview** tab.
 3.  Select the **Nginx** tab.
 

--- a/docs/platform/manager/using-the-linode-shell-lish/index.md
+++ b/docs/platform/manager/using-the-linode-shell-lish/index.md
@@ -121,7 +121,7 @@ Now you can use the console, or exit to the Lish prompt by pressing **CTRL+A** t
 
 If you don't want to enter your password every time you connect to Lish, or if you have [Third Party Authentication](/docs/platform/manager/third-party-authentication/) enabled on your account, you can add your public SSH key to the Linode Cloud Manager. If you haven't yet created SSH keys, please see our [Public Key Authentication with SSH](/docs/security/use-public-key-authentication-with-ssh/) guide for more information.
 
-1. Log in to the [Linode Cloud Manager](https://manager.linode.com).
+1. Log in to the [Linode Cloud Manager](https://cloud.linode.com).
 
 1. Click on your profile icon in the top right hand corner of the Manager and select **My Profile**.
 

--- a/docs/quick-answers/linode-platform/enable-backups-on-a-linode/index.md
+++ b/docs/quick-answers/linode-platform/enable-backups-on-a-linode/index.md
@@ -16,7 +16,7 @@ hiddenguide: true
 
 This QuickAnswer will show you how to enable the [Linode Backup Service](https://www.linode.com/backups) on your Linode. See our full [Backup Service](/docs/platform/disk-images/linode-backup-service/) guide for additional information.
 
-1.  Log in to the [Linode Manager](https://manager.linode.com).
+1.  Log in to the [Linode Manager](https://cloud.linode.com).
 2.  From the **Linodes** tab, select the Linode you want to back up.
 3.  Click the **Backups** tab.
 4.  Click **Enable backups for this Linode**. The *Complete Your Order* webpage appears.

--- a/docs/security/recovering-from-a-system-compromise/index.md
+++ b/docs/security/recovering-from-a-system-compromise/index.md
@@ -30,7 +30,7 @@ If you choose to keep your data, you will need to audit all the content on the a
 
 This is the easiest option, but also the most destructive. It will wipe all of the data from your Linode and start over with a fresh disk.
 
-1.  Log in to the [Linode Manager](https://manager.linode.com/).
+1.  Log in to the [Linode Manager](https://cloud.linode.com/).
 2.  Select the **Linodes** tab.
 3.  Select the compromised Linode.
 4.  Select the **Rebuild** tab.

--- a/docs/tools-reference/custom-kernels-distros/install-alpine-linux-on-your-linode/index.md
+++ b/docs/tools-reference/custom-kernels-distros/install-alpine-linux-on-your-linode/index.md
@@ -43,7 +43,7 @@ While this guide will provide you with a fully operational Alpine installation, 
 
 In this section, we'll create the disk images necessary to install Alpine Linux. Although it is not strictly necessary, giving each disk a descriptive name upon creation will make it easier to keep track of its role in the system.
 
-1.  Log in to the [Linode Manager](https://manager.linode.com/linodes/) and select the Linode to install Alpine Linux on.
+1.  Log in to the [Linode Manager](https://cloud.linode.com/linodes/) and select the Linode to install Alpine Linux on.
 
 2.  Create your boot disk image by selecting **Create a new Disk** under the Disks section. The size should be between 128 and 256 MB, and the type should be **ext4**.
 

--- a/docs/tools-reference/custom-kernels-distros/install-nixos-on-linode/index.md
+++ b/docs/tools-reference/custom-kernels-distros/install-nixos-on-linode/index.md
@@ -296,4 +296,4 @@ services.longview = {
         export longview_key="01234567-89AB-CDEF-0123456789ABCDEF" # This is an example, fill with your own key
         echo $longview_key > /var/lib/longview/apiKeyFile | sudo tee /var/lib/longview/apiKeyFile
 
-    Replace the value of `longview_key` above with with the one you got from [Longview](https://manager.linode.com/longview/add).
+    Replace the value of `longview_key` above with with the one you got from [Longview](https://cloud.linode.com/longview/clients).

--- a/docs/tools-reference/introduction-to-linux-concepts/index.md
+++ b/docs/tools-reference/introduction-to-linux-concepts/index.md
@@ -65,7 +65,7 @@ Before you install Linux, decide which distribution to install. Linux comes in s
 
 ### Install Linux to Get Started
 
-Here at Linode, you install Linux with the [Linode Manager](https://manager.linode.com/) dashboard. It takes just a few clicks to install Linux with this dashboard. If you don't have a particular Linux distribution in mind, install **Ubuntu 16.04 LTS**. Ubuntu is good for Linux beginners because it is well-supported and doesn't change often.
+Here at Linode, you install Linux with the [Linode Manager](https://cloud.linode.com/) dashboard. It takes just a few clicks to install Linux with this dashboard. If you don't have a particular Linux distribution in mind, install **Ubuntu 16.04 LTS**. Ubuntu is good for Linux beginners because it is well-supported and doesn't change often.
 
 After you know which distribution you want to install, follow the instructions for installing Linux in the [Getting Started](/docs/getting-started/) article. Follow that article until you complete [Booting Your Linode](/docs/getting-started#boot-your-linode), then come back here.
 

--- a/docs/tools-reference/linux-system-administration-basics/index.md
+++ b/docs/tools-reference/linux-system-administration-basics/index.md
@@ -659,7 +659,7 @@ The *Domain Name System*, or DNS, is the service that the internet uses to assoc
 
 CNAMEs are *only* valid when pointing from one domain to another. If you need to redirect a full URL, you will need to set up a web server and [configure redirection](/docs/web-servers/apache-tips-and-tricks/redirect-urls-with-the-apache-web-server/) and/or virtual hosting on the server level. CNAMEs will allow you to redirect subdomains, such as `team.example.com`, to other subdomains or domains, such as `jack.example.org`. CNAMEs must point to a valid domain that has a valid A Record, or to another CNAME.
 
-Although limited in their capabilities, CNAMEs can be quite useful in some situations. In particular, if you need to change the hostname of a machine, CNAMEs are quite useful. To learn how to set up CNAME records with the [Linode Manager](https://cloud.linode.com//), refer to our [DNS Manager Guide](/docs/platform/manager/dns-manager/).
+Although limited in their capabilities, CNAMEs can be quite useful in some situations. In particular, if you need to change the hostname of a machine, CNAMEs are quite useful. To learn how to set up CNAME records with the [Linode Manager](https://cloud.linode.com/), refer to our [DNS Manager Guide](/docs/platform/manager/dns-manager/).
 
 ### Set Up Subdomains
 

--- a/docs/tools-reference/linux-system-administration-basics/index.md
+++ b/docs/tools-reference/linux-system-administration-basics/index.md
@@ -659,7 +659,7 @@ The *Domain Name System*, or DNS, is the service that the internet uses to assoc
 
 CNAMEs are *only* valid when pointing from one domain to another. If you need to redirect a full URL, you will need to set up a web server and [configure redirection](/docs/web-servers/apache-tips-and-tricks/redirect-urls-with-the-apache-web-server/) and/or virtual hosting on the server level. CNAMEs will allow you to redirect subdomains, such as `team.example.com`, to other subdomains or domains, such as `jack.example.org`. CNAMEs must point to a valid domain that has a valid A Record, or to another CNAME.
 
-Although limited in their capabilities, CNAMEs can be quite useful in some situations. In particular, if you need to change the hostname of a machine, CNAMEs are quite useful. To learn how to set up CNAME records with the [Linode Manager](https://manager.linode.com//), refer to our [DNS Manager Guide](/docs/platform/manager/dns-manager/).
+Although limited in their capabilities, CNAMEs can be quite useful in some situations. In particular, if you need to change the hostname of a machine, CNAMEs are quite useful. To learn how to set up CNAME records with the [Linode Manager](https://cloud.linode.com//), refer to our [DNS Manager Guide](/docs/platform/manager/dns-manager/).
 
 ### Set Up Subdomains
 

--- a/docs/troubleshooting/disaster-recovery-guide/index.md
+++ b/docs/troubleshooting/disaster-recovery-guide/index.md
@@ -20,7 +20,7 @@ If you are having issues accessing your Linode after maintenance has been applie
 
 Confirm that the Linode is fully booted.
 
-1. Log in to the Linode Manager. On the [*Linodes*](https://manager.linode.com/linodes) page, under the *Status* column look for *Running* as the status of your Linode.
+1. Log in to the Linode Manager. On the [*Linodes*](https://cloud.linode.com/linodes) page, under the *Status* column look for *Running* as the status of your Linode.
 
 1. If your Linode's status displays *Powered Off*, click on the *Dashboard* link. Under the *Dashboard* section, click the grey **Boot** button to boot your Linode.
 

--- a/docs/troubleshooting/troubleshooting-basic-connection-issues/index.md
+++ b/docs/troubleshooting/troubleshooting-basic-connection-issues/index.md
@@ -46,7 +46,7 @@ Review the installation instructions in Linode's [Diagnosing Network Issues with
 
 ## Is your Linode Running?
 
-Log in to the [Linode Manager](https://manager.linode.com/) and inspect the Linode's dashboard. If the Linode is powered off, turn it on.
+Log in to the [Linode Manager](https://cloud.linode.com/) and inspect the Linode's dashboard. If the Linode is powered off, turn it on.
 
 ### Inspect the Lish Console
 

--- a/docs/troubleshooting/troubleshooting/index.md
+++ b/docs/troubleshooting/troubleshooting/index.md
@@ -102,17 +102,6 @@ The applications on your Linode require a certain amount of physical memory to f
 1.  Read through the [Troubleshooting Memory and Networking Issues](/docs/troubleshooting/troubleshooting-memory-and-networking-issues/) guide for troubleshooting commands which display your memory use.
 1.  If an application is consuming all of your available memory, you have three options. You can kill the application, change the application's settings to reduce its memory footprint, or [upgrade your Linode](https://www.linode.com/pricing) to a larger plan.
 
-    {{< disclosure-note "Steps for the Linode Classic Manager" >}}
-  If you are using the Linode Classic Manager, you can follow these steps:
-
-  1.  Log in to the [Linode Classic Manager](https://cloud.linode.com).
-  1.  Click the **Linode** tab. A list of your Linodes appears.
-  1.  Select a Linode. The Linode's dashboard appears.
-  1.  Select the **Launch Console** link. The LISH console window appears. If memory errors are displayed in the LISH console, stop some running services to free up memory or upgrade to larger plan.
-  1.  Read through the [Troubleshooting Memory and Networking Issues](/docs/troubleshooting/troubleshooting-memory-and-networking-issues/) guide for troubleshooting commands which display your memory use.
-  1.  If an application is consuming all of your available memory, you have three options. You can kill the application, change the application's settings to reduce its memory footprint, or [upgrade your Linode](https://www.linode.com/pricing) to a larger plan.
-    {{</ disclosure-note >}}
-
 If your Linode is not out of memory, continue to the next section.
 
 ### Is there a Disk I/O Bottleneck?
@@ -194,14 +183,3 @@ If you recently upgraded your plan, your Linode won't be able to take advantage 
     [![Disk storage allocation](disk-storage-allocation.png)](disk-storage-allocation.png)
 
     Follow our steps for [resizing a disk](/docs/platform/disk-images/disk-images-and-configuration-profiles/#resizing-a-disk) to take advantage of the extra space.
-
-    {{< disclosure-note "Steps for the Linode Classic Manager" >}}
-  If you are using the Linode Classic Manager, you can follow these steps:
-
-  1.  Log in to the [Linode Manager](https://cloud.linode.com).
-  1.  Click the **Linode** tab. A list of your Linodes appears.
-  1.  Select a Linode. The Linode's dashboard appears.
-  1.  Examine the *Storage* pane on the sidebar, as shown below. If you have free storage space, you can allocate that space to your existing disks.
-
-      [![Resize disks.](944-troubleshooting4-1.png)](944-troubleshooting4-1.png)
-    {{</ disclosure-note >}}

--- a/docs/troubleshooting/troubleshooting/index.md
+++ b/docs/troubleshooting/troubleshooting/index.md
@@ -105,7 +105,7 @@ The applications on your Linode require a certain amount of physical memory to f
     {{< disclosure-note "Steps for the Linode Classic Manager" >}}
   If you are using the Linode Classic Manager, you can follow these steps:
 
-  1.  Log in to the [Linode Classic Manager](https://manager.linode.com).
+  1.  Log in to the [Linode Classic Manager](https://cloud.linode.com).
   1.  Click the **Linode** tab. A list of your Linodes appears.
   1.  Select a Linode. The Linode's dashboard appears.
   1.  Select the **Launch Console** link. The LISH console window appears. If memory errors are displayed in the LISH console, stop some running services to free up memory or upgrade to larger plan.
@@ -198,7 +198,7 @@ If you recently upgraded your plan, your Linode won't be able to take advantage 
     {{< disclosure-note "Steps for the Linode Classic Manager" >}}
   If you are using the Linode Classic Manager, you can follow these steps:
 
-  1.  Log in to the [Linode Manager](https://manager.linode.com).
+  1.  Log in to the [Linode Manager](https://cloud.linode.com).
   1.  Click the **Linode** tab. A list of your Linodes appears.
   1.  Select a Linode. The Linode's dashboard appears.
   1.  Examine the *Storage* pane on the sidebar, as shown below. If you have free storage space, you can allocate that space to your existing disks.

--- a/docs/uptime/monitoring-and-maintaining-your-server/index.md
+++ b/docs/uptime/monitoring-and-maintaining-your-server/index.md
@@ -104,7 +104,7 @@ There are several free third-party performance monitoring tools available for yo
 
 ## Linode Managed
 
-[Linode Managed](https://www.linode.com/managed) is our monitoring service that offers 24x7 incident response, dashboard metrics for your Linodes, free cPanel, and an automatic backup service. With a three-month Linode Managed commitment, you also get two complimentary standard site migrations performed by our [Professional Services Team](https://www.linode.com/professional-services). If you are running more than one Linode, not all are required to be managed. You can establish separate accounts (e.g., production and development) and monitor only the most critical services running on designated Linode(s). Existing customers can sign up for Linode Managed by [contacting support](https://cloud.linode.com/support/tickets) or from the Linode Classic Manager's [account tab](https://cloud.linode.com/account).
+[Linode Managed](https://www.linode.com/managed) is our monitoring service that offers 24x7 incident response, dashboard metrics for your Linodes, free cPanel, and an automatic backup service. With a three-month Linode Managed commitment, you also get two complimentary standard site migrations performed by our [Professional Services Team](https://www.linode.com/professional-services). If you are running more than one Linode, not all are required to be managed. You can establish separate accounts (e.g., production and development) and monitor only the most critical services running on designated Linode(s). Existing customers can sign up for Linode Managed by [contacting support](https://cloud.linode.com/support/tickets).
 
 ## Manage Logs
 

--- a/docs/uptime/monitoring-and-maintaining-your-server/index.md
+++ b/docs/uptime/monitoring-and-maintaining-your-server/index.md
@@ -104,7 +104,7 @@ There are several free third-party performance monitoring tools available for yo
 
 ## Linode Managed
 
-[Linode Managed](https://www.linode.com/managed) is our monitoring service that offers 24x7 incident response, dashboard metrics for your Linodes, free cPanel, and an automatic backup service. With a three-month Linode Managed commitment, you also get two complimentary standard site migrations performed by our [Professional Services Team](https://www.linode.com/professional-services). If you are running more than one Linode, not all are required to be managed. You can establish separate accounts (e.g., production and development) and monitor only the most critical services running on designated Linode(s). Existing customers can sign up for Linode Managed by [contacting support](https://cloud.linode.com/support/tickets) or from the Linode Classic Manager's [account tab](https://manager.linode.com/account).
+[Linode Managed](https://www.linode.com/managed) is our monitoring service that offers 24x7 incident response, dashboard metrics for your Linodes, free cPanel, and an automatic backup service. With a three-month Linode Managed commitment, you also get two complimentary standard site migrations performed by our [Professional Services Team](https://www.linode.com/professional-services). If you are running more than one Linode, not all are required to be managed. You can establish separate accounts (e.g., production and development) and monitor only the most critical services running on designated Linode(s). Existing customers can sign up for Linode Managed by [contacting support](https://cloud.linode.com/support/tickets) or from the Linode Classic Manager's [account tab](https://cloud.linode.com/account).
 
 ## Manage Logs
 


### PR DESCRIPTION
I didn't look at the full context, just searched through the repo and for all of the non-deprecated docs, I updated the links from manager.linode.com to cloud.linode.com. May still need a bit of copy-editing. 

