### PR TITLE
Fix page titles for static pages (guides, product docs)

### DIFF
--- a/_vendor/github.com/bep/linodedocs/layouts/_default/baseof.html
+++ b/_vendor/github.com/bep/linodedocs/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
   {{ block "head-meta-main" . }}
     {{/* The default static title and SEO meta markup. */}}
     <title>
-      {{ if .IsPage }}{{ .FirstSection.Title }} | {{ end }}{{ .Title }}
+      {{ .Title }} | {{ $.Site.Params.page_title_suffix | default "Linode" }}
     </title>
     {{/* SEO */}}
     {{ partial "sections/head-seo.html" . }}
@@ -19,24 +19,24 @@
      is-not-topbar-pinned
      is-not-explorer-open
      is-not-toc-open
-     is-not-search-panel-open 
+     is-not-search-panel-open
      is-not-search-panel_filters-open
      is-not-search-input-open {{ block "body-class" . }}{{ end }}">
-  
+
   {{ partial "sections/after-body-start.html" . }}
-  
+
   {{/* Base grid */}}
   <div id="grid" class="grid--base bg-backgroundcolor">
-  
+
   {{ block "icons" . }}
     {{ partial "icons/navigation.html" .}}
     {{ partial "icons/social.html" .}}
   {{ end }}
-  
+
   <header id="linode-menus" class="z-20">
     {{ partial "linode-header.html" }}
   </header>
-  
+
   {{/* Top navbar */}}
   <nav id="navbar" class="bg-white w-full box-border sticky top-0 z-10 border-b-gray">
     <div id="navbar__icons--left" class="h-full flex justify-start"  @nav:toggle.document="receiveToggle($event.detail)" x-data="lnNavController.New()"
@@ -68,12 +68,12 @@
       {{ partial "sections/navigation/toc.html" . }}
     </div>
   </nav>
-  
+
   {{/* Left side explorer menu. */}}
   <nav id="explorer" class="bg-white sticky overflow-y-scroll z-0 top--navbar-row border-r-gray">
     {{ partialCached "sections/navigation/explorer.html" . }}
   </nav>
-  
+
   {{/* Main content area. */}}
   <main class="main bg-backgroundcolor h-full min-h-screen z-0 overflow-hidden">
     <div class="main__inner">
@@ -90,12 +90,12 @@
       </section>
     </div>
   </main>
-  
+
   {{/* Common Linide footer */}}
   <div id="footer" class="border-t-gray z-50">
     {{ partial "linode-footer.html" }}
   </div>
-  
+
   {{/* Scripts etc. added before body end. */}}
   {{ partial "sections/before-body-end.html" . }}
 </body>

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bep/linodedocs v0.0.0-20201028163546-1e2def1c7431
+# github.com/bep/linodedocs v0.0.0-20201029131522-c656d102af90
 # github.com/linode/linode-website-partials v0.0.0-20201027160459-020df188fe47
 # github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.7.1
 # github.com/alpinejs/alpine v2.7.0+incompatible

--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,7 @@ time_format_RFC3339 = "2006-01-02T15:04:05Z07:00"
 time_format_default = "Monday, January 2, 2006"
 promo_code = "DOCS3DR5GT"
 promo_code_amount = 100
+page_title_suffix = "Linode"
 
 [params.search_config]
 app_id = "KGUN8FAIPF"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/bep/hugo-jslibs/alpinejs v0.5.14 // indirect
 	github.com/bep/hugo-jslibs/instantpage v0.0.0-20200822093604-7b6e0aaba587 // indirect
 	github.com/bep/hugo-jslibs/turbolinks v0.1.2 // indirect
-	github.com/bep/linodedocs v0.0.0-20201028163546-1e2def1c7431
+	github.com/bep/linodedocs v0.0.0-20201029131522-c656d102af90
 	github.com/linode/linode-api-docs/v4 v4.78.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/bep/linodedocs v0.0.0-20201022183302-e57b2abd7aa4 h1:vUbTou5q2L3IQ1tt
 github.com/bep/linodedocs v0.0.0-20201022183302-e57b2abd7aa4/go.mod h1:hjrQVt6vP+n2xhetwJ8WOiYORr2r5VylsAN467Wu/UA=
 github.com/bep/linodedocs v0.0.0-20201028163546-1e2def1c7431 h1:tnhi0Dp/wJn7CN+yAymizG9h9qG0OX8km+2iD8aPdX0=
 github.com/bep/linodedocs v0.0.0-20201028163546-1e2def1c7431/go.mod h1:Jaf9UDYxVmfTOesVMNvyBGU+0Q78L9Or7hDEN1I7gAc=
+github.com/bep/linodedocs v0.0.0-20201029131522-c656d102af90 h1:4M/jEnVKdnSgk7JZZTfQabZrfSMIKeUngtO4jYxk2Qs=
+github.com/bep/linodedocs v0.0.0-20201029131522-c656d102af90/go.mod h1:Jaf9UDYxVmfTOesVMNvyBGU+0Q78L9Or7hDEN1I7gAc=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.5.0/go.mod h1:XvAGp/0tQ8bZpoCcM6rdx1NbzZUy3/KtetedtdgaNek=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.6.0/go.mod h1:QB5IEnFYPAWpMEBg4tF1OW0xzI1O68QNWnqfPuUkpnU=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.7.0/go.mod h1:e1pgFkSbGd2EzKUbAuXHSnVqMX2suwsSklPZfDXeQkg=


### PR DESCRIPTION
Example:

Before:
```
<title>Linode Guides &amp; Tutorials | What is iptables</title>
```
After:
```
<title>What is iptables | Linode</title>
```

This aligns with what we did on the old site, and it makes sure more of the page's actual title is visible in search results.

The appended text (e.g. "Linode") can be changed by setting `page_title_suffix` in the site params in config.toml

---

This does not changed the titles for section pages--I haven't figured that out yet. Nor does it change the titles and other <head> attributes for wordpress content pages. We have an open issue for that.