### PR TITLE
Update provisioners section for Terraform >= 0.12

### DIFF
--- a/docs/guides/applications/configuration-management/terraform/beginners-guide-to-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/beginners-guide-to-terraform/index.md
@@ -230,6 +230,8 @@ resource "linode_instance" "example_instance" {
 }
 {{< /file >}}
 
+When a provisioner is assigned, it should also include the addition of a [connection block](https://www.terraform.io/docs/language/resources/provisioners/connection.html) nested within the resource block to describe how terraform will connect to the remote resource.
+
 Most provisioners are declared inside of a resource declaration. When multiple provisioners are declared inside a resource, they are executed in the order they are listed. For a full list of [provisioners](https://www.terraform.io/docs/provisioners/index.html), review the official Terraform documentation.
 
 {{< note >}}

--- a/docs/guides/applications/configuration-management/terraform/beginners-guide-to-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/beginners-guide-to-terraform/index.md
@@ -209,6 +209,13 @@ The following example uploads a setup script to a newly created Linode instance 
 resource "linode_instance" "example_instance" {
   # ...
 
+  connection {
+      type     = "ssh"
+      user     = "root"
+      password = var.root_pass
+      host     = self.ip_address
+  }
+
   provisioner "file" {
       source      = "setup_script.sh"
       destination = "/tmp/setup_script.sh"


### PR DESCRIPTION
> I have submitted two accompanying pull requests to parent project terraform to also reflect these changes, https://github.com/hashicorp/terraform/pull/28578 and https://github.com/hashicorp/terraform/pull/28579 these may provide more context if needed.

In this article, the [Provisioners](https://www.linode.com/docs/guides/beginners-guide-to-terraform/#provisioners) section advises to use the following block of code:

```hcl
resource "linode_instance" "example_instance" {
  # ...

  provisioner "file" {
      source      = "setup_script.sh"
      destination = "/tmp/setup_script.sh"
  }

  provisioner "remote-exec" {
    inline = [
      "chmod +x /tmp/setup_script.sh",
      "/tmp/setup_script.sh",
    ]
  }
}
```

This results in the following error:

> Error: missing connection configuration for provisioner

According to the [Terraform docoumentation](https://www.terraform.io/docs/language/resources/provisioners/connection.html), the behavior of Terraform has changed in v0.12 to require a connection field:

> Note: In Terraform 0.11 and earlier, providers could set default values for some connection settings, so that connection blocks could sometimes be omitted. This feature was removed in 0.12 in order to make Terraform's behavior more predictable.

I assume the type of connection that Terraform previously automagically set up for the user with the above code was an SSH connection. I have supplied a minimal viable example of how that's done:

```hcl
resource "linode_instance" "example_instance" {
  # ...

  connection {
      type     = "ssh"
      user     = "root"
      password = var.root_pass
      host     = self.ip_address
  }

  provisioner "file" {
      source      = "setup_script.sh"
      destination = "/tmp/setup_script.sh"
  }

  provisioner "remote-exec" {
    inline = [
      "chmod +x /tmp/setup_script.sh",
      "/tmp/setup_script.sh",
    ]
  }
}
```