### PR TITLE
Update Algolia upload script to optionally apply an index suffix

### DIFF
--- a/scripts/update_linode_docs_search_indices/main.go
+++ b/scripts/update_linode_docs_search_indices/main.go
@@ -21,6 +21,7 @@ const (
 
 type config struct {
 	SourceDir string `arg:"required" help:"filesystem path to read files relative from (e.g. /public)"`
+	IndexSuffix string `default:"" help:"suffix to append to index names in Algolia"`
 	AppKey    string `arg:"env:ALGOLIA_ADMIN_API_KEY"`
 	AppID     string `arg:"env:ALGOLIA_APP_ID"`
 }
@@ -60,12 +61,12 @@ func main() {
 
 	indices := []algoliaIndex{
 		algoliaIndex{
-			name:    "linode-documentation",
+			name:    "linode-documentation" + cfg.IndexSuffix,
 			source:  "index.json",
 			replace: true,
 		},
 		algoliaIndex{
-			name: "linode-documentation-sections",
+			name: "linode-documentation-sections" + cfg.IndexSuffix,
 
 			source: "data/sections/index.json",
 			// This index is shared between Hugo and WordPress,
@@ -77,7 +78,7 @@ func main() {
 			replace: false,
 		},
 		algoliaIndex{
-			name:    "linode-documentation-api",
+			name:    "linode-documentation-api" + cfg.IndexSuffix,
 			source:  "api/index.json",
 			replace: true,
 		},


### PR DESCRIPTION
This change supports keeping several namespaced sets of indices on the same Algolia account. These would be used to maintain several staging servers, each of which has its own Algolia index collection.

If no `indexsuffix` is passed to the script, then these changes have no effect.