### PR TITLE
[update] fixed the indentation for the message

### DIFF
--- a/docs/guides/applications/configuration-management/ansible/deploy-linodes-using-ansible/index.md
+++ b/docs/guides/applications/configuration-management/ansible/deploy-linodes-using-ansible/index.md
@@ -133,8 +133,8 @@ You can now begin creating Linode instances using Ansible. In this section, you 
         {{< file >}}
 ...
 - name: Print info about my Linode instance
-    debug:
-      msg: "ID is {{ my_linode.instance.id }} IP is {{ my_linode.instance.ipv4 }}"
+  debug:
+  msg: "ID is {{ my_linode.instance.id }} IP is {{ my_linode.instance.ipv4 }}"
         {{</ file >}}
 
 ### Create the Variables File


### PR DESCRIPTION
- As per the comment in disqus: I think there's a minor typo in the Ansible debug message -

<code>- name: Print info about my Linode instance
    debug:
      msg: "ID is {{ my_linode.instance.id }} IP is {{ my_linode.instance.ipv4 }}"</code>

debug should be unindented two spaces, as should msg.