### PR TITLE
Remove outdated reference in UFW guide

### DIFF
--- a/docs/security/firewalls/configure-firewall-with-ufw/index.md
+++ b/docs/security/firewalls/configure-firewall-with-ufw/index.md
@@ -26,7 +26,7 @@ If you are running Docker, by default Docker directly manipulates iptables. Any 
 
 1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  Ensure that you complete the sections of [How to Secure Your Server](/docs/security/securing-your-server/) guide to create a standard user account, harden SSH access and remove unnecessary network services. Do **not** follow the [Configure a Firewall](/docs/security/securing-your-server/#configure-a-firewall) section in [How to Secure Your Server](/docs/security/securing-your-server/) guide. This guide is an introduction to using UFW, which is a separate method of controlling a firewall than iptables commands. The guide lists the commands for Arch Linux, Debian or Ubuntu distributions only. However, you can use the relevant commands for the outlined tasks on various Linux distributions.
+2.  Ensure that you complete the sections of [How to Secure Your Server](/docs/security/securing-your-server/) guide to create a standard user account, harden SSH access and remove unnecessary network services. This guide lists the commands for Arch Linux, Debian or Ubuntu distributions only. However, you can use the relevant commands for the outlined tasks on various Linux distributions.
 
 3.  Update your system.
 


### PR DESCRIPTION
The UFW guide currently says "do not follow the Configure a Firewall section in How to Secure Your Server guide", presumably because the "How to Secure Your Server" guide used to include only instructions for using `iptables`. However, that guide now includes links to guides that provide different options for firewall configuration (including this UFW guide), so this "warning" in the UFW guide no longer makes sense. This commit removes it.