### PR TITLE
[Hotfix] v1.6.1

### DIFF
--- a/_vendor/github.com/bep/linodedocs/assets/js/main/navigation/create-href.js
+++ b/_vendor/github.com/bep/linodedocs/assets/js/main/navigation/create-href.js
@@ -26,7 +26,7 @@ var lnCreateHref = {};
 			},
 			hrefEntry: function(hit) {
 				let urlParts = hit.url.split('/');
-				let contentType = hit.objectID.split("#").shift().replace("content", "resource");
+				let contentType = hit.objectID.split('#').shift().replace('content', 'resource');
 				let slug = urlParts.pop() || urlParts.pop();
 				return `${WP_CONTENT_BASEPATH}${contentType}/${slug}/`;
 			}

--- a/_vendor/github.com/bep/linodedocs/assets/js/main/navigation/explorer.js
+++ b/_vendor/github.com/bep/linodedocs/assets/js/main/navigation/explorer.js
@@ -252,7 +252,7 @@ var lnSearchExplorer = {};
 				let title = opts.level === 1 ? opts.section.config.title : opts.name;
 				let ordinal = 1;
 				if (opts.level > 1) {
-					let m = this.data.searchState.metaSearch.results.get(opts.key.toLowerCase());
+					let m = this.data.searchState.metaSearch.getSectionMeta(opts.key.toLowerCase());
 					if (m) {
 						title = m.linkTitle;
 						if (m.ordinal) {

--- a/_vendor/github.com/bep/linodedocs/assets/js/main/navigation/init.js
+++ b/_vendor/github.com/bep/linodedocs/assets/js/main/navigation/init.js
@@ -7,6 +7,8 @@ var lnInitController = {};
 		(typeof LN_DEBUG !== 'undefined' && LN_DEBUG) || 0 ? console.log.bind(console, '[init]') : function() {};
 
 	ctx.New = function() {
+		const dispatcher = lnSearchEventDispatcher.New();
+
 		return {
 			// init will run after Alpine has made its initial updates to the DOM,
 			// and this is the init function for the last component on the page.
@@ -28,6 +30,9 @@ var lnInitController = {};
 							}
 						} catch (e) {}
 					}
+
+					// Send the static page info to components who need it.
+					dispatcher.sendPageInfo(lnPageInfo);
 				};
 			}
 		};

--- a/_vendor/github.com/bep/linodedocs/assets/js/main/search/dispatcher.js
+++ b/_vendor/github.com/bep/linodedocs/assets/js/main/search/dispatcher.js
@@ -31,6 +31,10 @@ var lnSearchEventDispatcher = {};
 			// Event with the initial blank search result.
 			EVENT_SEARCHRESULT_BLANK: 'search:results-blank',
 
+			// Event with the initial data structure. This will not contain any Algolia search results,
+			// but may contain other metadata.
+			EVENT_SEARCHRESULT_INITIAL: 'search:results-initial',
+
 			// Event that register a named search to be refreshed on any filter changes..
 			EVENT_SUBSCRIBE: 'search:subscribe',
 
@@ -89,6 +93,11 @@ var lnSearchEventDispatcher = {};
 			broadCastFilteredSearchResult: function(searchresult, toEvent) {
 				debug('broadCastFilteredSearchResult', searchresult, 'to', toEvent);
 				sendEvent(toEvent, searchresult);
+			},
+
+			sendPageInfo: function(pageInfo) {
+				debug('sendPageInfo', pageInfo);
+				sendEvent('ln:page-info', pageInfo);
 			},
 
 			events: events

--- a/_vendor/github.com/bep/linodedocs/assets/js/main/search/search.js
+++ b/_vendor/github.com/bep/linodedocs/assets/js/main/search/search.js
@@ -72,7 +72,6 @@ class Searcher {
 		handleData,
 		handleError = (error) => {
 			this.onError(error);
-			throw error;
 		}
 	) {
 		fetch(this.urlQueries, {
@@ -119,11 +118,9 @@ class Searcher {
 					hit.section = hit.section.toLowerCase();
 				}
 
-				if (self.searchState.metaSearch.results.get) {
-					let m = self.searchState.metaSearch.results.get(hit.section);
-					if (m) {
-						hit.sectionTitle = m.linkTitle;
-					}
+				let m = self.searchState.metaSearch.getSectionMeta(hit.section);
+				if (m) {
+					hit.sectionTitle = m.linkTitle;
 				}
 
 				hit.titleHighlighted =
@@ -467,6 +464,9 @@ class Searcher {
 				if (b) {
 					this.loadingState = searchItemLoadingStates.INITIAL;
 					this.publish = false;
+					if (this.hugoData) {
+						this.hugoData.loadingState = searchItemLoadingStates.INITIAL;
+					}
 				}
 				return b;
 			};
@@ -522,11 +522,56 @@ class Searcher {
 				}),
 				metaSearch: newSearchItem({
 					name: 'meta',
+					getSectionMeta: function(key) {
+						// First look in the Hugo data
+						let m = this.hugoData.data.get(key);
+						if (m) {
+							return m;
+						}
+						// Then look in the Algolia data.
+						if (!this.results.get) {
+							return null;
+						}
+						return this.results.get(key);
+					},
+					hugoData: {
+						loadingState: searchItemLoadingStates.INITIAL,
+						data: new Map(),
+						loadIfNotLoaded: function() {
+							if (this.loadingState > searchItemLoadingStates.INITIAL) {
+								return;
+							}
+							this.loadingState = searchItemLoadingStates.LOADING;
+							var self = this;
+							fetch('/docs/data/sections/index.json', {})
+								.then((response) => response.json())
+								.then((data) => {
+									self.data = data.reduce(function(m, item) {
+										item.href = router.hrefSection(item.objectID);
+										m.set(item.objectID, item);
+										return m;
+									}, new Map());
+									self.loadingState = searchItemLoadingStates.LOADED;
+									dispatcher.broadCastSearchResult(s, dispatcher.events.EVENT_SEARCHRESULT_INITIAL);
+								})
+								.catch(function(error) {
+									console.warn(error);
+									self.loadingState = searchItemLoadingStates.INITIAL;
+								});
+						}
+					},
+
 					query: {
 						requests: [
 							{
 								indexName: searchConfig.meta_index,
-								params: 'query=&hitsPerPage=600'
+								params: 'query=&hitsPerPage=600',
+								// We load the Hugo data from the published JSON to save Algolia queries on
+								// load (for the breadcrumbs).
+								// This filter is just to save some bytes for when the Algolia data IS loaded,
+								// as the guides is the most populated section tree.
+								filters:
+									'NOT section:guides AND NOT section:api AND NOT section:products AND NOT section:content AND NOT section:development'
 							}
 						]
 					}
@@ -540,6 +585,9 @@ class Searcher {
 				staticSearchRequestsResults: [],
 				staticSearchCache: new Map()
 			};
+
+			// Load metadata from /docs/data/sections/index.json
+			s.metaSearch.hugoData.loadIfNotLoaded();
 
 			s.reset = function() {
 				this.mainSearch.reset();
@@ -703,6 +751,8 @@ class Searcher {
 				let opts = arg || {};
 				debug('search', opts);
 
+				this.searchState.metaSearch.hugoData.loadIfNotLoaded();
+
 				var event = opts.event;
 				if (event === dispatcher.events.EVENT_SEARCHRESULT_BLANK && this.searchState.blankSearch.isLoading()) {
 					// One is already in progress.
@@ -764,6 +814,8 @@ class Searcher {
 				var self = this;
 				var searcher = newSearcher(normalizeHit(self), function(err) {
 					self.searchState.reset();
+					// TODO(bep) error status in view
+					throw err;
 				});
 
 				if (this.searchState.staticSearchRequests.length > 0) {

--- a/_vendor/github.com/bep/linodedocs/assets/js/main/sections/home/home.js
+++ b/_vendor/github.com/bep/linodedocs/assets/js/main/sections/home/home.js
@@ -38,6 +38,8 @@ var lnHome = {};
 				throw 'items must be provided';
 			}
 
+			debug('newPager', el, items);
+
 			let pager = {
 				index: 0, // current page, zero based.
 				numPages: 0, // The total number of pages.
@@ -176,7 +178,7 @@ var lnHome = {};
 					throw 'missing data';
 				}
 
-				let meta = results.metaSearch.results;
+				let meta = results.metaSearch;
 				let sectionsResults = results.blankSearch.results;
 
 				debug('receiveCommonData: meta', meta);
@@ -187,7 +189,7 @@ var lnHome = {};
 
 				for (var k in productsFacets) {
 					let count = productsFacets[k];
-					let m = meta.get(k);
+					let m = meta.getSectionMeta(k);
 					if (m) {
 						productsItems.push({
 							title: m.title,
@@ -201,9 +203,9 @@ var lnHome = {};
 
 				debug('receiveCommonData: productsItems', productsItems);
 
-				this.data.sectionMeta['products'] = meta.get('products');
+				this.data.sectionMeta['products'] = meta.getSectionMeta('products');
 				sectionNames.forEach((name) => {
-					this.data.sectionMeta[name] = meta.get(name);
+					this.data.sectionMeta[name] = meta.getSectionMeta(name);
 				});
 				let el = this.$refs[`carousel-products`];
 				this.data.productsTiles = newPager(productsStripPageSize, el, productsItems, 0.5);

--- a/_vendor/github.com/bep/linodedocs/assets/js/main/sections/sections/list.js
+++ b/_vendor/github.com/bep/linodedocs/assets/js/main/sections/sections/list.js
@@ -212,8 +212,8 @@ var lnSectionsController = {};
 				}
 
 				this.data.result = ns.results[0];
-				this.data.sectionMetaMap = data.metaSearch.results;
-				let sectionMeta = this.data.sectionMetaMap.get(this.key);
+				this.data.sectionMetaMap = data.metaSearch;
+				let sectionMeta = this.data.sectionMetaMap.getSectionMeta(this.key);
 				if (sectionMeta) {
 					this.data.meta = sectionMeta;
 				} else {
@@ -249,11 +249,14 @@ var lnSectionsController = {};
 				var self = this;
 				var assembleSections = function(parts) {
 					let sections = [];
+					if (!parts) {
+						return sections;
+					}
 					let sectionKeys = [];
 					for (let section of parts) {
 						sectionKeys.push(section);
 						let key = sectionKeys.join(' > ');
-						let sm = self.data.sectionMetaMap.get(key);
+						let sm = self.data.sectionMetaMap.getSectionMeta(key);
 						if (sm) {
 							sections.push(sm);
 						}
@@ -276,7 +279,7 @@ var lnSectionsController = {};
 				}
 
 				let newSection = function(key, value) {
-					let m = self.data.sectionMetaMap.get(key);
+					let m = self.data.sectionMetaMap.getSectionMeta(key);
 					let s = { key, title: '', linkTitle: '', thumbnail: '', count: value };
 					s.href = hrefFactory.hrefSection(key);
 

--- a/_vendor/github.com/bep/linodedocs/layouts/content/list.html
+++ b/_vendor/github.com/bep/linodedocs/layouts/content/list.html
@@ -1,3 +1,7 @@
+{{ define "head-meta-main" }}
+  {{/* The title and SEO meta is set (see blog-article.js) client side, but we need a non-whitespace string here to avoid getting the defaults. */}}
+  <!-- -->
+{{ end }}
 {{ define "main" }}
   <div class="blog-article" x-data="lnArticleController.New(lnSearchConfig)" x-init="() => {  init() }">
     {{ partial "components/error.html" . }}
@@ -28,4 +32,3 @@
     </div>
   </div>
 {{ end }}
- 

--- a/_vendor/github.com/bep/linodedocs/layouts/data/metadata_sections.json
+++ b/_vendor/github.com/bep/linodedocs/layouts/data/metadata_sections.json
@@ -1,4 +1,5 @@
 {{- $sections := where site.Pages "Kind" "section" -}}
+{{- $sections = where $sections "Section" "not in" (slice "content" "development") -}}
 {{- $list := slice -}}
 {{- range $i, $e := $sections -}}
 {{- $thumb := "" -}}

--- a/_vendor/github.com/bep/linodedocs/layouts/partials/sections/after-body-start.html
+++ b/_vendor/github.com/bep/linodedocs/layouts/partials/sections/after-body-start.html
@@ -1,5 +1,5 @@
 {{/* TODO(bep) improve this with the upcoming improvements in js.Build. */}}
-{{ $pageInfo := dict "href" .RelPermalink "permalink" .Permalink "linkTitle" .LinkTitle "title" .Title "isStatic" (not (or (eq .Type "content") (eq .Type "sections")) ) "sectionsEntries" .SectionsEntries  }}
+{{ $pageInfo := dict "href" .RelPermalink "permalink" .Permalink "linkTitle" .LinkTitle "title" .Title "sectionsEntries" .SectionsEntries "type" .Type "kind" .Kind }}
 {{ $pageInfoJSON := $pageInfo | jsonify }}
 <script data-cfasync="false">
   {{/* This global is used by the breadcrumbs builder, Disqus and possibly others. */}}

--- a/_vendor/github.com/bep/linodedocs/layouts/partials/sections/navigation/breadcrumbs.html
+++ b/_vendor/github.com/bep/linodedocs/layouts/partials/sections/navigation/breadcrumbs.html
@@ -1,7 +1,8 @@
 {{ $p := .page }}
 {{ $wrap := .wrap }}
-<nav class="breadcrumbs text-sm w-full" aria-label="breadcrumbs" x-data="lnBreadcrumbs.New(lnSearchConfig)"
-    x-init="init(lnPageInfo)" @search:results-blank.document="receiveData($event.detail);">
+<nav class="breadcrumbs text-sm w-full" aria-label="breadcrumbs" x-data="lnBreadcrumbs.New(lnSearchConfig)" id="breadcrumbs-{{ $wrap }}"
+    @search:results-blank.document="receiveData($event.detail);" @search:results-initial.document="receiveData($event.detail);"  
+    @ln:page-info.document="receivePageInfo($event.detail);" @turbolinks:before-render.document="onTurbolinksBeforeRender();" data-turbolinks-permanent>
   <ol class="list-none pb-0 inline-flex {{if $wrap }}flex-wrap {{end}}w-full -mt-2">
     <li class="flex items-center mt-2">
       <a class="max-w-32 truncate" href="{{ site.Home.RelPermalink }}">
@@ -19,18 +20,22 @@
           </div>
         </div>
       </a>
-      <template x-if="data.breadcrumbs.length > 0">
+      <template x-if="data.breadcrumbs.sections.length > 0">
         {{ template "breadcrumbs-arrow" . }}
       </template>
     </li>
-    <template x-for="(b, i) in data.breadcrumbs" :key="b">
+    <template x-for="(b, i) in data.breadcrumbs.sections" :key="b">
       <li class="flex items-center mt-2">
         <a x-text="b.linkTitle" :href="b.href"></a>
-        <template x-if="i < (data.breadcrumbs.length -1 )">
+        <template x-if="i < (data.breadcrumbs.sections.length - 1)">
           {{ template "breadcrumbs-arrow" . }}
         </template>
       </li>
     </template>
+    <li class="flex items-center mt-2" x-show="data.breadcrumbs.page.kind === 'page'">
+      {{ template "breadcrumbs-arrow" . }}
+      <a x-text="data.breadcrumbs.page.linkTitle" :href="data.breadcrumbs.page.href"></a>
+    </li>
   </ol>
 </nav>
 

--- a/_vendor/github.com/linode/linode-website-partials/footer.css
+++ b/_vendor/github.com/linode/linode-website-partials/footer.css
@@ -114,6 +114,10 @@
   padding-bottom: 56px;
 }
 
+.c-site-footer__primary .o-layout__colset {
+  max-width: none;
+}
+
 .c-site-footer__primary .c-identity {
   margin-top: 32px;
 }

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,5 +1,5 @@
-# github.com/bep/linodedocs v0.0.0-20201102172434-98f06c13f3f1
-# github.com/linode/linode-website-partials v0.0.0-20201027160459-020df188fe47
+# github.com/bep/linodedocs v0.0.0-20201111153041-b12904ff176a
+# github.com/linode/linode-website-partials v0.0.0-20201106150449-790c71d060a5
 # github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.7.1
 # github.com/alpinejs/alpine v2.7.0+incompatible
 # github.com/SimoTod/alpine-turbolinks-adapter v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/bep/hugo-jslibs/alpinejs v0.5.14 // indirect
 	github.com/bep/hugo-jslibs/instantpage v0.0.0-20200822093604-7b6e0aaba587 // indirect
 	github.com/bep/hugo-jslibs/turbolinks v0.1.2 // indirect
-	github.com/bep/linodedocs v0.0.0-20201102172434-98f06c13f3f1
+	github.com/bep/linodedocs v0.0.0-20201111153041-b12904ff176a
 	github.com/linode/linode-api-docs/v4 v4.79.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/bep/linodedocs v0.0.0-20201029131522-c656d102af90 h1:4M/jEnVKdnSgk7JZ
 github.com/bep/linodedocs v0.0.0-20201029131522-c656d102af90/go.mod h1:Jaf9UDYxVmfTOesVMNvyBGU+0Q78L9Or7hDEN1I7gAc=
 github.com/bep/linodedocs v0.0.0-20201102172434-98f06c13f3f1 h1:VU+omU5athrlCiZ68GYF4nCs9MjAYjmNFTRZvE4b2P0=
 github.com/bep/linodedocs v0.0.0-20201102172434-98f06c13f3f1/go.mod h1:Jaf9UDYxVmfTOesVMNvyBGU+0Q78L9Or7hDEN1I7gAc=
+github.com/bep/linodedocs v0.0.0-20201111153041-b12904ff176a h1:fVHJpf21OIm1JUJ0sPixnJ3HxxBS8oWaKMwuvV8Z4oc=
+github.com/bep/linodedocs v0.0.0-20201111153041-b12904ff176a/go.mod h1:Atubll9MuX2IrA54MDZOge85Vj1VI3uLHAp0mPQEaT8=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.5.0/go.mod h1:XvAGp/0tQ8bZpoCcM6rdx1NbzZUy3/KtetedtdgaNek=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.6.0/go.mod h1:QB5IEnFYPAWpMEBg4tF1OW0xzI1O68QNWnqfPuUkpnU=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.7.0/go.mod h1:e1pgFkSbGd2EzKUbAuXHSnVqMX2suwsSklPZfDXeQkg=
@@ -198,4 +200,5 @@ github.com/linode/linode-website-partials v0.0.0-20201001182036-fe8965a45b3c h1:
 github.com/linode/linode-website-partials v0.0.0-20201001182036-fe8965a45b3c/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/linode/linode-website-partials v0.0.0-20201008204609-a59453d99ac9/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/linode/linode-website-partials v0.0.0-20201027160459-020df188fe47/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
+github.com/linode/linode-website-partials v0.0.0-20201106150449-790c71d060a5/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/turbolinks/turbolinks-source-gem v5.2.0+incompatible/go.mod h1:Cl0Br9tUXkQvxumVNGTvyaa7dqpFC2kPMrsS0Ttc94U=

--- a/scripts/generate_permanent_redirects_for_nginx.sh
+++ b/scripts/generate_permanent_redirects_for_nginx.sh
@@ -6,9 +6,11 @@
 # Or, optionally:
 #    BASE_URL=<base URL of site> ./generate_permanent_redirects_for_nginx.sh
 #
-# BASE_URL is set to '$scheme://$http_host/docs' if it is not found as
-# an environment variable. This is what you should use in most cases
-# so you probably don't usually need to set it yourself.
+# BASE_URL is set to '{{ base_url }}' by default in the script, but you can
+# override this value by setting it as an environment variable. The value of
+# '{{ base_url }}' is used so that it can be updated by Salt pillar on the
+# web boxes. If you are running this script to create a new redirects.conf
+# on the web boxes, then use this default value.
 #
 # This script iterates through the public/ folder and searches for any pages
 # created from Hugo's `aliases` frontmatter. It generates an NGINX permanent
@@ -21,7 +23,7 @@
 
 set -eo pipefail
 
-[[ -z "$BASE_URL" ]] && { BASE_URL='$scheme://$http_host/docs'; }
+[[ -z "$BASE_URL" ]] && { BASE_URL='{{ base_url }}'; }
 
 > ../redirects.conf
 


### PR DESCRIPTION
Theme updates:
- Breadcrumb fixes (breadcrumbs now appear fully correct after a 'hard page refresh' for product docs/guides/api/blogs)
- SEO head information for blogs/resources/apps (rel canonical link, meta descriptions, og:descriptions, etc)
- Update linode-website-partials (full-width footer style change)

Update generate_permanent_redirects_for_nginx.sh to fix HTTPS 301 issue


---

For any reviewers, a couple known issues that will be fixed separately:
- Blogs have full breadcrumbs, but not resources or apps
- There's some funny URL encoding happening inside the breadcrumb string for some characters; see the dash in the title of this blog post for example:
<img width="920" alt="Screen Shot 2020-11-11 at 10 51 49 AM" src="https://user-images.githubusercontent.com/255491/98833462-0eb6ca80-240c-11eb-8c40-1b01c82775b0.png">
