### PR TITLE
Include caution messages for Backup deletion when removing services

### DIFF
--- a/docs/guides/platform/billing-and-support/manage-billing-in-cloud-manager/index.md
+++ b/docs/guides/platform/billing-and-support/manage-billing-in-cloud-manager/index.md
@@ -86,6 +86,16 @@ Our services are provided without a contract, so you're free to remove services 
 1.  To remove a NodeBalancer from your account, select **NodeBalancers** from the sidebar links. Open the menu of the NodeBalancer you would like to remove, then select **Remove**.
 1.  To remove the Linode Backup Service, select **Linodes** from the sidebar links. Select the corresponding Linode. Under the **Backups** tab click the **Cancel Backups** button at the bottom of the page.
 
+{{< caution >}}
+Removing a Linode from your account will make its data irretrievable. This include the backups of it that you have created through [our Backup Service](/docs/platform/disk-images/linode-backup-service/), including Manual Snapshots.
+
+If you would like to preserve your Linode's data before removing it from your account, you will need to create an external backup. You may use the suggestions in our [Backing Up Your Data](/docs/guides/backing-up-your-data/) guide for some examples of how to do this.
+
+When removing a Linode from your account that has been active for at least 24 hours, our systems will automatically create a [Linode Image](/docs/guides/linode-images/) out of the backup. You may use [this guide](https://www.linode.com/community/questions/17441/how-do-i-restore-a-deleted-linode) from [our Community Questions site](https://www.linode.com/community/questions/) to restore this backup.
+
+There is a very small chance that Linode Support can restore your data outside of these circumstances. The sooner you reach out to Linode Support, the more likely this can occur. Please open up [a Support ticket](https://cloud.linode.com/support/tickets) to explore this possibility.
+{{</ caution >}}
+
 ## Cancelling Your Account
 
 {{< content "cancel-your-account-shortguide" >}}

--- a/docs/guides/platform/billing-and-support/manage-billing-in-cloud-manager/index.md
+++ b/docs/guides/platform/billing-and-support/manage-billing-in-cloud-manager/index.md
@@ -87,13 +87,13 @@ Our services are provided without a contract, so you're free to remove services 
 1.  To remove the Linode Backup Service, select **Linodes** from the sidebar links. Select the corresponding Linode. Under the **Backups** tab click the **Cancel Backups** button at the bottom of the page.
 
 {{< caution >}}
-Removing a Linode from your account will make its data irretrievable. This include the backups of it that you have created through [our Backup Service](/docs/platform/disk-images/linode-backup-service/), including Manual Snapshots.
+Removing a Linode from your account makes its data irretrievable. This includes the backups of it that you have created through [our Backup Service](/docs/guides/linode-backup-service/), including Manual Snapshots.
 
-If you would like to preserve your Linode's data before removing it from your account, you will need to create an external backup. You may use the suggestions in our [Backing Up Your Data](/docs/guides/backing-up-your-data/) guide for some examples of how to do this.
+If you would like to preserve your Linode's data before removing it from your account, you need to create an external backup. You may use the suggestions in our [Backing Up Your Data](/docs/guides/backing-up-your-data/) guide for some examples of how to do this.
 
-When removing a Linode from your account that has been active for at least 24 hours, our systems will automatically create a [Linode Image](/docs/guides/linode-images/) out of the backup. You may use [this guide](https://www.linode.com/community/questions/17441/how-do-i-restore-a-deleted-linode) from [our Community Questions site](https://www.linode.com/community/questions/) to restore this backup.
+When removing a Linode from your account that has been active for at least 24 hours, our systems automatically create a [Linode Image](/docs/guides/linode-images/) from the backup. You may use [this guide](https://www.linode.com/community/questions/17441/how-do-i-restore-a-deleted-linode) from [our Community Questions site](https://www.linode.com/community/questions/) to restore this backup.
 
-There is a very small chance that Linode Support can restore your data outside of these circumstances. The sooner you reach out to Linode Support, the more likely this can occur. Please open up [a Support ticket](https://cloud.linode.com/support/tickets) to explore this possibility.
+There is a very small chance that Linode Support can restore your data outside of these circumstances. The sooner you reach out to Linode Support, the more likely this can occur. Please open [a Support ticket](https://cloud.linode.com/support/tickets) to explore this possibility.
 {{</ caution >}}
 
 ## Cancelling Your Account

--- a/docs/guides/platform/disk-images/linode-backup-service/index.md
+++ b/docs/guides/platform/disk-images/linode-backup-service/index.md
@@ -82,6 +82,12 @@ This section shows how to restore a backup to a [new](/docs/platform/disk-images
 
 You can cancel the Backup Service at any time. From your Linode's details page, choose the **Backups** tab and click the **Cancel Backups** link at the bottom of the page. Cancelling the service will remove your saved backups from the Linode platform.
 
+{{< caution >}}
+Cancelling your Backup Service will irretrievably delete all of your Linode's Backups, including its manual Snapshot.
+
+To preserve this data, you will need to back up your data independently of our Backup Service before cancelling it. You may consult the suggestions in [Backing Up Your Data](/docs/guides/backing-up-your-data/) for more information on how to do this.
+{{</ caution >}}
+
 ## Limitations
 
 There are some limitations to what the Linode Backup Service can back up. Here are some things you should be aware of:
@@ -89,7 +95,7 @@ There are some limitations to what the Linode Backup Service can back up. Here a
 -   The Backup Service must be able to mount your disks. If you've created partitions, configured full disk encryption, or made other changes that prevent us from mounting the disk as a filesystem, you will likely not be able to use the Linode Backup Service. The backup system operates at the file level, not at the block level.
 -    Because the Backup Service is file-based, the number of files stored on disk will impact both the time it takes for backups and restores to complete, and your ability to successfully take and restore backups. Customers who need to permanently store a large number of files may want to archive bundles of smaller files into a single file, or consider other backup services.
 
-    {{< note >}}
+{{< note >}}
 The percentage of customers who may run into this limitation is low. If you are not sure if this limitation applies to you, please [contact Linode Support](/docs/platform/billing-and-support/support/#contacting-linode-support).
 {{< /note >}}
 

--- a/docs/guides/platform/disk-images/linode-backup-service/index.md
+++ b/docs/guides/platform/disk-images/linode-backup-service/index.md
@@ -64,7 +64,7 @@ The daily and weekly backups are automatically erased when a new backup is perfo
 
 ## Restore from a Backup
 
-This section shows how to restore a backup to a [new](/docs/platform/disk-images/linode-backup-service/#restore-to-a-new-linode) Linode, or to an [existing](/docs/platform/disk-images/linode-backup-service/#restore-to-an-existing-linode) Linode.
+This section shows how to restore a backup to a [new](/docs/guides/linode-backup-service/#restore-to-a-new-linode) Linode, or to an [existing](/docs/guides/linode-backup-service/#restore-to-an-existing-linode) Linode.
 
 ### Restore to a New Linode
 
@@ -80,25 +80,25 @@ This section shows how to restore a backup to a [new](/docs/platform/disk-images
 
 ## Cancel the Backup Service
 
-You can cancel the Backup Service at any time. From your Linode's details page, choose the **Backups** tab and click the **Cancel Backups** link at the bottom of the page. Cancelling the service will remove your saved backups from the Linode platform.
+You can cancel the Backup Service at any time. From your Linode's details page, choose the **Backups** tab and click the **Cancel Backups** link at the bottom of the page. Cancelling the service removes your saved backups from the Linode platform.
 
 {{< caution >}}
-Cancelling your Backup Service will irretrievably delete all of your Linode's Backups, including its manual Snapshot.
+Cancelling your Backup Service irretrievably deletes all of your Linode's Backups, including its manual Snapshot.
 
-To preserve this data, you will need to back up your data independently of our Backup Service before cancelling it. You may consult the suggestions in [Backing Up Your Data](/docs/guides/backing-up-your-data/) for more information on how to do this.
+To preserve this data, you need to back up your data independently from the Backup Service before cancelling it. You may consult the suggestions in [Backing Up Your Data](/docs/guides/backing-up-your-data/) for more information on how to do this.
 {{</ caution >}}
 
 ## Limitations
 
 There are some limitations to what the Linode Backup Service can back up. Here are some things you should be aware of:
 
--   The Backup Service must be able to mount your disks. If you've created partitions, configured full disk encryption, or made other changes that prevent us from mounting the disk as a filesystem, you will likely not be able to use the Linode Backup Service. The backup system operates at the file level, not at the block level.
--    Because the Backup Service is file-based, the number of files stored on disk will impact both the time it takes for backups and restores to complete, and your ability to successfully take and restore backups. Customers who need to permanently store a large number of files may want to archive bundles of smaller files into a single file, or consider other backup services.
+-   The Backup Service must be able to mount your disks. If you've created partitions, configured full disk encryption, or made other changes that prevent us from mounting the disk as a file system, you likely can not use the Linode Backup Service. The backup system operates at the file level, not at the block level.
+-    Because the Backup Service is file-based, the number of files stored on disk impacts both the time it takes for backups and restores to complete, and your ability to successfully take and restore backups. Customers who need to permanently store a large number of files may want to archive bundles of smaller files into a single file, or consider other backup services.
 
 {{< note >}}
-The percentage of customers who may run into this limitation is low. If you are not sure if this limitation applies to you, please [contact Linode Support](/docs/platform/billing-and-support/support/#contacting-linode-support).
+The percentage of customers who may run into this limitation is low. If you are not sure if this limitation applies to you, please [contact Linode Support](/docs/guides/support/#contacting-linode-support).
 {{< /note >}}
 
--   Backups taken of ext4 or ext3 filesystems will be restored as ext4. Backups taken of other mountable filesystem types will have their contents restored using ext4.
--   Files that have been modified but have the same size and modify time will not be considered "changed" during a subsequent backup. ACLs and extended attributes are *not* tracked.
--   The Backup Service uses a snapshot of your disks to take consistent backups while your Linode is running. This method is very reliable, but can fail to properly back up the data files for database services like MySQL. If the snapshot occurs during a transaction, the database's files may be backed up in an unclean state. We recommend scheduling routine dumps of your database to a file on the filesystem. The resulting file will then be backed up, allowing you to restore the contents of the database if you need to restore from a backup.
+-   Backups taken of ext4 or ext3 filesystems are restored as ext4. Backups taken of other mountable file system types have their contents restored using ext4.
+-   Files that have been modified but have the same size and modify time are not be considered "changed" during a subsequent backup. ACLs and extended attributes are *not* tracked.
+-   The Backup Service uses a snapshot of your disks to take consistent backups while your Linode is running. This method is very reliable, but can fail to properly back up the data files for database services like MySQL. If the snapshot occurs during a transaction, the database's files may be backed up in an unclean state. We recommend scheduling routine dumps of your database to a file on the filesystem. The resulting file is then be backed up, allowing you to restore the contents of the database if you need to restore from a backup.


### PR DESCRIPTION
Removing a Linode's backups or the Linode itself will delete all
backups generated by the Linode Backup Service, including snapshots.

There is also a small formatting change in this commit on the Backup
Service guide to correct monospaced text that was appearing on a note.