### PR TITLE
[Hotfix] 1.25.1

### DIFF
--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/before-body-end.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/before-body-end.html
@@ -3,3 +3,11 @@
 {{- $js := resources.GetMatch "js/body/index.js" -}}
 {{ partial "helpers/script-src.html" (dict "js" $js "params" (dict "weglot_api_key" site.Params.weglot_api_key ) ) }}
 <div x-data="lnc.NewInitController()" x-init="init()"></div>
+{{ with $.Params.gtags }}
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    {{ range . -}}
+    window.dataLayer.push({'{{ .key }}': '{{ .value }}'});
+    {{ end -}}
+  </script>
+{{ end }}

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/linode/linode-docs-theme v0.0.0-20210226204656-69790b1d69bc
+# github.com/linode/linode-docs-theme v0.0.0-20210302141717-33288c3be04c
 # github.com/linode/linode-website-partials v0.0.0-20210128152044-047fb439264c
 # github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.8.0
 # github.com/alpinejs/alpine v2.8.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/bep/hugo-jslibs/turbolinks v0.1.2 // indirect
 	github.com/bep/linodedocs v0.0.0-20210212231859-10aa00d2e096
 	github.com/linode/linode-api-docs/v4 v4.85.0 // indirect
-	github.com/linode/linode-docs-theme v0.0.0-20210226204656-69790b1d69bc // indirect
+	github.com/linode/linode-docs-theme v0.0.0-20210302141717-33288c3be04c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ github.com/linode/linode-docs-theme v0.0.0-20210225102921-7c8a91c6347c h1:vCPkHO
 github.com/linode/linode-docs-theme v0.0.0-20210225102921-7c8a91c6347c/go.mod h1:2x/UxSy9ZlNdGFzD0USCZu2AWzjIZv/iYK06Du+bFqI=
 github.com/linode/linode-docs-theme v0.0.0-20210226204656-69790b1d69bc h1:qUv5o2Wy/2VHRYGRE26q2vRQ0qHISN3rZ29OSmsTTV0=
 github.com/linode/linode-docs-theme v0.0.0-20210226204656-69790b1d69bc/go.mod h1:2x/UxSy9ZlNdGFzD0USCZu2AWzjIZv/iYK06Du+bFqI=
+github.com/linode/linode-docs-theme v0.0.0-20210302141717-33288c3be04c h1:wlaVDDS+gzQr9xXtHznihBT8bgZH0So9hwTBIH+f5Yc=
+github.com/linode/linode-docs-theme v0.0.0-20210302141717-33288c3be04c/go.mod h1:2x/UxSy9ZlNdGFzD0USCZu2AWzjIZv/iYK06Du+bFqI=
 github.com/linode/linode-website-partials v0.0.0-20200907163220-d3856e759e21/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/linode/linode-website-partials v0.0.0-20200921210751-887bbecdd5dd/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/linode/linode-website-partials v0.0.0-20201001182036-fe8965a45b3c h1:j2j0WYHnoSEsGg7790A+gNQqKYIXGTi/i1FHTwt9zBM=


### PR DESCRIPTION
* Update theme: add content grouping
* This will have no visible effect. If a guide includes the following front matter, this triggers special behavior that does not affect the UI:
```
gtags:
  - key: external-contributors
    value: est-ext
```