### PR TITLE
Vale GHA improvements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
     - name: Get Changed Files
       id: get_changed_files
       uses: jitterbit/get-changed-files@v1
+      continue-on-error: true
       with:
         format: 'json'
     - name: Vale

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,12 +39,18 @@ jobs:
     - name: Get Changed Files
       id: get_changed_files
       uses: jitterbit/get-changed-files@v1
+      # The continue-on-error parameter is set to true as a
+      # workaround for the `head commit is not ahead of base
+      # commit` error that can appear when the PR branch is
+      # out of date.
       continue-on-error: true
       with:
         format: 'json'
     - name: Install more-utils
       run: sudo apt-get install moreutils
     - name: Select Files in Docs Dir
+      # This action filters the list of added and modified
+      # files to only the files that are in the docs/ directory
       id: select_docs_dir_files
       run: |
         docs_dir_files=$(echo $added_modified |  jq -c '[.[] | select(.|test("^docs/"))]')
@@ -55,6 +61,10 @@ jobs:
         added_modified: ${{ steps.get_changed_files.outputs.added_modified }}
     - name: Vale
       uses: errata-ai/vale-action@v1.3.0
+      # Only run the Vale step if the list of added and modified
+      # files inside the docs directory is not empty. If we don't
+      # add this conditional, the Vale step hangs and never
+      # completes when it is passed the empty array.
       if: ${{ '[]' != steps.select_docs_dir_files.outputs.added_modified }}
       with:
         files: '${{ steps.select_docs_dir_files.outputs.added_modified }}'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,10 +42,21 @@ jobs:
       continue-on-error: true
       with:
         format: 'json'
+    - name: Install more-utils
+      run: sudo apt-get install moreutils
+    - name: Select Files in Docs Dir
+      id: select_docs_dir_files
+      run: |
+        docs_dir_files=$(echo $added_modified |  jq -c '[.[] | select(.|test("^docs/"))]')
+        echo "::set-output name=added_modified::$docs_dir_files"
+        echo "Added or modified files located within docs/ directory:"
+        echo $docs_dir_files | jq '.'
+      env:
+        added_modified: ${{ steps.get_changed_files.outputs.added_modified }}
     - name: Vale
       uses: errata-ai/vale-action@v1.3.0
       with:
-        files: '${{ steps.get_changed_files.outputs.added_modified }}'
+        files: '${{ steps.select_docs_dir_files.outputs.added_modified }}'
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,7 @@ jobs:
         added_modified: ${{ steps.get_changed_files.outputs.added_modified }}
     - name: Vale
       uses: errata-ai/vale-action@v1.3.0
+      if: ${{ '[]' != steps.select_docs_dir_files.outputs.added_modified }}
       with:
         files: '${{ steps.select_docs_dir_files.outputs.added_modified }}'
       env:


### PR DESCRIPTION
This PR does two things:

- Integrate a workaround for the "head commit not ahead of base commit" error. Workaround proposed here:
https://github.com/jitterbit/get-changed-files/issues/11#issuecomment-718254652

- Filter out files that are not in the docs/ directory
  This helps us avoid running Vale on non-content files, like our typography test page at _vendor/github.com/linode/linode-docs-theme/content/typografy-test.md