### PR TITLE
Update LKE static site guide to use alpine base image

### DIFF
--- a/docs/kubernetes/how-to-deploy-a-static-site-on-linode-kubernetes-engine/index.md
+++ b/docs/kubernetes/how-to-deploy-a-static-site-on-linode-kubernetes-engine/index.md
@@ -234,11 +234,10 @@ In this section you will create a Docker container for your static site, which y
 
     {{< file "lke-example/Dockerfile" >}}
 # Install the latest Debain operating system.
-FROM debian:latest as HUGO
+FROM alpine:3.12.0 as HUGO
 
 # Install Hugo.
-RUN apt-get update -y
-RUN apt-get install hugo -y
+RUN apk update && apk add hugo
 
 # Copy the contents of the current working directory to the
 # static-site directory.


### PR DESCRIPTION
The container image in this guide uses an older version of Hugo, v0.54.0, while the latest is v0.74.3. When building the container image, hugo exits with the following error:
```
Error: Error building site: Failed to load translations in file “bg.toml”: unsupported file extension .toml
```
Updating Hugo to a more recent package resolves this issue. The Debian Buster(stable) repo has `0.54.0` as the latest available, while Debian Sid (unstable) has the more recent `0.74.3-1`.

This PR updates the base image to `alpine:3.12.0`, which has the more recent hugo `v0.71.1` package. Alpine is also a smaller base image, which should reduce the build time a bit.