### PR TITLE
[Update] Xen Guides

### DIFF
--- a/docs/guides/all-linodes-kvm-shortguide/index.md
+++ b/docs/guides/all-linodes-kvm-shortguide/index.md
@@ -1,0 +1,23 @@
+---
+slug: all-linodes-kvm-shortguide
+author:
+  name: Linode
+  email: docs@linode.com
+description: 'Shortguide that displays the note that all Linodes are now KVM.'
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+modified: 2020-12-01
+modified_by:
+  name: Heather Zoppetti
+published: 2020-12-01
+title: All Linodes Are Now KVM
+keywords: []
+headless: true
+show_on_rss_feed: false
+aliases: ['/all-linodes-kvm-shortguide/']
+---
+
+{{< note >}}
+
+This guide mentions XEN architecture. However, all Linode instances now use KVM architecture. This guide may be updated or replaced in the future; or it may be retained for historical purposes.
+
+{{< /note >}}

--- a/docs/guides/all-linodes-kvm-shortguide/index.md
+++ b/docs/guides/all-linodes-kvm-shortguide/index.md
@@ -18,6 +18,6 @@ aliases: ['/all-linodes-kvm-shortguide/']
 
 {{< note >}}
 
-This guide mentions XEN architecture. However, all Linode instances now use KVM architecture. This guide may be updated or replaced in the future; or it may be retained for historical purposes.
+This guide mentions Xen architecture. However, all Linode instances now use KVM architecture. This guide may be updated or replaced in the future; or it may be retained for historical purposes.
 
 {{< /note >}}

--- a/docs/guides/platform/disk-images/kvm-reference/index.md
+++ b/docs/guides/platform/disk-images/kvm-reference/index.md
@@ -17,7 +17,7 @@ tags: ["linode platform"]
 
 Linode's current virtualization stack is built on KVM. Previously, Linode used Xen, and older Linodes may still be on the Xen platform. Along with the increased performance of KVM virtualization, several details are different between Xen and KVM Linodes.
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 ## What's Changed?
 

--- a/docs/guides/platform/disk-images/kvm-reference/index.md
+++ b/docs/guides/platform/disk-images/kvm-reference/index.md
@@ -7,7 +7,7 @@ description: KVM Reference explains the differences when going from Xen to KVM v
 keywords: ["kvm", "kvm reference", "virtual machine mode", "kvm linode", "xen"]
 aliases: ['/platform/disk-images/kvm-reference/','/platform/kvm-reference/','/platform/kvm/']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2016-09-14
+modified: 2020-12-01
 modified_by:
   name: Alex Fornuto
 published: 2015-06-15
@@ -16,6 +16,8 @@ tags: ["linode platform"]
 ---
 
 Linode's current virtualization stack is built on KVM. Previously, Linode used Xen, and older Linodes may still be on the Xen platform. Along with the increased performance of KVM virtualization, several details are different between Xen and KVM Linodes.
+
+{{ content "all-linodes-kvm-shortguide" }}
 
 ## What's Changed?
 

--- a/docs/guides/security/encryption/full-disk-encryption-xen/index.md
+++ b/docs/guides/security/encryption/full-disk-encryption-xen/index.md
@@ -10,7 +10,7 @@ keywords: ['full disk encryption', 'debian', 'wheezy', 'security', 'cryptsetup']
 aliases: ['/security/full-disk-encryption-xen/','/security/encryption/full-disk-encryption-xen/']
 tags: ["security","debian"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2014-06-19
+modified: 2020-12-01
 modified_by:
   name: Linode
 published: 2013-07-05
@@ -23,6 +23,8 @@ Full disk encryption protects the information stored on your Linode's disks by c
 -   Install a base Debian 7 (Wheezy) system with `debootstrap`
 -   Configure services and networking
 -   Boot from the encrypted images
+
+{{ content "all-linodes-kvm-shortguide" }}
 
 ## Potential Drawbacks
 

--- a/docs/guides/security/encryption/full-disk-encryption-xen/index.md
+++ b/docs/guides/security/encryption/full-disk-encryption-xen/index.md
@@ -24,7 +24,7 @@ Full disk encryption protects the information stored on your Linode's disks by c
 -   Configure services and networking
 -   Boot from the encrypted images
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 ## Potential Drawbacks
 

--- a/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-10-04-lts-lucid/index.md
+++ b/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-10-04-lts-lucid/index.md
@@ -9,7 +9,7 @@ keywords: ["ubuntu upgrade", "distro upgrade", "linux upgrade howto"]
 tags: ["security","ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/security/upgrading/how-to-upgrade-to-ubuntu-10-04-lts-lucid/','/upgrading/upgrade-to-ubuntu-10-04-lucid/']
-modified: 2013-10-01
+modified: 2020-12-01
 modified_by:
   name: Linode
 published: 2010-04-29
@@ -21,7 +21,7 @@ relations:
             - distribution: Ubuntu 10.04
 ---
 
-
+{{ content "all-linodes-kvm-shortguide" }}
 
 This guide explains how to upgrade your Linode to Ubuntu 10.04 LTS (Lucid). As with any task involving major system changes, you are strongly encouraged to make backups of your data before proceeding. You should be logged in as root for these procedures.
 

--- a/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-10-04-lts-lucid/index.md
+++ b/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-10-04-lts-lucid/index.md
@@ -21,7 +21,7 @@ relations:
             - distribution: Ubuntu 10.04
 ---
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 This guide explains how to upgrade your Linode to Ubuntu 10.04 LTS (Lucid). As with any task involving major system changes, you are strongly encouraged to make backups of your data before proceeding. You should be logged in as root for these procedures.
 

--- a/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-10-10-maverick/index.md
+++ b/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-10-10-maverick/index.md
@@ -9,7 +9,7 @@ keywords: ["ubuntu 10.10 upgrade", "ubuntu maverick upgrade", "distro upgrade", 
 tags: ["security","ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/security/upgrading/how-to-upgrade-to-ubuntu-10-10-maverick/','/upgrading/upgrade-to-ubuntu-10-10-maverick/']
-modified: 2013-05-10
+modified: 2020-12-01
 modified_by:
   name: Linode
 published: 2010-10-13
@@ -21,7 +21,7 @@ relations:
             - distribution: Ubuntu 10.10
 ---
 
-
+{{ content "all-linodes-kvm-shortguide" }}
 
 This guide explains how to upgrade your Linode to Ubuntu 10.10 (Maverick). As with any task involving major system changes, you are strongly encouraged to make backups of your data before proceeding. You should be logged in as root for these procedures. Ubuntu only officially supports direct upgrades between LTS releases. However, you may follow these steps to upgrade your system if you're willing to handle any potential snags that may occur.
 

--- a/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-10-10-maverick/index.md
+++ b/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-10-10-maverick/index.md
@@ -21,7 +21,7 @@ relations:
             - distribution: Ubuntu 10.10
 ---
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 This guide explains how to upgrade your Linode to Ubuntu 10.10 (Maverick). As with any task involving major system changes, you are strongly encouraged to make backups of your data before proceeding. You should be logged in as root for these procedures. Ubuntu only officially supports direct upgrades between LTS releases. However, you may follow these steps to upgrade your system if you're willing to handle any potential snags that may occur.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-centos-7/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-centos-7/index.md
@@ -8,7 +8,7 @@ description: 'Instructions for configuring your Linode to run a custom compiled 
 keywords: ["compile kernel", "kernel compiling", "pv-grub", "pvgrub", "custom linux kernel", "custom linode", "centos"]
 tags: ["centos"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2015-04-14
+modified: 2020-12-01
 modified_by:
   name: Linode
 published: 2010-07-17
@@ -20,6 +20,8 @@ relations:
             - distribution: CentOS 7
 aliases: ['/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-centos-7/']
 ---
+
+{{ content "all-linodes-kvm-shortguide" }}
 
 Running a custom-compiled Linux kernel is useful if you need to enable or disable certain kernel features that are unavailable in Linode-supplied or distribution-supplied kernels. For example, some users desire [SELinux](http://en.wikipedia.org/wiki/Security-Enhanced_Linux) support, which is not enabled in stock Linode kernels, and may not be enabled in some distribution-supplied kernels.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-centos-7/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-centos-7/index.md
@@ -21,7 +21,7 @@ relations:
 aliases: ['/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-centos-7/']
 ---
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 Running a custom-compiled Linux kernel is useful if you need to enable or disable certain kernel features that are unavailable in Linode-supplied or distribution-supplied kernels. For example, some users desire [SELinux](http://en.wikipedia.org/wiki/Security-Enhanced_Linux) support, which is not enabled in stock Linode kernels, and may not be enabled in some distribution-supplied kernels.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu/index.md
@@ -9,7 +9,7 @@ aliases: ['/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-p
 keywords: ["compile kernel", "kernel compiling", "pv-grub", "pvgrub", "custom linux kernel", "custom linode", "debian", "ubuntu"]
 tags: ["debian", "ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2015-04-03
+modified: 2020-12-01
 modified_by:
   name: Linode
 published: 2015-04-03
@@ -20,6 +20,8 @@ relations:
         keywords:
             - distribution: Debian/Ubuntu
 ---
+
+{{ content "all-linodes-kvm-shortguide" }}
 
 Running a custom-compiled Linux kernel is useful if you need to enable or disable certain kernel features that are unavailable in Linode-supplied or distribution-supplied kernels. For example, some users desire [SELinux](http://en.wikipedia.org/wiki/Security-Enhanced_Linux) support, which is not enabled in stock Linode kernels, and may not be enabled in some distribution-supplied kernels.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-debian-ubuntu/index.md
@@ -21,7 +21,7 @@ relations:
             - distribution: Debian/Ubuntu
 ---
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 Running a custom-compiled Linux kernel is useful if you need to enable or disable certain kernel features that are unavailable in Linode-supplied or distribution-supplied kernels. For example, some users desire [SELinux](http://en.wikipedia.org/wiki/Security-Enhanced_Linux) support, which is not enabled in stock Linode kernels, and may not be enabled in some distribution-supplied kernels.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-on-arch/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-on-arch/index.md
@@ -7,7 +7,7 @@ author:
 description: 'Instructions for configuring your Linode to run a custom compiled kernel with PV-GRUB on Arch Linux'
 keywords: ["compile kernel", "kernel compiling", "pv-grub", "pvgrub", "custom linux kernel", "custom linode", "arch"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2014-06-19
+modified: 2020-12-01
 modified_by:
     name: Linode
 published: 2010-07-17
@@ -19,6 +19,8 @@ relations:
             - distribution: Arch Linux
 aliases: ['/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-on-arch/']
 ---
+
+{{ content "all-linodes-kvm-shortguide" }}
 
 Running a custom-compiled Linux kernel is useful if you need to enable or disable certain kernel features that are unavailable in Linode-supplied or distribution-supplied kernels. For example, some users desire [SELinux](http://en.wikipedia.org/wiki/Security-Enhanced_Linux) support, which is not enabled in stock Linode kernels, and may not be enabled in some distribution-supplied kernels.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-on-arch/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-on-arch/index.md
@@ -20,7 +20,7 @@ relations:
 aliases: ['/tools-reference/custom-kernels-distros/custom-compiled-kernel-with-pvgrub-on-arch/']
 ---
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 Running a custom-compiled Linux kernel is useful if you need to enable or disable certain kernel features that are unavailable in Linode-supplied or distribution-supplied kernels. For example, some users desire [SELinux](http://en.wikipedia.org/wiki/Security-Enhanced_Linux) support, which is not enabled in stock Linode kernels, and may not be enabled in some distribution-supplied kernels.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/index.md
@@ -11,11 +11,11 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/','/tools-reference/custom-kernels-distros/running-a-custom-linux-distro-on-a-linode-vps/','/tools-reference/custom-kernels-distros/custom-distro-on-kvm-linode/']
 modified_by:
   name: Linode
-modified: 2018-10-16
+modified: 2020-12-01
 title: Install a Custom Distribution on a Linode
 ---
 
-This guide will show you how to install and configure a custom distribution on your Linode.
+This guide shows you how to install and configure a custom distribution on your Linode.
 
 ![Install a Custom Distribution on a Linode](install-a-custom-distribution-on-a-linode.png "Install a Custom Distribution on a Linode")
 
@@ -23,23 +23,23 @@ For the sake of organization, it has been split into two main sections:
 
 *  [Install a Custom Distribution](#install-a-custom-distribution): shows you how to use the advantages of **Direct Disk Boot** to easily install the custom distribution.
 
-*  [Linode Manager Compatibility](#linode-manager-compatibility): builds upon the steps in the first section, and offers instructions to make your custom distribution work with features of the Linode Manager such as disk resizing, helpers, and the [Linode Backup Service](/docs/platform/disk-images/linode-backup-service/).
+*  [Linode Manager Compatibility](#linode-manager-compatibility): builds upon the steps in the first section, and offers instructions to make your custom distribution work with features of the Linode Manager such as disk resizing, helpers, and the [Linode Backup Service](/docs/guides/linode-backup-service/).
 
-This guide will use Debian 8 (Jessie) as an example, but the steps provided are generic in nature and should work with most distributions.
+This guide uses Debian 8 (Jessie) as an example, but the steps provided are generic in nature and should work with most distributions.
 
 ## Advantages of KVM on Linode
 
-Linodes running on our KVM hypervisor offer several advantages over Xen, particularly for those looking to install a custom operating system:
+Linodes running on our KVM hypervisor offer several advantages, particularly for those looking to install a custom operating system:
 
-*  **Direct Disk Boot:** Direct disk booting allows you to boot from any disk with a Master Boot Record (MBR). This can be especially useful for operating systems that do not make use of the Grub bootloader, such as [FreeBSD](/docs/tools-reference/custom-kernels-distros/install-freebsd-on-linode/).
+*  **Direct Disk Boot:** Direct disk booting allows you to boot from any disk with a Master Boot Record (MBR). This can be especially useful for operating systems that do not make use of the Grub bootloader, such as [FreeBSD](/docs/guides/install-freebsd-on-linode/).
 
 *  **Full Virtualization:** Our KVM hypervisor offers a full virtualization option that simulates the experience of running directly from hardware. This can be useful for non-standard configurations.
 
-*  **Glish:** KVM introduces the [Glish](/docs/platform/manager/using-the-linode-graphical-shell-glish/) graphical console, which makes it easy to access your distribution's installer directly from a disk.
+*  **Glish:** KVM introduces the [Glish](/docs/guides/using-the-linode-graphical-shell-glish/) graphical console, which makes it easy to access your distribution's installer directly from a disk.
 
 ## Install a Custom Distribution
 
-In this section you'll install your custom distro onto a raw disk, with the *direct disk boot* option. The end result will be a working custom install; however, it will not support disk resizing from within the Linode Manager, nor will it be compatible with the Backup Service.
+In this section you install your custom distro onto a raw disk, with the *direct disk boot* option. The end result is a working custom install; however, it does not support disk resizing from within the Linode Manager, nor is it compatible with the Backup Service.
 
 ### Prepare your Linode
 
@@ -49,22 +49,22 @@ In this section you'll install your custom distro onto a raw disk, with the *dir
 
 1.  Click the **Resize** tab and uncheck the **Auto Resize Disk** option at the bottom of the screen.
 
-1.  Next, click the **Disks/Configs** tab and resize the main disk so you have some room for new disks; you'll want to free 2100 MB for the Debian 9 disk we used in this example.
+1.  Next, click the **Disks/Configs** tab and resize the main disk so you have some room for new disks; you want to free 2100 MB for the Debian 9 disk we used in this example.
 
     {{< note >}}
 Depending on the distribution you install first, you may need to resize your disk to a size slightly larger than 2100 MB. You can always check how much space your disk is actively using and would therefore require by entering the `df -h` command when it's mounted.
 {{< /note >}}
 
-1.  [Create two raw, unformatted disk images](/docs/platform/disk-images/disk-images-and-configuration-profiles/#creating-a-blank-disk) from the Linode's Dashboard:
+1.  [Create two raw, unformatted disk images](/docs/guides/disk-images-and-configuration-profiles/#creating-a-blank-disk) from the Linode's Dashboard:
 
-    * A disk labeled **Installer**. The size of this disk will depend upon the size of your distribution's installer, but it's recommended to make it slightly larger than the space taken up by the install media itself. For this example, the installer disk will be 100MB in size, giving us plenty of room for the Debian network installer.
+    * A disk labeled **Installer**. The size of this disk depends upon the size of your distribution's installer, but it's recommended to make it slightly larger than the space taken up by the install media itself. For this example, the installer disk is 100MB in size, giving us plenty of room for the Debian network installer.
     * A disk labeled **Boot**. If you *don't* plan to complete the next section on Linode Manager compatibility, this can take up the rest of the free space available on your Linode.
 
     {{< caution >}}
 If you intend to continue to the next section on [Linode Manager Compatibility](#linode-manager-compatibility), you should make your boot disk no larger than necessary - in this example we'll install Debian to a 2000MB disk.
 {{< /caution >}}
 
-1.  [Create two configuration profiles](/docs/platform/disk-images/disk-images-and-configuration-profiles/#configuration-profiles) and disable the options under **Filesystem / Boot Helpers** for each of them, as well as the [Lassie](/docs/uptime/monitoring-and-maintaining-your-server/#configuring-shutdown-watchdog) shutdown watchdog under the **Settings** menu. Both profiles will use the **Direct Disk** option from the **Kernel** dropdown menu:
+1.  [Create two configuration profiles](/docs/guides/disk-images-and-configuration-profiles/#configuration-profiles) and disable the options under **Filesystem / Boot Helpers** for each of them, as well as the [Lassie](/docs/guides/monitoring-and-maintaining-your-server/#configuring-shutdown-watchdog) shutdown watchdog under the **Settings** menu. Both profiles use the **Direct Disk** option from the **Kernel** dropdown menu:
 
     **Installer profile**
 
@@ -83,7 +83,7 @@ If you intend to continue to the next section on [Linode Manager Compatibility](
 
 ### Download and Install Image
 
-1.  Boot into [Rescue Mode](/docs/troubleshooting/rescue-and-rebuild/#booting-into-rescue-mode) with your *Installer* disk mounted to `/dev/sda`, and connect to your Linode using the [Lish Console](/docs/platform/manager/using-the-linode-shell-lish/).
+1.  Boot into [Rescue Mode](/docs/guides/rescue-and-rebuild/#booting-into-rescue-mode) with your *Installer* disk mounted to `/dev/sda`, and connect to your Linode using the [Lish Console](/docs/guides/using-the-linode-shell-lish/).
 
 1.  Once in Rescue Mode, download your installation media and copy it to your *Installer* disk. In this example we're using the Debian network installer, but you can replace the URL in the following command with the location of the image you want to install:
 
@@ -104,21 +104,21 @@ If you would prefer to write the installer directly to the disk as it downloads,
 
         sync; echo 3 > /proc/sys/vm/drop_caches
 
-1.  Close the Lish window and go back to Cloud Manager. Reboot into your *Installer* configuration profile and open the [Glish](/docs/platform/manager/using-the-linode-graphical-shell-glish/) graphical console. You'll see your distribution's installer, and you can begin the install process.
+1.  Close the Lish window and go back to Cloud Manager. Reboot into your *Installer* configuration profile and open the [Glish](/docs/guides/using-the-linode-graphical-shell-glish/) graphical console. You see your distribution's installer, and you can begin the install process.
 
-1.  During your installer's partitioning/installation phase, be sure to instruct it to use the `/dev/sda` volume. Most installers will create separate root and swap partitions, but you can adjust this as needed.
+1.  During your installer's partitioning/installation phase, be sure to instruct it to use the `/dev/sda` volume. Most installers create separate root and swap partitions, but you can adjust this as needed.
 
     {{< note >}}
 Some installers offer an option to place `/boot` on a separate partition. If you intend to make use of the steps in the [second part](#linode-manager-compatibility) of this guide for Linode Manager compatibility, it's important that your `/boot` directory is located on the same partition as your root filesystem.
 {{< /note >}}
 
-1.  Once the installation completes, close the Glish window and return to the Cloud Manager. Reboot into your *Boot* profile and open the Glish console. You will have access to a login prompt:
+1.  Once the installation completes, close the Glish window and return to the Cloud Manager. Reboot into your *Boot* profile and open the Glish console. You have access to a login prompt:
 
     ![Glish Console Prompt](install-custom-distro-glish-console.png "Glish Console Prompt")
 
 ### Configure Grub for Lish Access
 
-At this point you can connect to your Linode via SSH or the Glish graphical console. However, you will not be able to connect to your Linode using the Lish serial console. To fix this, update the following settings in your `/etc/default/grub` file:
+At this point you can connect to your Linode via SSH or the Glish graphical console. However, you can not connect to your Linode using the Lish serial console. To fix this, update the following settings in your `/etc/default/grub` file:
 
 {{< file "/etc/default/grub" >}}
 GRUB_TIMEOUT=10
@@ -146,13 +146,13 @@ If you're still not able to access your Linode via Lish after updating your GRUB
 
 ## Linode Manager Compatibility
 
-If you've followed the steps so far, you should have a working custom distribution with raw disks, using the *direct disk* boot option. While this setup is functional, it's not compatible with several features of the Linode Manager that require the ability to mount your filesystem, such as:
+If you've followed the steps so far, you should have a working custom distribution with raw disks, using the *direct disk* boot option. While this setup is functional, it's not compatible with several features of the Linode Manager that require the ability to mount your file system, such as:
 
-*  **Disk Resizing:** Since the Linode Cloud Manager cannot determine the amount of *used* storage space on a raw disk, it can only **increase** the size. The Linode Cloud Manager cannot be used to make a raw disk smaller, and it cannot resize the filesystem on the disk - this would need to be done manually. Also, some ext4 features like enabled metadata_csum are not supported for custom distribution images.
+*  **Disk Resizing:** Since the Linode Cloud Manager cannot determine the amount of *used* storage space on a raw disk, it can only **increase** the size. The Linode Cloud Manager cannot be used to make a raw disk smaller, and it cannot resize the file system on the disk - this would need to be done manually. Also, some ext4 features like enabled metadata_csum are not supported for custom distribution images.
 
 *  **Backups:** The Linode Backup Service needs to be able to mount your filesystem, and does not support partitioned disks.
 
-*  **Helpers:** Several helpful features within the Linode Manager, such as [root password resets](/docs/platform/accounts-and-passwords/#resetting-the-root-password) and [Network Helper](/docs/platform/network-helper/), need access to your filesystem in order to make changes.
+*  **Helpers:** Several helpful features within the Linode Manager, such as [root password resets](/docs/guides/#resetting-the-root-password) and [Network Helper](/docs/guides/network-helper/), need access to your file system in order to make changes.
 
 This section covers how to move your custom installation over to an **ext4** formatted disk so it can take advantage of these tools.
 
@@ -162,13 +162,13 @@ These features are not available even if you formatted the disk to *ext4* during
 
 ### Prepare your Linode
 
-1.  Create some room for two new disks. One will be formatted *ext4* to move the file system to and one will be for *swap*. To make more room, consider deleting the initial distribution that was created during Linode creation.
+1.  Create some room for two new disks. One formatted *ext4* to move the file system to and one for *swap*. To make more room, consider deleting the initial distribution that was created during Linode creation.
 
-1.  [Create a new ext4 disk](/docs/platform/disk-images/disk-images-and-configuration-profiles/#creating-a-blank-disk). The new disk should be large enough to accommodate the root filesystem that was created on your raw disk (2000 MB). You can make this as large as you'd like, but you should leave enough space for a separate swap partition. For this example, we'll name this disk *Boot-New*.
+1.  [Create a new ext4 disk](/docs/guides/disk-images-and-configuration-profiles/#creating-a-blank-disk). The new disk should be large enough to accommodate the root file system that was created on your raw disk (2000 MB). You can make this as large as you'd like, but you should leave enough space for a separate swap partition. For this example, name this disk *Boot-New*.
 
-1.  Create the second new disk and choose *swap* for the disk type. The size of this disk will depend upon your needs, but it's recommended that you make it between 256-512MB to start. We'll label this disk *Swap*.
+1.  Create the second new disk and choose *swap* for the disk type. The size of this disk depends upon your needs, but it's recommended that you make it between 256-512MB to start. Label this disk *Swap*.
 
-1.  [Create a new configuration profile](/docs/platform/disk-images/disk-images-and-configuration-profiles/#configuration-profiles) with a name of your choice. For this example, we'll call the new profile *Installer-New* and it will use the following options:
+1.  [Create a new configuration profile](/docs/guides/disk-images-and-configuration-profiles/#configuration-profiles) with a name of your choice. For this example, call the new profile *Installer-New* and it uses the following options:
 
     **Installer-New profile**
 
@@ -208,7 +208,7 @@ sr0     11:0    1 1024M  0 rom
 
 ### Configure Grub
 
-1.  Confirm the location of your `grub.cfg` file. Some distributions (notably, CentOS and Fedora) place this file under the `/boot/grub2` directory, while others have it under `/boot/grub`. Your new setup will use our *Grub 2* mode, which looks for a configuration file under `/boot/grub/grub.cfg`. You can confirm if your `grub.cfg` is located in the necessary spot with the `ls` command:
+1.  Confirm the location of your `grub.cfg` file. Some distributions (notably, CentOS and Fedora) place this file under the `/boot/grub2` directory, while others have it under `/boot/grub`. Your new setup uses our *Grub 2* mode, which looks for a configuration file under `/boot/grub/grub.cfg`. You can confirm if your `grub.cfg` is located in the necessary spot with the `ls` command:
 
         ls -la /boot/grub/grub.cfg
 
@@ -222,24 +222,24 @@ sr0     11:0    1 1024M  0 rom
         mkdir /boot/grub
         ln -s /boot/grub2/grub.cfg /boot/grub/grub.cfg
 
-1.  Update your `grub.cfg` file, replacing all instances of `/dev/sda1` with `/dev/sda`. Note that this command will need to be adjusted if your root filesystem is located on a partition other than `/dev/sda1`:
+1.  Update your `grub.cfg` file, replacing all instances of `/dev/sda1` with `/dev/sda`. Note that this command needs to be adjusted if your root file system is located on a partition other than `/dev/sda1`:
 
         sed -i -e 's$/dev/sda1$/dev/sda$g' /boot/grub/grub.cfg
 
     Keep in mind that if your `grub.cfg` is located under `/boot/grub2`, you should adjust this command to reflect that.
 
-### Transfer your Root Filesystem to your Ext4 Disk
+### Transfer your Root File System to your Ext4 Disk
 
-Now that you've updated the necessary configuration files, you're ready to move your root filesystem to the ext4 disk you created previously. To get started, boot your Linode into [Rescue Mode](/docs/troubleshooting/rescue-and-rebuild/) with the following disk assignments:
+Now that you've updated the necessary configuration files, you're ready to move your root file system to the ext4 disk you created previously. To get started, boot your Linode into [Rescue Mode](/docs/guides/rescue-and-rebuild/) with the following disk assignments:
 
 *  *Boot* disk mounted to `/dev/sda`
 *  *Boot-New* disk mounted to `/dev/sdb`
 
-In Rescue Mode, connect via Lish and transfer your root filesystem from the `/dev/sda1` partition to your new ext4 disk:
+In Rescue Mode, connect via Lish and transfer your root file system from the `/dev/sda1` partition to your new ext4 disk:
 
     dd if=/dev/sda1 of=/dev/sdb bs=1M
 
-Once the transfer completes, reboot into your *Installer-New* profile. You now have a custom distribution that works with the Linode Manager's extra features. In order to make use of the Backup Service, you'll need to remove the raw disks that were used during the installation process.
+Once the transfer completes, reboot into your *Installer-New* profile. You now have a custom distribution that works with the Linode Manager's extra features. In order to make use of the Backup Service, you need to remove the raw disks that were used during the installation process.
 
 ### Linode Images
-Linode offers an image feature. The feature allows users to quickly deploy custom or preconfigured distribution images to new Linodes. Read this [guide](/docs/platform/disk-images/linode-images/) to learn more.
+Linode offers an image feature. The feature allows users to quickly deploy custom or preconfigured distribution images to new Linodes. Read this [guide](/docs/guides/linode-images/) to learn more.

--- a/docs/guides/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-xen-linode/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-xen-linode/index.md
@@ -11,11 +11,13 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/platform/custom-kernels-distros/running-a-custom-linux-distro-on-a-linode-vps/','/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-xen-linode/','/custom-instances/custom-distro-howto/']
 modified_by:
   name: Linode
-modified: 2014-10-08
+modified: 2020-12-01
 title: Install a Custom Distribution on a Xen Linode
 ---
 
 If you'd like to run a Linux distribution on your Linode that isn't available from our distribution list, you can do so by following these instructions. This guide is handy for people who prefer distributions that aren't heavily used in the community, or for those interested in creating a highly customized Linux environment and porting it to their Linode.
+
+{{ content "all-linodes-kvm-shortguide" }}
 
 {{< note >}}
 This guide is intended for Linodes using our older Xen hypervisor. To install a custom distribution on a new KVM Linode, see [this guide](/docs/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/).

--- a/docs/guides/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-xen-linode/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-xen-linode/index.md
@@ -17,7 +17,7 @@ title: Install a Custom Distribution on a Xen Linode
 
 If you'd like to run a Linux distribution on your Linode that isn't available from our distribution list, you can do so by following these instructions. This guide is handy for people who prefer distributions that aren't heavily used in the community, or for those interested in creating a highly customized Linux environment and porting it to their Linode.
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 {{< note >}}
 This guide is intended for Linodes using our older Xen hypervisor. To install a custom distribution on a new KVM Linode, see [this guide](/docs/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/).

--- a/docs/guides/tools-reference/custom-kernels-distros/install-coreos-on-your-linode/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/install-coreos-on-your-linode/index.md
@@ -4,12 +4,12 @@ deprecated: true
 author:
   name: Linode Community
   email: docs@linode.com
-description: 'CoreOS is a container-centric Linux distribution designed for clustered systems running in the cloud. This guide details installing CoreOS on a KVM Linode.'
-keywords: ["coreos", "custom", "finnix", "lish", "kvm"]
+description: 'CoreOS is a container-centric Linux distribution designed for clustered systems running in the cloud. This guide details installing CoreOS on a Linode.'
+keywords: ["coreos", "custom", "finnix", "lish"]
 tags: ["cloud manager"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2016-01-07
-modified: 2016-01-08
+modified: 2020-12-01
 modified_by:
   name: Linode
 title: Install CoreOS on Your Linode
@@ -26,21 +26,20 @@ relations:
 aliases: ['/tools-reference/custom-kernels-distros/install-coreos-on-your-linode/']
 ---
 
-
 {{< note >}}
 CoreOS Container Linux is now available for deployment from the Linode Manager.
 {{< /note >}}
 
-[CoreOS](https://coreos.com/) is a container-centric Linux distribution designed for clustered systems running in the cloud. With user applications running inside containers, the host system itself provides minimal functionality. This guide details installing CoreOS on a **KVM** Linode. If you're running a Xen Linode, you can [upgrade](/docs/platform/kvm-reference/#how-to-enable-kvm), but it is currently not possible to install CoreOS on a Xen Linode.
+[CoreOS](https://coreos.com/) is a container-centric Linux distribution designed for clustered systems running in the cloud. With user applications running inside containers, the host system itself provides minimal functionality.
 
 CoreOS is not officially supported by Linode so there are limitations to using it in comparison to the Linux images provided in the Linode Manager.
 
-*   The CoreOS installer will create a partition table on the disk image which will interfere with the [Linode Backup](/docs/platform/disk-images/linode-backup-service/) service because the disk image will not be directly mountable.
+*   The CoreOS installer creates a partition table on the disk image which interferes with the [Linode Backup](/docs/guides/linode-backup-service/) service because the disk image is not be directly mountable.
 
-*   Unlike the case with most partitioned images, you *will* be able to resize the disk image holding a CoreOS system; however, it can only grow, not shrink. CoreOS will resize its root partition to fill the disk on next boot.
+*   Unlike the case with most partitioned images, you *can* resize the disk image holding a CoreOS system; however, it can only grow, not shrink. CoreOS resizes its root partition to fill the disk on next boot.
 
 {{< caution >}}
-These instructions perform **destructive** operations on your Linode! You should not attempt to install CoreOS on a Linode with data you want to preserve. You may wish to [use a second Linode](/docs/security/recovering-from-a-system-compromise/#using-a-second-linode) and transfer your data after installation.
+These instructions perform **destructive** operations on your Linode! You should not attempt to install CoreOS on a Linode with data you want to preserve. You may wish to [use a second Linode](/docs/guides/recovering-from-a-system-compromise/#using-a-second-linode) and transfer your data after installation.
 {{< /caution >}}
 
 ## Before You Begin
@@ -50,23 +49,23 @@ CoreOS configures no default way to log in except by supplying an option to the 
 
 ## Prepare the Linode
 
-1. From the [Linode Manager](https://manager.linode.com/), create a new Linode.
+1. From the [Linode Cloud Manager](https://cloud.linode.com/), create a new Linode.
 
 2. Under the **Disks** section of the Linode Dashboard, click on **Create a new Disk**:
 
     [![Create a new disk](custom-distro-new-disk_small.png)](custom-distro-new-disk.png)
 
-3. Label your new disk image and choose an appropriate size. You will probably need to allocate at least **5 GB**. Set the **Type** to **unformatted / raw**.
+3. Label your new disk image and choose an appropriate size. You probably need to allocate at least **5 GB**. Set the **Type** to **unformatted / raw**.
 
     [![Specify disk name and size](coreos-disk-image-small.png)](coreos-disk-image.png)
 
-   If you're not sure how big your disk image needs to be, you may wish to choose a small size so that you can grow the disk later. You will not be able to shrink the disk image after it has been generated.
+   If you're not sure how big your disk image needs to be, you may wish to choose a small size so that you can grow the disk later. You can not shrink the disk image after it has been generated.
 
-4. Return to the **Linode Dashboard** and select the **Rescue** tab. Check to make sure the CoreOS disk image you created is set as `/dev/sda` and all other selectable devices set to **--None--**, then click the **Reboot into Rescue Mode** button. Your Linode will now boot into the Finnix recovery image.
+4. Return to the **Linode Dashboard** and select the **Rescue** tab. Check to make sure the CoreOS disk image you created is set as `/dev/sda` and all other selectable devices set to **--None--**, then click the **Reboot into Rescue Mode** button. Your Linode now boots into the Finnix recovery image.
 
     [![Set /dev/sda to CoreOS disk image](coreos-device-identifier-small.png)](coreos-device-identifier.png)
 
-5.  Use [Lish](/docs/platform/manager/using-the-linode-shell-lish/) to access your Linode. From your Linode's dashboard, click the **Launch Console** link to open an SSH connection in the local system's terminal.
+5.  Use [Lish](/docs/guides/using-the-linode-shell-lish/) to access your Linode. From your Linode's dashboard, click the **Launch Console** link to open an SSH connection in the local system's terminal.
 
 ## Collect Installation Files
 

--- a/docs/guides/tools-reference/custom-kernels-distros/run-a-custom-compiled-kernel-with-pvgrub/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/run-a-custom-compiled-kernel-with-pvgrub/index.md
@@ -8,12 +8,14 @@ description: 'Instructions for configuring your Linode to run a custom compiled 
 keywords: ["compile kernel", "kernel compiling", "pv-grub", "pvgrub", "custom linux kernel", "custom linode"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/custom-instances/pv-grub-custom-compiled-kernel/','/tools-reference/custom-kernels-distros/run-a-custom-compiled-kernel-with-pvgrub/','/platform/custom-kernels-distros/run-a-custom-compiled-kernel-with-pvgrub/']
-modified: 2014-06-19
+modified: 2020-12-01
 modified_by:
   name: Linode
 published: 2010-07-17
 title: 'Run a Custom Compiled Kernel with PV-GRUB'
 ---
+
+{{ content "all-linodes-kvm-shortguide" }}
 
 For some use cases, you may wish to run a custom-compiled Linux kernel on your Linode. This can be useful if you need to enable certain kernel features that are unavailable in Linode-supplied or distribution-supplied kernels, or when you want to disable features that are compiled into such kernels. For example, some users may desire [SELinux](http://en.wikipedia.org/wiki/Security-Enhanced_Linux) support, which is not enabled in stock Linode kernels, and may not be enabled in some distribution-supplied kernels.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/run-a-custom-compiled-kernel-with-pvgrub/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/run-a-custom-compiled-kernel-with-pvgrub/index.md
@@ -15,7 +15,7 @@ published: 2010-07-17
 title: 'Run a Custom Compiled Kernel with PV-GRUB'
 ---
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 For some use cases, you may wish to run a custom-compiled Linux kernel on your Linode. This can be useful if you need to enable certain kernel features that are unavailable in Linode-supplied or distribution-supplied kernels, or when you want to disable features that are compiled into such kernels. For example, some users may desire [SELinux](http://en.wikipedia.org/wiki/Security-Enhanced_Linux) support, which is not enabled in stock Linode kernels, and may not be enabled in some distribution-supplied kernels.
 

--- a/docs/guides/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub/index.md
@@ -15,7 +15,7 @@ title: 'Run a Distribution-Supplied Kernel with PV-GRUB'
 deprecated: true
 ---
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 {{< caution >}}
 This guide is for legacy Xen Linodes. For newer Linodes, consult our guide on how to [Run a Distribution-Supplied Kernel](/docs/guides/run-a-distribution-supplied-kernel/).

--- a/docs/guides/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub/index.md
@@ -7,7 +7,7 @@ description: 'Instructions for configuring your Linode to run a native distribut
 keywords: ["pv-grub", "pvgrub", "custom linux kernel", "custom linode"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/custom-instances/pv-grub-howto/','/platform/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub/','/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub/']
-modified: 2014-08-20
+modified: 2020-12-01
 modified_by:
   name: James Stewart
 published: 2009-09-09
@@ -15,15 +15,17 @@ title: 'Run a Distribution-Supplied Kernel with PV-GRUB'
 deprecated: true
 ---
 
+{{ content "all-linodes-kvm-shortguide" }}
+
 {{< caution >}}
-This guide is for legacy Xen Linodes. For newer Linodes, consult our guide on how to [Run a Distribution-Supplied Kernel](/docs/tools-reference/custom-kernels-distros/run-a-distribution-supplied-kernel/).
+This guide is for legacy Xen Linodes. For newer Linodes, consult our guide on how to [Run a Distribution-Supplied Kernel](/docs/guides/run-a-distribution-supplied-kernel/).
 {{< /caution >}}
 
 PV-GRUB makes it possible to run your own kernel on your Linode, instead of using a host-supplied kernel. This is useful in cases where you'd like to enable specific kernel features, or you'd prefer to handle kernel upgrades directly.
 
-If you'd like to run a custom distro on your Linode in combination with PV-GRUB, please follow our [Custom Distro](/docs/tools-reference/custom-kernels-distros/install-a-custom-distribution-on-a-linode/) guide before taking these steps.
+If you'd like to run a custom distro on your Linode in combination with PV-GRUB, please follow our [Custom Distro](/docs/guides/install-a-custom-distribution-on-a-linode/) guide before taking these steps.
 
-Before you get started, make sure you follow the steps outlined in our [Getting Started](/docs/getting-started/) guide. Your Linode needs to be in a functional state. These steps should be performed as `root` on your Linode, via an SSH session.
+Before you get started, make sure you follow the steps outlined in our [Getting Started](/docs/guides/getting-started/) guide. Your Linode needs to be in a functional state. These steps should be performed as `root` on your Linode, via an SSH session.
 
 ## Ubuntu 13.04 (Raring)
 
@@ -51,7 +53,7 @@ timeout 3
 {{< /file >}}
 
 
-4.  Change it to match the following excerpt. This will give you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future.
+4.  Change it to match the following excerpt. This gives you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future.
 
     {{< file "/boot/grub/menu.lst" >}}
 timeout 10
@@ -156,7 +158,7 @@ timeout 3
 {{< /file >}}
 
 
-4.  Edit the file to match the following excerpt. This will give you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future.
+4.  Edit the file to match the following excerpt. This gives you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future.
 
     {{< file "/boot/grub/menu.lst" >}}
 timeout 10
@@ -263,7 +265,7 @@ timeout 3
 {{< /file >}}
 
 
-4.  Edit this line to match the following excerpt. This will give you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future.
+4.  Edit this line to match the following excerpt. This gives you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future.
 
     {{< file "/boot/grub/menu.lst" >}}
 timeout 10
@@ -379,7 +381,7 @@ timeout 5
 {{< /file >}}
 
 
-5.  Change it to match the following excerpt. This will give you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future.
+5.  Change it to match the following excerpt. This gives you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future.
 
     {{< file "/boot/grub/menu.lst" >}}
 timeout 10
@@ -468,7 +470,7 @@ timeout 5
 {{< /file >}}
 
 
-5.  Change it to match the following excerpt. This will give you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future:
+5.  Change it to match the following excerpt. This gives you a bit of additional time at boot to select your desired kernel, in case you feel the need to go back to an older one in the future:
 
     {{< file "/boot/grub/menu.lst" >}}
 timeout 10
@@ -535,7 +537,7 @@ timeout 10
 
         Linux li63-119 2.6.32-358.14.1.el6.x86_64 #1 SMP Tue Jul 16 23:51:20 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
 
-4.  Make a note of the kernel you're currently using (`2.6.32-358.14.1.el6.x86_64` in our example). You will be replacing it with the kernel shown in the configuration below.
+4.  Make a note of the kernel you're currently using (`2.6.32-358.14.1.el6.x86_64` in our example). You are replacing it with the kernel shown in the configuration below.
 
 5.  Issue the following command to install the default kernel for CentOS6:
 
@@ -573,7 +575,7 @@ title CentOS (2.6.32-431.23.3.el6.x86_64)
 
 ## CentOS 5
 
-[Warren Togami](http://togami.com/) was kind enough to provide a script to automate getting a native CentOS 5 kernel up and running, including with SELinux support. We will use this script in the following instructions.
+[Warren Togami](http://togami.com/) was kind enough to provide a script to automate getting a native CentOS 5 kernel up and running, including with SELinux support. We use this script in the following instructions.
 
 1.  Issue the following commands as `root` to retrieve and run the script:
 
@@ -635,4 +637,4 @@ title Fedora 17, kernel 3.9.10-100.fc17.x86\_64 root (hd0) kernel /boot/vmlinuz-
 
         Linux li63-119 3.9.10-100.fc17.x86_64 #1 SMP Sun Jul 14 01:31:27 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
 
-Note that if you later install an updated kernel, you'll need to add an entry for it to your `menu.lst` file. By default, the first kernel in the list will be booted.
+Note that if you later install an updated kernel, you need to add an entry for it to your `menu.lst` file. By default, the first kernel in the list is booted.

--- a/docs/guides/tools-reference/custom-kernels-distros/use-the-distribution-supplied-kernel-on-centos-6-with-grub-legacy/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/use-the-distribution-supplied-kernel-on-centos-6-with-grub-legacy/index.md
@@ -7,7 +7,7 @@ description: 'Configure your CentOS 6 Linode to use the distribution-supplied ke
 keywords: ["centos 6", "custom kernel", "grub legacy"]
 tags: ["centos"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2017-03-10
+modified: 2020-12-01
 modified_by:
   name: Nick Brewer
 published: 2017-03-10
@@ -23,6 +23,8 @@ Before you get started, make sure you follow the steps outlined in our [Getting 
 {{< note >}}
 This guide is intended for Linodes running on our KVM hypervisor. For older Xen Linodes, see [this](/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub) guide.
 {{< /note >}}
+
+{{ content "all-linodes-kvm-shortguide" }}
 
 ## Install the Kernel and Configure Grub
 

--- a/docs/guides/tools-reference/custom-kernels-distros/use-the-distribution-supplied-kernel-on-centos-6-with-grub-legacy/index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/use-the-distribution-supplied-kernel-on-centos-6-with-grub-legacy/index.md
@@ -24,7 +24,7 @@ Before you get started, make sure you follow the steps outlined in our [Getting 
 This guide is intended for Linodes running on our KVM hypervisor. For older Xen Linodes, see [this](/docs/tools-reference/custom-kernels-distros/run-a-distributionsupplied-kernel-with-pvgrub) guide.
 {{< /note >}}
 
-{{ content "all-linodes-kvm-shortguide" }}
+{{< content "all-linodes-kvm-shortguide" >}}
 
 ## Install the Kernel and Configure Grub
 


### PR DESCRIPTION
I left these guides alone but added a short guide note:
- kvm-reference (this one should probably be left alone for "history")
- full-disk-encryption-xen (this one should probably be re-written for non-xen. The title of the guide doesn't say Xen, just the slug/folder)
 
These all didn't say Xen outright but used the xvda file system base examples instead of sda. They could be updated but they are deprecated, except for that last one that oddly has a front matter deprecated: false.

- run-a-custom-compiled-kernel-with-pvgrub (deprecated)
- run-a-distributionsupplied-kernel-with-pvgrub (deprecated)
- custom-compiled-kernel-with-pvgrub-centos-7 (deprecated)
- how-to-upgrade-to-ubuntu-10-10-maverick (deprecated)
- how-to-upgrade-to-ubuntu-10-04-lts-lucid (deprecated)
- custom-compiled-kernel-with-pvgrub-on-arch (deprecated)
- custom-compiled-kernel-with-pvgrub-debian-ubuntu (deprecated)
- install-a-custom-distribution-on-a-xen-linode (deprecated)
- use-the-distribution-supplied-kernel-on-centos-6-with-grub-legacy (this says deprecated: false, but maybe that should be true)

Updated to remove Xen: 
- install-a-custom-distribution-on-a-linode
- install-coreos-on-your-linode (deprecated)