### PR TITLE
Some ext4 features (e.g. metadata_csum) not supported.

### DIFF
--- a/docs/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/index.md
+++ b/docs/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/index.md
@@ -150,7 +150,7 @@ If you're still not able to access your Linode via Lish after updating your GRUB
 
 If you've followed the steps so far, you should have a working custom distribution with raw disks, using the *direct disk* boot option. While this setup is functional, it's not compatible with several features of the Linode Manager that require the ability to mount your filesystem, such as:
 
-*  **Disk Resizing:** Since the Linode Cloud Manager cannot determine the amount of *used* storage space on a raw disk, it can only **increase** the size. The Linode Cloud Manager cannot be used to make a raw disk smaller, and it cannot resize the filesystem on the disk - this would need to be done manually.
+*  **Disk Resizing:** Since the Linode Cloud Manager cannot determine the amount of *used* storage space on a raw disk, it can only **increase** the size. The Linode Cloud Manager cannot be used to make a raw disk smaller, and it cannot resize the filesystem on the disk - this would need to be done manually. Also, some ext4 features like enabled metadata_csum are not supported for custom distribution images.
 
 *  **Backups:** The Linode Backup Service needs to be able to mount your filesystem, and does not support partitioned disks.
 


### PR DESCRIPTION
Adding some documentation around unsupported ext4 features in custom distributions, specifically Meta-Data Checksums and that they don’t currently work with Linode Cloud Manager features.