### PR TITLE
[Update] Block Storage CSI driver guides

### DIFF
--- a/docs/guides/kubernetes/deploy-volumes-with-the-linode-block-storage-csi-driver/index.md
+++ b/docs/guides/kubernetes/deploy-volumes-with-the-linode-block-storage-csi-driver/index.md
@@ -46,7 +46,7 @@ The Block Storage CSI Driver supports Kubernetes version 1.13 or higher. To chec
     After deploying your cluster with kubeadm, to continue with this guide, you'll need to install the CSI driver using the instructions in the [Installing the Linode Block Storage CSI Driver](/docs/kubernetes/how-to-install-the-linode-block-storage-csi-driver) guide.
 
     {{< note >}}
-Using either the Linode Kubernetes Engine or Terraform methods above will install both the Linode Block Storage CSI Driver and and the `linode` secret token as part of their deployment methods automatically.
+Using either the Linode Kubernetes Engine or Terraform methods above will install both the Linode Block Storage CSI Driver and the `linode` secret token as part of their deployment methods automatically.
 {{</ note >}}
 
 ## Create a Persistent Volume Claim

--- a/docs/guides/kubernetes/how-to-install-the-linode-block-storage-csi-driver/index.md
+++ b/docs/guides/kubernetes/how-to-install-the-linode-block-storage-csi-driver/index.md
@@ -26,27 +26,15 @@ The [Container Storage Interface](https://github.com/container-storage-interface
 
 ## Before You Begin
 
-This guide assumes you have a working Kubernetes cluster running on Linode. You can deploy a Kubernetes cluster on Linode in the following ways:
+This guide assumes you have a working Kubernetes cluster running on Linode. If you have already created a Kubernetes cluster managed with [LKE](https://www.linode.com/docs/guides/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/), then the Block Storage CSI driver and the `linode` secret token will already be pre-installed on your cluster. See the [Deploying Persistent Volume Claims with the Linode Block Storage CSI Driver](/docs/guides/deploy-volumes-with-the-linode-block-storage-csi-driver) guide for the next steps for working with Persistent Volume Claims.
 
-1. Use the [Linode Kubernetes Engine (LKE)](https://www.linode.com/products/kubernetes/) to deploy a cluster. LKE is Linode's managed Kubernetes service. You can deploy a Kubernetes cluster using:
-
-    - The [Linode Cloud Manager](/docs/guides/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/).
-    - [Linode's API v4](/docs/guides/deploy-and-manage-lke-cluster-with-api-a-tutorial/).
-    - [Terraform](/docs/guides/how-to-deploy-an-lke-cluster-using-terraform/), the popular infrastructure as code (IaC) tool.
-
-1. Deploy an [unmanaged Kubernetes cluster using Terraform](/docs/guides/how-to-provision-an-unmanaged-kubernetes-cluster-using-terraform/) and the [Kubernetes Terraform installer](https://registry.terraform.io/modules/linode/k8s/linode/0.1.2).
-
-1. Use kubeadm to manually deploy a Kubernetes cluster on Linode. You can follow the [Getting Started with Kubernetes: Use kubeadm to Deploy a Cluster on Linode](/docs/guides/getting-started-with-kubernetes/) guide to do this.
+If you are not using LKE or the [Kubernetes Terraform installer](https://registry.terraform.io/modules/linode/k8s/linode/0.1.2), the Kubernetes cluster will require the Block Storage CSI driver in order to use Linode's Block Storage. If you need to set up an unmanaged Kubernetes cluster, you can follow the [Getting Started with Kubernetes: Use kubeadm to Deploy a Cluster on Linode](/docs/guides/getting-started-with-kubernetes/) guide to do this.
 
     {{< note >}}
 The Block Storage CSI supports Kubernetes version 1.13 or higher. To check the version of Kubernetes you are running, you can issue the following command:
 
     kubectl version
     {{</ note >}}
-
-Using either the Linode Kubernetes Engine or Terraform methods above installs both the Linode Block Storage CSI Driver and and the `linode` secret token described below as part of their deployment methods automatically. See the [Deploying Persistent Volume Claims with the Linode Block Storage CSI Driver](/docs/guides/deploy-volumes-with-the-linode-block-storage-csi-driver) guide for the next steps for working with Persistent Volume Claims.
-
-However, deploying a Kubernetes cluster with kubeadm does **not** install the CSI Driver, and you want to follow the instructions below.
 
 ## Installing the CSI Driver
 ### Create a Kubernetes Secret


### PR DESCRIPTION
- Repositions explanation on when manual installation of the CSI driver is needed for Kubernetes support 