### PR TITLE
Testing out: Integrate workaround for "head commit not ahead of base commit"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
     - name: Get Changed Files
       id: get_changed_files
       uses: jitterbit/get-changed-files@v1
+      continue-on-error: true
       with:
         format: 'json'
     - name: Vale


### PR DESCRIPTION
Workaround proposed here:
https://github.com/jitterbit/get-changed-files/issues/11#issuecomment-718254652