### PR TITLE
Script: generate NGINX 301 redirects from Hugo aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ yarn.lock
 search_index/
 resources/_gen/assets
 hugo_stats.json
+
+redirects.conf

--- a/scripts/generate_permanent_redirects_for_nginx.sh
+++ b/scripts/generate_permanent_redirects_for_nginx.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Usage:
+#    ./generate_permanent_redirects_for_nginx.sh
+#
+# Or, optionally:
+#    BASE_URL=<base URL of site> ./generate_permanent_redirects_for_nginx.sh
+#
+# BASE_URL is set to '$scheme://$http_host/docs' if it is not found as
+# an environment variable. This is what you should use in most cases
+# so you probably don't usually need to set it yourself.
+#
+# This script iterates through the public/ folder and searches for any pages
+# created from Hugo's `aliases` frontmatter. It generates an NGINX permanent
+# rewrite rule that will serve a 301 redirect for requests on the page.
+# Without this rule, the page would serve a browser-based redirect.
+#
+# These rewrite rules are appended to a redirects.conf file that is placed
+# in the root of the docs repo. You will then need to copy this file to the
+# NGINX server that will serve the website.
+
+set -eo pipefail
+
+[[ -z "$BASE_URL" ]] && { BASE_URL='$scheme://$http_host/docs'; }
+
+> ../redirects.conf
+
+egrep -R '<!DOCTYPE html><html><head><title>(https:\/\/.*\/)<\/title><link rel="canonical" href="(https:\/\/.*\/)"\/><meta name="robots" content="noindex"><meta charset="utf-8" \/><meta http-equiv="refresh" content="0; url=(https:\/\/.*\/)" \/><\/head><\/html>' ../public | while read -r line ; do
+    # Gets the path (relative to the base URL) that the redirect should point to
+    # Example: /guides/how-to-install-mariadb-on-centos-7/
+    redirect_target_path="/$(echo $line | egrep -o '<title>https:\/\/.*\/<\/title>' | cut -c 36- | rev | cut -c 9- | rev)"
+    # Gets the path that the redirect is done from
+    # Example: /docs/databases/mariadb/how-to-install-mariadb-on-centos-7/
+    redirect_from_path="/docs$(echo $line | cut -d ':' -f 1 | cut -c 10- | rev | cut -c 11- | rev)"
+
+    echo "rewrite ^$redirect_from_path?$ $BASE_URL$redirect_target_path permanent;" >> ../redirects.conf
+done


### PR DESCRIPTION
This script creates a set of 301 redirects that can then be copied over to an NGINX web server that hosts the docs site. The 301s that are generated correspond to the frontmatter `aliases` set within the guides.