### PR TITLE
[Updated] How to Configure Load Balancing with TLS Encryption on a Kubernetes Cluster

### DIFF
--- a/docs/guides/kubernetes/how-to-configure-load-balancing-with-tls-encryption-on-a-kubernetes-cluster/index.md
+++ b/docs/guides/kubernetes/how-to-configure-load-balancing-with-tls-encryption-on-a-kubernetes-cluster/index.md
@@ -9,6 +9,7 @@ keywords: ['load balancers','kubernetes','pods','cloud controller manager']
 tags: ["kubernetes","container","nginx","networking","security"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2020-07-17
+modified: 2021-05-13
 modified_by:
   name: Linode
 title: "How to Configure Load Balancing with TLS Encryption on a Kubernetes Cluster"
@@ -20,15 +21,14 @@ external_resources:
 aliases: ['/kubernetes/how-to-configure-load-balancing-with-tls-encryption-on-a-kubernetes-cluster/']
 ---
 
-This guide will use an example Kubernetes Deployment and Service to demonstrate how to route external traffic to a Kubernetes application over HTTPS. This is accomplished using the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/#using-helm), [cert-manager](https://cert-manager.io/docs/) and [Linode NodeBalancers](/docs/platform/nodebalancer/). The NGINX Ingress Controller uses Linode NodeBalancers, which are Linode's load balancing service, to route a Kubernetes Service's traffic to the appropriate backend Pods over HTTP and HTTPS. cert-manager creates a Transport Layer Security (TLS) certificate from the [Let’s Encrypt](https://letsencrypt.org/) certificate authority (CA) providing secure HTTPS access to a Kubernetes Service.
+This guide will use an example Kubernetes Deployment and Service to demonstrate how to route external traffic to a Kubernetes application over HTTPS. This is accomplished using the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/#using-helm), [cert-manager](https://cert-manager.io/docs/) and [Linode NodeBalancers](/docs/platform/nodebalancer/). The NGINX Ingress Controller uses Linode NodeBalancers, which are Linode's load balancing service, to route a Kubernetes Service's traffic to the appropriate backend Pods over HTTP and HTTPS. The cert-manager tool creates a Transport Layer Security (TLS) certificate from the [Let’s Encrypt](https://letsencrypt.org/) certificate authority (CA) providing secure HTTPS access to a Kubernetes Service.
 
 {{< note >}}
-The [*Linode Cloud Controller Manager*](https://github.com/linode/linode-cloud-controller-manager) provides a way for a Kubernetes cluster to create, configure, and delete Linode NodeBalancers.  The Linode CCM is installed by default on clusters deployed with the [Linode Kubernetes Engine](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/) and the [Linode Terraform K8s module](/docs/applications/configuration-management/terraform/how-to-provision-an-unmanaged-kubernetes-cluster-using-terraform/).
+The [*Linode Cloud Controller Manager*](https://github.com/linode/linode-cloud-controller-manager) provides a way for a Kubernetes cluster to create, configure, and delete Linode NodeBalancers. The Linode CCM is installed by default on clusters deployed with the [Linode Kubernetes Engine](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/) and the [Linode Terraform K8s module](/docs/applications/configuration-management/terraform/how-to-provision-an-unmanaged-kubernetes-cluster-using-terraform/).
 
 To learn about the various configurations available for Linode NodeBalancers via [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/), see [Getting Started with Load Balancing on a Linode Kubernetes Engine (LKE) Cluster](/docs/kubernetes/getting-started-with-load-balancing-on-a-lke-cluster/#configuring-your-linode-nodebalancers-with-annotations).
 
-While Linode NodeBalancers do support ProxyProtocol, the Linode CCM does not. For this reason, the Linode Kubernetes Engine does not support ProxyProtocol yet. This means you cannot both terminate TLS inside your Kubernetes cluster and whitelist client IP addresses. ProxyProtocol support is coming soon to the Linode CCM.
-
+While Linode NodeBalancers do support ProxyProtocol, the Linode CCM does not. For this reason, the Linode Kubernetes Engine does not support ProxyProtocol yet. This means you cannot both terminate TLS inside your Kubernetes cluster and create an allowlist for client IP addresses. ProxyProtocol support is coming soon to the Linode CCM.
 {{</ note >}}
 
 ## Before you Begin
@@ -37,15 +37,15 @@ While Linode NodeBalancers do support ProxyProtocol, the Linode CCM does not. Fo
 
     {{< note >}}
 The recommended way to deploy a Kubernetes cluster on Linode is using the Linode Kubernetes Engine (managed) or the Linode Terraform K8s module (unmanaged). However, to learn how to install the Linode CCM on a cluster that was not installed in the two ways mentioned above, see the [Installing the Linode CCM on an Unmanaged Kubernetes Cluster](/docs/kubernetes/installing-the-linode-ccm-on-an-unmanaged-kubernetes-cluster/) guide.
-    {{</ note >}}
+{{</ note >}}
 
-1. Install [Helm 3](/docs/kubernetes/how-to-install-apps-on-kubernetes-with-helm-3/#install-helm), and [kubectl](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/#install-kubectl) to your local environment.
+1. Install [Helm 3](/docs/kubernetes/how-to-install-apps-on-kubernetes-with-helm-3/#install-helm) and [kubectl](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/#install-kubectl) to your local environment.
 
-1. Purchase a domain name from a reliable domain registrar. In a later section, you will use Linode's DNS Manager, to [create a new Domain](/docs/platform/manager/dns-manager/#add-a-domain) and to [add a DNS "A" record](/docs/platform/manager/dns-manager/#add-dns-records) for two subdomains, one named `blog` and another named `shop`. Your subdomains will point to the example Kubernetes Services you will create in this guide. The example domain names used throughout this guide are `blog.example.com` and `shop.example.com`.
+1. Purchase a domain name from a reliable domain registrar. In a later section, you will use Linode's DNS Manager to [create a new Domain](/docs/platform/manager/dns-manager/#add-a-domain) and to [add a DNS "A" record](/docs/platform/manager/dns-manager/#add-dns-records) for two subdomains: one named `blog` and another named `shop`. Your subdomains will point to the example Kubernetes Services you will create in this guide. The example domain names used throughout this guide are `blog.example.com` and `shop.example.com`.
 
     {{< note >}}
 Optionally, you can create a Wildcard DNS record, `*.example.com` and point your NodeBalancer's external IP address to it. Using a Wildcard DNS record, will allow you to expose your Kubernetes services without requiring further configuration using the Linode DNS Manager.
-    {{</ note >}}
+{{</ note >}}
 
 ## Create an Example Application
 
@@ -89,7 +89,7 @@ spec:
         image: nginxdemos/hello
         ports:
         - containerPort: 80
-        {{</ file >}}
+{{</ file >}}
 
 1. Create a second Service and Deployment manifest file named `hello-two.yaml` with the contents of the example file.
 
@@ -125,12 +125,12 @@ spec:
         image: nginxdemos/hello
         ports:
         - containerPort: 80
-        {{</ file>}}
+{{</ file>}}
 
 1. Use kubectl to create the Services and Deployments for your example applications.
 
-        kubectl create -f hello-one.yaml
-        kubectl create -f hello-two.yaml
+       kubectl create -f hello-one.yaml
+       kubectl create -f hello-two.yaml
 
     You should see a similar output:
 
@@ -139,11 +139,11 @@ service/hello-one created
 deployment.apps/hello-one created
 service/hello-two created
 deployment.apps/hello-two created
-    {{</ output >}}
+{{</ output >}}
 
 1. Verify that the Services are running.
 
-        kubectl get svc
+       kubectl get svc
 
     You should see a similar output:
 
@@ -152,7 +152,7 @@ NAME         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
 hello-one    ClusterIP   10.128.94.166    <none>        80/TCP    6s
 hello-two    ClusterIP   10.128.102.187   <none>        80/TCP    6s
 kubernetes   ClusterIP   10.128.0.1       <none>        443/TCP   18m
-    {{</ output >}}
+{{</ output >}}
 
 ## Install the NGINX Ingress Controller
 
@@ -164,15 +164,15 @@ If you would like a slightly deeper dive into the NGINX Ingress Controller, see 
 
 1. Add the stable Helm ingress-nginx repository to your Helm repos.
 
-        helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+       helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
 1. Update your Helm repositories.
 
-        helm repo update
+       helm repo update
 
 1. Install the NGINX Ingress Controller. This installation will result in a Linode NodeBalancer being created.
 
-        helm install ingress-nginx ingress-nginx/ingress-nginx
+       helm install ingress-nginx ingress-nginx/ingress-nginx
 
     You will see a similar output:
 
@@ -188,7 +188,7 @@ The ingress-nginx controller has been installed.
 It may take a few minutes for the LoadBalancer IP to be available.
 You can watch the status by running 'kubectl --namespace default get services -o wide -w ingress-nginx-controller'
 ...
-   {{</ output >}}
+{{</ output >}}
 
 ### Create a Subdomain DNS Entries for your Example Applications
 
@@ -196,14 +196,14 @@ Now that Linode NodeBalancers have been created by the NGINX Ingress Controller,
 
 1. Access your NodeBalancer's assigned external IP address.
 
-        kubectl --namespace default get services -o wide -w ingress-nginx-controller
+       kubectl --namespace default get services -o wide -w ingress-nginx-controller
 
     The command will return a similar output:
 
     {{< output >}}
 NAME                          TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE     SELECTOR
 my-ingress-nginx-controller   LoadBalancer   10.128.169.60   192.0.2.0   80:32401/TCP,443:30830/TCP   7h51m   app.kubernetes.io/instance=cingress-nginx,app.kubernetes.io/name=ingress-nginx
-    {{</ output >}}
+{{</ output >}}
 
 1. Copy the IP address of the `EXTERNAL IP` field and navigate to [Linode's DNS manager](https://cloud.linode.com/domains) and [add two "A" records](/docs/platform/manager/dns-manager/#add-dns-records) for the `blog` and `shop` subdomains. Ensure you point each record to the NodeBalancer's IPv4 address you retrieved in the previous step.
 
@@ -229,30 +229,30 @@ If you would like a deeper dive into cert-manager, see our guide [’’]().
 ### Install cert-manager
 1. Install cert-manager's CRDs.
 
-        kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.1/cert-manager.crds.yaml
+       kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.crds.yaml
 
 1. Create a cert-manager namespace.
 
-        kubectl create namespace cert-manager
+       kubectl create namespace cert-manager
 
 1. Add the Helm repository which contains the cert-manager Helm chart.
 
-        helm repo add jetstack https://charts.jetstack.io
+       helm repo add jetstack https://charts.jetstack.io
 
 1. Update your Helm repositories.
 
-        helm repo update
+       helm repo update
 
 1. Install the cert-manager Helm chart. These basic configurations should be sufficient for many use cases, however, additional cert-manager configurable parameters can be found in [cert-manager's official documentation](https://hub.helm.sh/charts/jetstack/cert-manager).
 
-        helm install \
-        cert-manager jetstack/cert-manager \
-        --namespace cert-manager \
-        --version v0.15.1
+       helm install \
+       cert-manager jetstack/cert-manager \
+       --namespace cert-manager \
+       --version v1.3.1
 
 1. Verify that the corresponding cert-manager pods are now running.
 
-        kubectl get pods --namespace cert-manager
+       kubectl get pods --namespace cert-manager
 
     You should see a similar output:
 
@@ -261,18 +261,18 @@ NAME                                       READY   STATUS    RESTARTS   AGE
 cert-manager-579d48dff8-84nw9              1/1     Running   3          1m
 cert-manager-cainjector-789955d9b7-jfskr   1/1     Running   3          1m
 cert-manager-webhook-64869c4997-hnx6n      1/1     Running   0          1m
-    {{</ output >}}
+{{</ output >}}
 
     {{< note >}}
 You should wait until all cert-manager pods are ready and running prior to proceeding to the next section.
-    {{</ note >}}
+{{</ note >}}
 
 ### Create a ClusterIssuer Resource
 
 1. Create a manifest file named `acme-issuer-prod.yaml` that will be used to create a ClusterIssuer resource on your cluster. Ensure you replace `user@example.com` with your own email address.
 
       {{< file "acme-issuer-prod.yaml">}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
@@ -286,27 +286,26 @@ spec:
     - http01:
         ingress:
           class: nginx
-
-      {{</ file >}}
+{{</ file >}}
 
     - This manifest file creates a ClusterIssuer resource that will register an account on an ACME server. The value of `spec.acme.server` designates Let's Encrypt's production ACME server, which should be trusted by most browsers.
 
         {{< note >}}
 Let's Encrypt provides a staging ACME server that can be used to test issuing trusted certificates, while not worrying about hitting [Let's Encrypt's production rate limits](https://letsencrypt.org/docs/rate-limits/). The staging URL is `https://acme-staging-v02.api.letsencrypt.org/directory`.
-        {{</ note >}}
+{{</ note >}}
 
     - The value of `privateKeySecretRef.name` provides the name of a secret containing the private key for this user's ACME server account (this is tied to the email address you provide in the manifest file). The ACME server will use this key to identify you.
     - To ensure that you own the domain for which you will create a certificate, the ACME server will issue a challenge to a client. cert-manager provides two options for solving challenges, [`http01`](https://cert-manager.io/docs/configuration/acme/http01/) and [`DNS01`](https://cert-manager.io/docs/configuration/acme/dns01/). In this example, the `http01` challenge solver will be used and it is configured in the `solvers` array. cert-manager will spin up *challenge solver* Pods to solve the issued challenges and use Ingress resources to route the challenge to the appropriate Pod.
 
 1. Create the ClusterIssuer resource:
 
-        kubectl create -f acme-issuer-prod.yaml
+       kubectl create -f acme-issuer-prod.yaml
 
     You should see a similar output:
 
       {{< output >}}
 clusterissuer.cert-manager.io/letsencrypt-prod created
-      {{</ output >}}
+{{</ output >}}
 
 ## Enable HTTPS for your Application
 
@@ -315,7 +314,7 @@ clusterissuer.cert-manager.io/letsencrypt-prod created
 1. Create an Ingress resource manifest file named `hello-app-ingress.yaml`. If you assigned a different name to your ClusterIssuer, ensure you replace `letsencrypt-prod` with the name you used. Replace all `hosts` and `host` values with your own application's domain name.
 
     {{< file "hello-app-ingress.yaml" >}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hello-app-ingress
@@ -332,30 +331,38 @@ spec:
   - host: blog.example.com
     http:
       paths:
-      - backend:
-          serviceName: hello-one
-          servicePort: 80
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: hello-one
+            port:
+              number: 80
   - host: shop.example.com
     http:
       paths:
-      - backend:
-          serviceName: hello-two
-          servicePort: 80
-    {{</ file >}}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: hello-two
+            port:
+              number: 80
+{{</ file >}}
 
     This resource defines how traffic coming from the Linode NodeBalancers is handled. In this case, NGINX will accept these connections over port 80, diverting traffic to both of your services via their domain names. The `tls` section of the Ingress resource manifest handles routing HTTPS traffic to the hostnames that are defined.
 
 1. Create the Ingress resource.
 
-        kubectl create -f hello-app-ingress.yaml
+       kubectl create -f hello-app-ingress.yaml
 
     You should see a similar output:
 
     {{< output >}}
 ingress.networking.k8s.io/hello-app-ingress created
-    {{</ output >}}
+{{</ output >}}
 
-1. Navigate to your app's domain or if you have been following along with the example, navigate to `blog.example.com` and then, `shop.example.com`. You should see the demo NGINX page load and display information about the Pod being used to serve your request.
+1. Navigate to your app's domain or if you have been following along with the example, navigate to `blog.example.com` and then, `shop.example.com`. You should see the demo NGINX page load and display information about the Pod being used to serve your request. Keep in mind that it may take a few minutes for the TLS certificate to be fully issued.
 
       ![The NGINX demo page loads with information about the Pod being used to serve your request](nginx-demo-page.png)
 


### PR DESCRIPTION
- Updated `cert-manager` from `v0.15.1` to `v1.3.1` (the latest non alpha/beta release)
- Updated ClusterIssuer resource `apiVersion` from `cert-manager.io/v1alpha2` to `cert-manager.io/v1`
- Updated Ingress resource `apiVersion` from `networking.k8s.io/v1beta1` to `networking.k8s.io/v1`
- Updated Ingress resource manifest file
- Fixed formatting issues with extra spaces in code blocks and extra lines in output/file.