### PR TITLE
[Update] Add New Cloud Firewall Rules Shortguide

### DIFF
--- a/docs/guides/platform/cloud-firewall/add-new-cloud-firewall-rules-shortguide/index.md
+++ b/docs/guides/platform/cloud-firewall/add-new-cloud-firewall-rules-shortguide/index.md
@@ -47,29 +47,3 @@ Any newly added rules do not take effect until you **Apply Changes** to the Fire
 {{</ note >}}
 
     ![Apply your changes to the Firewall.](apply-your-changes-to-the-firewall.png "Apply your changes to the Firewall.")
-
-### Edit Cloud Firewall Rules
-
-Follow the steps in this section to edit predefined and custom Firewall Rules.
-
-1. Log into your [Linode Cloud Manager](https://cloud.linode.com/) and select **Firewalls** from the navigation menu.
-
-1. From the **Firewalls** listing page, click on the Firewall whose rules you'd like to edit. This takes you to the Firewall's **Rules** page.
-
-1. Click on the ***more options ellipsis*** corresponding to the rule you'd like to edit and select **Edit** from the dropdown menu.
-
-    ![Select edit from the dropdown menu.](edit-this-firewall-rule.png "Select edit from the dropdown menu.")
-
-1. From the **Edit Rule** drawer, update the rule's configurations as needed.
-
-1. Click on the **Edit Rule** button to save your changes and apply them to the rule. If you would like to edit any additional rules, repeat the process outlined in this section.
-
-    ![Save your Firewall rule edits.](edit-firewall-rule.png "Save your Firewall rule edits.")
-
-1. When you are done editing your Firewall rules, click on the **Apply Changes** button on the **Rules** page.
-
-    {{< note >}}
-Any edits made to rules do not take effect until you **Apply Changes** to the Firewall.
-{{</ note >}}
-
-    ![Apply your edit rule changes to the Firewall.](apply-edit-rule-changes.png "Apply your edit rule changes to the Firewall.")


### PR DESCRIPTION
Remove edit section from Add New Rules shortguide to prevent duplication. Edit has it's own separate shortguide