### PR TITLE
Update index.md

### DIFF
--- a/docs/databases/mysql/how-to-optimize-mysql-performance-using-mysqltuner/index.md
+++ b/docs/databases/mysql/how-to-optimize-mysql-performance-using-mysqltuner/index.md
@@ -14,7 +14,7 @@ title: How to Optimize MySQL Performance Using MySQLTuner
 external_resources:
  - '[MySQL Documentation Library](http://dev.mysql.com/doc/index.html)'
  - '[MySQL Tuning Server Parameters](http://dev.mysql.com/doc/refman/5.7/en/server-parameters.html)'
- - '[MySQLTuner](http://mysqltuner.com/)'
+ - '[MySQLTuner](https://github.com/major/MySQLTuner-perl)'
 dedicated_cpu_link: true
 ---
 
@@ -37,7 +37,7 @@ In order to determine if your MySQL database needs to be reconfigured, it is bes
 
 ### MySQLTuner
 
-The [MySQLTuner](http://mysqltuner.com/) script assesses your MySQL installation, and then outputs suggestions for increasing your server's performance and stability.
+The [MySQLTuner](https://github.com/major/MySQLTuner-perl) script assesses your MySQL installation, and then outputs suggestions for increasing your server's performance and stability.
 
 1. Download the MySQLTuner script:
 


### PR DESCRIPTION
mysqltuner.com now points to a gun website, after what looks like a recent change:
```
$ whois mysqltuner.com | grep Updat
   Updated Date: 2020-08-01T10:59:45Z
Updated Date: 2020-08-01T10:59:45Z
```

This was brought to our attention by someone on Twitter after we tweeted out a link to this guide: https://twitter.com/zaherg/status/1302611089226706945
```
the link to mysqltuner website is for a gun recommendation blog!! so its better to change it to the github repo instead
```

My change is to link to the GitHub repo, rather than mysqltuner.com, which occurred twice in this doc. There's still a reference to it in the output of the script, but that doesn't link anywhere.