### PR TITLE
[Update] cloud-stackscripts-shortguide (Fixed URL)

### DIFF
--- a/docs/guides/platform/manager/cloud-stackscripts-shortguide/index.md
+++ b/docs/guides/platform/manager/cloud-stackscripts-shortguide/index.md
@@ -19,4 +19,4 @@ aliases: ['/platform/manager/cloud-stackscripts-shortguide/']
 
 [StackScripts](https://www.linode.com/stackscripts/) provide Linode users with the ability to automate the deployment of custom systems on top of our default Linux distribution images. StackScripts are usually Bash scripts, stored in the Linode Cloud Manager, and can be accessed when you deploy a Linode. Linodes deployed with a StackScript run the script as part of the first boot process.
 
-To get started using StackScripts in Cloud Manager, see the [Automate Deployment with StackScripts](/docs/guides/stackscripts/) guide.
+To get started using StackScripts in Cloud Manager, see the [Automate Deployment with StackScripts](/docs/guides/platform/stackscripts/) guide.


### PR DESCRIPTION
Updated the **cloud-stackscripts-shortguide** to fix the URL to the StackScripts Guides page. This shortguide is referenced within [/docs/products/tools/cloud-manager/guides/cloud-stackscripts/](https://www.linode.com/docs/products/tools/cloud-manager/guides/cloud-stackscripts/).