### PR TITLE
updated iRedMail install guide DOCS-358

### DIFF
--- a/docs/email/iredmail/install-iredmail-on-ubuntu/index.md
+++ b/docs/email/iredmail/install-iredmail-on-ubuntu/index.md
@@ -65,12 +65,12 @@ A DNS MX record tells the internet where to send email directed at you domain. B
 3. Download the latest release of iRedMail. The current release, as of 16 September 2014, is 0.8.7 and can be downloaded by entering the following:
 
         cd /root/
-        wget https://bitbucket.org/zhb/iredmail/downloads/iRedMail-0.8.7.tar.bz2
+        wget https://github.com/iredmail/iRedMail/releases/download/1.3.1/iRedMail-1.3.1.tar.gz
 
 4. Uncompress the package and run the script:
 
-        tar xjf iRedMail-0.8.7.tar.bz2
-        cd iRedMail-0.8.7
+        tar zxf iRedMail-1.3.1.tar.gz
+        cd iRedMail-1.3.1
         bash iRedMail.sh
 
 


### PR DESCRIPTION
Original iRedMail download link was dead, updated to latest stable release and [here](https://www.linode.com/docs/email/iredmail/install-iredmail-on-ubuntu/#install-iredmail).