### PR TITLE
Hotfix v1.6.3

### DIFF
--- a/_vendor/github.com/bep/linodedocs/layouts/partials/sections/head.html
+++ b/_vendor/github.com/bep/linodedocs/layouts/partials/sections/head.html
@@ -2,6 +2,9 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0,user-scalable=0" />
+{{ if .Param "noindex" }}
+  <meta name="robots" content="noindex" />
+{{ end }}
 <link rel="shortcut icon" href='{{ "favicon.ico" | relURL }}' type="image/x-icon">
 {{ if hugo.IsProduction }}
   <!-- Google Tag Manager -->
@@ -19,4 +22,4 @@
   <!-- End Google Tag Manager -->
 {{ end }}
 
-{{ partialCached "sections/head-src.html" . "-"}} 
+{{ partialCached "sections/head-src.html" . "-"}}

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bep/linodedocs v0.0.0-20201111153041-b12904ff176a
+# github.com/bep/linodedocs v0.0.0-20201113200012-d9e9d7cb74fa
 # github.com/linode/linode-website-partials v0.0.0-20201106150449-790c71d060a5
 # github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.7.1
 # github.com/alpinejs/alpine v2.7.0+incompatible

--- a/ci/yaml_rules.json
+++ b/ci/yaml_rules.json
@@ -173,6 +173,12 @@
     "type": "list",
     "description": "List of operating systems to generate buttons"
   },
+  "noindex": {
+    "elements": false,
+    "required": false,
+    "type": "text",
+    "description": "Prevent search engines from indexing a guide."
+  },
   "promo_code_amount": {
       "elements": false,
 	  "required": false,

--- a/docs/guides/databases/mariadb/mariadb-setup-debian/index.md
+++ b/docs/guides/databases/mariadb/mariadb-setup-debian/index.md
@@ -24,6 +24,7 @@ deprecated: true
 tags: ["debian","mariadb","database"]
 _build:
   list: false
+noindex: true
 ---
 
 ![How to Set Up MariaDB on Debian 9](how-to-set-up-mariadb-on-debian-smg.jpg)

--- a/docs/guides/platform/disk-images/tokyo2-migration/index.md
+++ b/docs/guides/platform/disk-images/tokyo2-migration/index.md
@@ -15,6 +15,7 @@ tags: ["linode platform"]
 aliases: ['/platform/tokyo2-migration/']
 _build:
   list: false
+noindex: true
 ---
 
 In November 2016, Linode [announced and opened](https://blog.linode.com/2016/11/21/new-linode-datacenter-tokyo-2/) the Tokyo 2 data center. This is the second facility operated by Linode in the Tokyo region. Linode is now making preparations to retire the original Tokyo 1 facility. All Linodes hosted in this data center will be migrated to Tokyo 2. This guide is written to prepare customers for this migration and to make migrating easier.

--- a/docs/guides/platform/manager/manually-enable-elastic-ip-on-your-linode/index.md
+++ b/docs/guides/platform/manager/manually-enable-elastic-ip-on-your-linode/index.md
@@ -8,6 +8,7 @@ og_description: 'This guide provides Linode users with steps to manually enable 
 keywords: ['networking','Elastic IP','keywords','and key phrases']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2020-06-02
+noindex: true
 modified_by:
   name: Linode
 title: "How to Manually Enable Elastic IP on your Linode"

--- a/docs/guides/quick-answers/linode-platform/enable-backups-on-a-linode/index.md
+++ b/docs/guides/quick-answers/linode-platform/enable-backups-on-a-linode/index.md
@@ -14,6 +14,7 @@ title: Enable Backups on a Linode
 cloud_manager_link: platform/disk-images/linode-backup-service/#enable-the-backup-service
 _build:
   list: false
+noindex: true
 tags: ["linode platform","cloud manager"]
 aliases: ['/quick-answers/linode-platform/enable-backups-on-a-linode/']
 ---

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/bep/hugo-jslibs/alpinejs v0.5.14 // indirect
 	github.com/bep/hugo-jslibs/instantpage v0.0.0-20200822093604-7b6e0aaba587 // indirect
 	github.com/bep/hugo-jslibs/turbolinks v0.1.2 // indirect
-	github.com/bep/linodedocs v0.0.0-20201111153041-b12904ff176a
+	github.com/bep/linodedocs v0.0.0-20201113200012-d9e9d7cb74fa
 	github.com/linode/linode-api-docs/v4 v4.79.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/bep/linodedocs v0.0.0-20201102172434-98f06c13f3f1 h1:VU+omU5athrlCiZ6
 github.com/bep/linodedocs v0.0.0-20201102172434-98f06c13f3f1/go.mod h1:Jaf9UDYxVmfTOesVMNvyBGU+0Q78L9Or7hDEN1I7gAc=
 github.com/bep/linodedocs v0.0.0-20201111153041-b12904ff176a h1:fVHJpf21OIm1JUJ0sPixnJ3HxxBS8oWaKMwuvV8Z4oc=
 github.com/bep/linodedocs v0.0.0-20201111153041-b12904ff176a/go.mod h1:Atubll9MuX2IrA54MDZOge85Vj1VI3uLHAp0mPQEaT8=
+github.com/bep/linodedocs v0.0.0-20201113200012-d9e9d7cb74fa h1:AFAJqYcCMhJ7yde+ngHRQ87xYrIOo2O/2QHDtKwqv5w=
+github.com/bep/linodedocs v0.0.0-20201113200012-d9e9d7cb74fa/go.mod h1:Atubll9MuX2IrA54MDZOge85Vj1VI3uLHAp0mPQEaT8=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.5.0/go.mod h1:XvAGp/0tQ8bZpoCcM6rdx1NbzZUy3/KtetedtdgaNek=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.6.0/go.mod h1:QB5IEnFYPAWpMEBg4tF1OW0xzI1O68QNWnqfPuUkpnU=
 github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.7.0/go.mod h1:e1pgFkSbGd2EzKUbAuXHSnVqMX2suwsSklPZfDXeQkg=


### PR DESCRIPTION
* Add frontmatter `noindex` to theme (adds `<meta name="robots" content="noindex" />`) to a page's `head` when present
* Add noindex to Elastic IP guide
* Add noindex to ci yaml rules
* Rebuild theme reference