### PR TITLE
Added information under the Linode CLI section of how-to-use-object-storage' about the --cluster option.

### DIFF
--- a/docs/platform/object-storage/how-to-use-object-storage/index.md
+++ b/docs/platform/object-storage/how-to-use-object-storage/index.md
@@ -256,6 +256,16 @@ To delete a bucket, use the `rb` command:
 
     linode-cli obj rb my-example-bucket
 
+Currently, the Linode CLI defaults to creating buckets in the Newark data center. To change the cluster a bucket is created in, use the `--cluster` option, followed by the cluster name below:
+
+  - `us-east-1` for the Newark data center. This is the current default.
+  - `eu-central-1` for the Frankfurt data center.
+  - `ap-south-1` for the Singapore data center.
+
+{{< note >}}
+You will need to use the `--cluster` option for every interaction with your bucket if it is not in `us-east-1`.
+{{</ note >}}
+
 If the bucket has objects in it, you can not delete it from the Linode CLI immediately. Instead, remove the objects first, then delete the bucket. The [s3cmd](/docs/platform/object-storage/how-to-use-object-storage/#s3cmd) tool has commands for deleting all objects from a bucket, and it can also force-delete a bucket with objects in it.
 
 ### Upload, Download, and Delete an Object with the CLI


### PR DESCRIPTION
Currently buckets are created in us-east-1 by default, regardless of your CLI configuration. If you want to make or interact with buckets in other clusters, the --cluster option is needed. 