### PR TITLE
updated the certbot install command

### DIFF
--- a/docs/guides/quick-answers/websites/how-to-install-certbot-on-ubuntu-18-04/index.md
+++ b/docs/guides/quick-answers/websites/how-to-install-certbot-on-ubuntu-18-04/index.md
@@ -39,7 +39,7 @@ If you're using Apache, change each instance of `nginx` to `apache` in the follo
 1. Install the Certbot and web server-specific packages, then run Certbot:
 
         sudo apt-get update
-        sudo add-apt-repository ppa:certbot/certbot
+        sudo apt-get install certbot
         sudo apt-get install python-certbot-nginx
         sudo certbot --nginx
 


### PR DESCRIPTION
- fixes https://github.com/linode/docs/issues/3952
- the certbot PPA has been deprecated, see https://launchpad.net/~certbot/+archive/ubuntu/certbot