### PR TITLE
[Update] NodeBalancer Guides for ProxyProtocol

### DIFF
--- a/docs/kubernetes/getting-started-with-load-balancing-on-a-lke-cluster/index.md
+++ b/docs/kubernetes/getting-started-with-load-balancing-on-a-lke-cluster/index.md
@@ -137,8 +137,8 @@ The Linode CCM accepts annotations that configure the behavior and settings of y
 | `check-interval` | integer | None | The duration, in seconds, between health checks. |
 | `check-timeout` | &bull; integer <br> &bull; value between `1`-`30` | None | Duration, in seconds, to wait for a health check to succeed before it is considered a failure. |
 | `check-attempts` | &bull; integer <br> &bull; value between `1`-`30` | None | Number of health checks to perform before removing a back-end Node from service. |
-| `check-passive` | boolean | `false` | When `true`, `5xx` status codes will cause the health check to fail. |
-| `preserve` | boolean | `false` | When `true`, deleting a LoadBalancer service does not delete the underlying NodeBalancer |
+| `check-passive` | Boolean | `false` | When `true`, `5xx` status codes will cause the health check to fail. |
+| `preserve` | Boolean | `false` | When `true`, deleting a LoadBalancer service does not delete the underlying NodeBalancer |
 
 {{< note >}}
 To view a list of deprecated annotations, visit the [Linode CCM GitHub repository](https://github.com/linode/linode-cloud-controller-manager/blob/master/README.md#deprecated-annotations).
@@ -149,7 +149,7 @@ To view a list of deprecated annotations, visit the [Linode CCM GitHub repositor
 This section describes how to set up TLS termination on your Linode NodeBalancers so a Kubernetes Service can be accessed over HTTPS.
 
 {{< note >}}
-Linode NodeBalancers do not currently support ProxyProtocol. For this reason, Kubernetes LoadBalancer Services running on Linode do not support ProxyProtocol either. This means you cannot both terminate TLS inside your Kubernetes cluster and whitelist client IP addresses. ProxyProtocol support is coming soon to Linode NodeBalancers.
+While Linode NodeBalancers do support ProxyProtocol, the Linode CCM does not. For this reason, the Linode Kubernetes Engine does not support ProxyProtocol yet. This means you cannot both terminate TLS inside your Kubernetes cluster and whitelist client IP addresses. ProxyProtocol support is coming soon to the Linode CCM.
 {{</ note >}}
 
 #### Generating a TLS type Secret

--- a/docs/kubernetes/how-to-configure-load-balancing-with-tls-encryption-on-a-kubernetes-cluster/index.md
+++ b/docs/kubernetes/how-to-configure-load-balancing-with-tls-encryption-on-a-kubernetes-cluster/index.md
@@ -24,7 +24,7 @@ The [*Linode Cloud Controller Manager*](https://github.com/linode/linode-cloud-c
 
 To learn about the various configurations available for Linode NodeBalancers via [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/), see [Getting Started with Load Balancing on a Linode Kubernetes Engine (LKE) Cluster](/docs/kubernetes/getting-started-with-load-balancing-on-a-lke-cluster/#configuring-your-linode-nodebalancers-with-annotations).
 
-Linode NodeBalancers do not currently support ProxyProtocol. For this reason, Kubernetes LoadBalancer Services running on Linode do not support ProxyProtocol either. This means you cannot both terminate TLS inside your Kubernetes cluster and whitelist client IP addresses. ProxyProtocol support is coming soon to Linode NodeBalancers.
+While Linode NodeBalancers do support ProxyProtocol, the Linode CCM does not. For this reason, the Linode Kubernetes Engine does not support ProxyProtocol yet. This means you cannot both terminate TLS inside your Kubernetes cluster and whitelist client IP addresses. ProxyProtocol support is coming soon to the Linode CCM.
 
 {{</ note >}}
 

--- a/docs/platform/nodebalancer/getting-started-with-nodebalancers/index.md
+++ b/docs/platform/nodebalancer/getting-started-with-nodebalancers/index.md
@@ -19,10 +19,6 @@ Nearly all applications that are built using Linodes can benefit from load balan
 
 This guide provides a high-level overview setting up a NodeBalancer, but it's outside this page's scope to explain each application a NodeBalancer could balance. For more information on various applications that might be useful behind NodeBalancer, see the rest of [Linode Guides & Tutorials on NodeBalancers](/docs/platform/nodebalancer/).
 
-{{< note >}}
-Linode NodeBalancers do not currently support ProxyProtocol. This means you cannot pass client connection information to backend nodes when using Linode NodeBalancers. ProxyProtocol support is coming soon to Linode NodeBalancers.
-{{</ note >}}
-
 ## Configuring a NodeBalancer
 
 {{< content "configure-nodebalancer-shortguide" >}}

--- a/docs/platform/nodebalancer/nodebalancer-ssl-configuration/index.md
+++ b/docs/platform/nodebalancer/nodebalancer-ssl-configuration/index.md
@@ -20,11 +20,6 @@ This guide will help you install an SSL certificate on your NodeBalancer. It inc
 Throughout this guide we will offer several suggested values for specific configuration settings; some of these values will be set by default. These settings are shown in the guide as a reference and you may need to modify them to suit your application accordingly.
 {{< /note >}}
 
-{{< note >}}
-Linode NodeBalancers do not currently support ProxyProtocol. This means you cannot pass client connection information to backend nodes when using Linode NodeBalancers. ProxyProtocol support is coming soon to Linode NodeBalancers.
-{{</ note >}}
-
-
 ## Before you Begin
 
 - When first configuring back-end Linodes, you should set them up according to the instructions in our [Getting Started](/docs/getting-started) guide. In addition, we recommend that you implement security precautions. For assistance with this, please see our guide on [Securing Your Server](https://linode.com/docs/security/securing-your-server)

--- a/docs/platform/nodebalancer/what-are-nodebalancers/index.md
+++ b/docs/platform/nodebalancer/what-are-nodebalancers/index.md
@@ -51,8 +51,6 @@ The optimal solution for a highly available site or application is to have multi
 
 - Nodebalancers have a maximum connection limit of 10,000 concurrent connections.
 
--  Linode NodeBalancers do not currently support ProxyProtocol. This means you cannot pass client connection information to backend nodes when using Linode NodeBalancers. ProxyProtocol support is coming soon to Linode NodeBalancers.
-
 ## Next Steps
 
 For more on NodeBalancers see the [Getting Started with NodeBalancers](/docs/platform/nodebalancer/getting-started-with-nodebalancers/) guide and the [NodeBalancer Reference](/docs/platform/nodebalancer/nodebalancer-reference-guide/) guide.


### PR DESCRIPTION
removed notes about ProxyProtocol not available and changed notes to say CCM does not have support for ProxyProtocol on LKE guides