### PR TITLE
Update Algolia ranking configs

### DIFF
--- a/algolia_settings.json
+++ b/algolia_settings.json
@@ -49,8 +49,8 @@
    "geo",
    "words",
    "filters",
-   "proximity",
    "asc(deprecated)",
+   "proximity",
    "attribute",
    "exact",
    "custom"
@@ -60,7 +60,7 @@
    "linode-documentation-sorted"
   ],
   "searchableAttributes": [
-   "title",
+   "unordered(title)",
    "keywords",
    "toc",
    "h1",


### PR DESCRIPTION
These settings were accidentally not included in release v1.19.1.
They have been set correctly on the production Algolia index,
so this commit gets algolia_settings.json aligned with the
production settings.