### PR TITLE
Set enableGitInfo = true in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,8 @@ timeout = "2m"
 
 disqusShortname="linode-1"
 
+enableGitInfo = true
+
 [outputs]
 # The JSON is for the search index. We build this on every build to make sure we have the image thumbnails in sync.
 home = ["HTML", "JSON", "RSS"]


### PR DESCRIPTION
This change makes the .Lastmod Hugo variable reflect the last commit date in Git. This was being used in the old docs site, but was lost in the migration to the new docs UI.

This should be merged alongside https://github.com/bep/linodedocs/pull/30. If we wanted to wait to merge that other PR, we could still merge this PR more immediately.