### PR TITLE
Add Absolute Paths to Key MV Commands

### DIFF
--- a/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8/index.md
+++ b/docs/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8/index.md
@@ -270,8 +270,8 @@ example.com
 
     Replace `YYYYMM` with the current year and month as in the key table. This will give you two files, `YYYYMM.private` containing the key and `YYYYMM.txt` containing the TXT record you'll need to set up DNS. Rename the files so they have names matching the third section of the second field of the key table for the domain:
 
-        mv YYYYMM.private example.private
-        mv YYYYMM.txt example.txt
+        mv /etc/opendkim/keys/YYYYMM.private /etc/opendkim/keys/example.private
+        mv /etc/opendkim/keys/YYYYMM.txt /etc/opendkim/keys/example.txt
 
     Repeat the commands in this step for every entry in the key table. The `-b 2048` indicates the number of bits in the RSA key pair used for signing and verification. 1024 bits is the minimum, but with modern hardware 2048 bits is safer. (It's possible 4096 bits will be required at some point.)
 


### PR DESCRIPTION
Following the guide steps do not place the user in the directory in which to run the commands in step 8.  Adding absolute paths to the commands removes the need for changing directory.