### PR TITLE
[Updated] How to Use the Linode Packer Builder

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -938,6 +938,7 @@ mitigations
 mixin
 mixins
 mkdir
+mkpasswd
 mnesia
 mngtmpaddr
 moby

--- a/docs/guides/applications/configuration-management/packer/how-to-use-linode-packer-builder/index.md
+++ b/docs/guides/applications/configuration-management/packer/how-to-use-linode-packer-builder/index.md
@@ -23,23 +23,23 @@ aliases: ['/applications/configuration-management/how-to-use-linode-packer-build
 
 [Packer](https://www.packer.io/) is a HashiCorp maintained open source tool that is used to create machine images. A machine image provides the operating system, applications, application configurations, and data files that a virtual machine instance will run once it's deployed. Packer can be used in conjunction with common configuration management tools like Chef, Puppet, or Ansible to install software to your Linode and include those configurations into your image.
 
-Packer *templates* store the configuration parameters used for building an image. This standardizes the imaging building process and ensures that everyone using that template file will always create an idential image. For instance, this can help your team maintain an [immutable infrastructure](/docs/development/ci/what-is-immutable-infrastructure/) within your [continuous delivery](/docs/development/ci/introduction-ci-cd/#what-is-continuous-delivery) pipeline.
+Packer *templates* store the configuration parameters used for building an image. This standardizes the imaging building process and ensures that everyone using that template file will always create an identical image. For instance, this can help your team maintain an [immutable infrastructure](/docs/development/ci/what-is-immutable-infrastructure/) within your [continuous delivery](/docs/development/ci/introduction-ci-cd/#what-is-continuous-delivery) pipeline.
 
 ## The Linode Packer Builder
 
 In Packer's ecosystem, [builders](https://www.packer.io/docs/builders) are responsible for building a system and generating an image from that system. Packer has multiple different types of builders, with each one being used to create images for a specific platform.
 
-The [Linode builder](https://www.packer.io/docs/builders/linode) integrates Packer with the Linode platform. This allows Packer to deploy a temporary Linode on your account (using an APIv4 token), configure the system on the Linode according to the parameters in the provided template file, and then create an image based on that Linode. Essentially, this is a convient way to automatically create [Linode Images](/docs/products/tools/images/) on your acount that can be used for rapidly deploying new Linodes.
+The [Linode builder](https://www.packer.io/docs/builders/linode) integrates Packer with the Linode platform. This allows Packer to deploy a temporary Linode on your account (using an APIv4 token), configure the system on the Linode according to the parameters in the provided template file, and then create an image based on that Linode. Essentially, this is a convenient way to automatically create [Linode Images](/docs/products/tools/images/) on your account that can be used for rapidly deploying new Linodes.
 
 ## Before You Begin
 
-This guide will walk you through the process of installing Packer, creating a  template file, building the image, and then deploying that image onto a new Linode. Going futher, it will also cover how to use the Ansible tool with Packer. Before you begin, review the following:
+This guide will walk you through the process of installing Packer, creating a  template file, building the image, and then deploying that image onto a new Linode. Going further, it will also cover how to use the Ansible tool with Packer. Before you begin, review the following:
 
 1. Ensure you have access to [cURL](https://en.wikipedia.org/wiki/CURL) on your computer.
 
 1. Generate a Linode API v4 access token with read/write permission for both *Linodes* and *Images*. You can follow the [Get an Access Token](/docs/platform/api/getting-started-with-the-linode-api/#get-an-access-token) section of the [Getting Started with the Linode API](/docs/platform/api/getting-started-with-the-linode-api/) guide if you do not already have one.
 
-1. *Optional:* Set a variable named `TOKEN` in your shell enviroment by running the following command. Replace *x* with your own API token.
+1. *Optional:* Set a variable named `TOKEN` in your shell environment by running the following command. Replace *x* with your own API token.
 
        export TOKEN=x
 
@@ -70,7 +70,7 @@ To install Packer on Mac, [Homebrew](https://brew.sh/) will be used. Run the fol
     sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
     sudo yum -y install packer
 
-### Verifing the Installation
+### Verifying the Installation
 
 Verify that Packer was successfully installed by running the command `packer --version`. This should output the version number for this installation of Packer. For reference, this guide was last tested using version 1.7.2.
 
@@ -122,7 +122,7 @@ A `variable` block contains a single user-defined variable along with any additi
 
 This example only contains one variable: `linode_api_token`. The value of this variable is intentionally left blank (`default = ""`). Instead of setting the variable within the template, it will be set through the command-line when running the `packer build` command: `packer build -var linode_api_token=x example.pkr.hcl`, where *x* is your API token.
 
-Learn more about Packer tempate variables on the [Variables](https://www.packer.io/docs/templates/hcl_templates/variables) page of Packer's documentation.
+Learn more about Packer template variables on the [Variables](https://www.packer.io/docs/templates/hcl_templates/variables) page of Packer's documentation.
 
 ### Source Block (the Linode Builder)
 
@@ -160,7 +160,7 @@ After the template file has been saved with your desired parameters, you're now 
 
 1. First, validate the template by running the `packer validate` command below. If you did not set TOKEN as a variable in your shell environment, replace *$TOKEN* with your own Linode API token. If successful, no errors will be given.
 
-        packer validate -var linode_api_token=$TOKEN example.pkr.hcl
+       packer validate -var linode_api_token=$TOKEN example.pkr.hcl
 
       {{< note >}}
   To learn how to securely store and use your API v4 token, see the [Vault](https://www.packer.io/docs/templates/hcl_templates/functions/contextual/vault) section of Packer's documentation.
@@ -168,7 +168,7 @@ After the template file has been saved with your desired parameters, you're now 
 
 1. Build the image by running the `packer build` command below. Just like in the last step, if you did not set TOKEN as a variable in your shell environment, replace *$TOKEN* with your own Linode API token. This process may take a few minutes to complete.
 
-        packer build -var linode_api_token=$TOKEN example.pkr.hcl
+       packer build -var linode_api_token=$TOKEN example.pkr.hcl
 
       The output of this command will outline each process that Packer goes through. Once finished, the last line will provide you with the ID for the new custom image.
 
@@ -182,9 +182,9 @@ Once the Packer build process completes, a new [Custom Image](/docs/products/too
 
       linode-cli linodes create --root_pass mypassword --region us-east --image linode/debian10
 
-- **Linode APIv4:** Use the Linode API to programatically create a new Linode by reviewing the documenation outlined under [API > Linode Istances > Linode Create](/docs/api/linode-instances/#linode-create). The following example curl command will deploy a 1GB Linode (Nanode) to the Newark data center. Ensure you replace any necessary parameters, including replacing `linode/debain10` with your Custom Image's ID and assigning your own `root_pass` and `label`.
+- **Linode APIv4:** Use the Linode API to programmatically create a new Linode by reviewing the documentation outlined under [API > Linode Instances > Linode Create](/docs/api/linode-instances/#linode-create). The following example curl command will deploy a 1GB Linode (Nanode) to the Newark data center. Ensure you replace any necessary parameters, including replacing `linode/debain10` with your Custom Image's ID and assigning your own `root_pass` and `label`.
 
-        curl -H "Content-Type: application/json" \
+      curl -H "Content-Type: application/json" \
           -H "Authorization: Bearer $TOKEN" \
           -X POST -d '{
             "image": "private/7550080",

--- a/docs/guides/applications/configuration-management/packer/how-to-use-linode-packer-builder/index.md
+++ b/docs/guides/applications/configuration-management/packer/how-to-use-linode-packer-builder/index.md
@@ -9,6 +9,7 @@ keywords: ['packer hashicorp','hashicorp packer','image','machine image','immuta
 tags: ["automation"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2019-11-12
+modified: 2021-05-21
 modified_by:
   name: Linode
 title: "How to Use the Linode Packer Builder"
@@ -18,9 +19,13 @@ contributor:
 aliases: ['/applications/configuration-management/how-to-use-linode-packer-builder/','/applications/configuration-management/packer/how-to-use-linode-packer-builder/']
 ---
 
-## What is Packer?
+## Introduction
+
+### What is Packer?
 
 Packer is a HashiCorp maintained open source tool that is used to create machine images. A machine image provides the operating system, applications, application configurations, and data files that a virtual machine instance will run once it's deployed. Using a single source configuration, you can generate identical machine images. Packer can be used in conjunction with common configuration management tools like Chef, Puppet, or Ansible to install software to your Linode and include those configurations into your image.
+
+You can share your image template across your team to ensure everyone is using a uniform development and testing environment. This process will help your team maintain an [immutable infrastructure](/docs/development/ci/what-is-immutable-infrastructure/) within your [continuous delivery](/docs/development/ci/introduction-ci-cd/#what-is-continuous-delivery) pipeline.
 
 In this guide you will complete the following steps:
 
@@ -28,6 +33,16 @@ In this guide you will complete the following steps:
 * [Create a Packer image template](#create-your-template). Optionally, the template will execute system configurations using Packer's Ansible provisioner.
 * [Generate a Linode Image](#create-your-linode-image) from your Packer template.
 * [Deploy a Linode](#deploy-a-linode-with-your-new-image) from your stored Packer image.
+
+### What is the Linode Packer Builder?
+
+In Packer's ecosystem, [builders](https://www.packer.io/docs/builders) are responsible for *building* a system and then generating an image from that system. Packer has multiple different types of builders, with each one being used to create images for a specific platform. For integration with [Linode Images](/docs/products/tools/images/), this guide will use the [Linode builder](https://www.packer.io/docs/builders/linode).
+
+When the Linode Packer builder runs, it's able to access your Linode account through the API token you created. It will use the template specified in the `build` command to create a Linode based on the image, plan type, scripts, and other parameters defined within that template. After Packer has successfully built and configured the Linode, a custom image based on that Linode's main disk will be created. This custom image is stored privately on your Linode account and can be used when creating new Linodes.
+
+{{< note >}}
+The Packer builder does not manage images. Once it creates an image, it will be stored on your Linode account and can be accessed and used as needed from the Linode Cloud Manager, via Linode's API v4, or using third-party tools like Terraform. Linode Images are limited to 2GB per Image and 3 Images per account.
+{{</ note >}}
 
 ## Before You Begin
 
@@ -52,145 +67,139 @@ If you do not do this, you will need to alter these commands so that your API to
 
 1. Install Ansible on your computer and familiarize yourself with basic Ansible concepts (optional). Using the [Getting Started With Ansible - Basic Installation and Setup](/docs/applications/configuration-management/getting-started-with-ansible/) guide, follow the steps in the [Install Ansible](/docs/applications/configuration-management/getting-started-with-ansible/#install-ansible) section.
 
-## The Linode Packer Builder
+## Installing Packer
 
-In Packer's ecosystem, *builders* are responsible for deploying machine instances and generating redeployable images from them. The Linode Packer builder can be used to create a Linode image that can be redeployed to other Linodes. You can share your image template across your team to ensure everyone is using a uniform development and testing environment. This process will help your team maintain an [immutable infrastructure](/docs/development/ci/what-is-immutable-infrastructure/) within your [continuous delivery](/docs/development/ci/introduction-ci-cd/#what-is-continuous-delivery) pipeline.
+The following instructions will install the latest version of Packer on Mac, Ubuntu, or CentOS. For more installation methods, including installing on other operating systems or compiling from source, see [Packer's official documentation](https://www.packer.io/intro/getting-started/install.html) and the [Download Packer](https://www.packer.io/downloads) webpage.
 
-The Linode Packer builder works in the following way:
+### Mac
 
-* You create a template to define the type of image you want Packer to build.
-* Packer uses the template to build the image on a temporary Linode.
-* A snapshot of the built image is taken and stored as a private [Linode image](/docs/platform/disk-images/linode-images/).
-* The temporary Linode is deleted.
-* You can then reuse the private Linode image as desired, for example, by using your image to create Linode instances with [Terraform](/docs/applications/configuration-management/how-to-build-your-infrastructure-using-terraform-and-linode/).
+To install Packer on Mac, [Homebrew](https://brew.sh/) will be used. Run the following commands on your terminal:
 
-## Install Packer
+    brew tap hashicorp/tap
+    brew install hashicorp/tap/packer
 
-The following instructions will install Packer on Ubuntu 18.04 from a downloaded binary. For more installation methods, including installing on other operating systems or compiling from source, see [Packer's official documentation](https://www.packer.io/intro/getting-started/install.html).
+### Ubuntu
 
-1. Make a Packer project directory in your home directory and then navigate to it:
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+    sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+    sudo apt-get update && sudo apt-get install packer
 
-        mkdir ~/packer
-        cd ~/packer
+### CentOS/RHEL
 
-1. Download the precompiled binary for your system from the Packer website. Example `wget` commands are listed using the latest version available at time of publishing (1.4.4). You should inspect the links on the [download page](https://www.packer.io/downloads.html) to see if a newer version is available and update the `wget` commands to use those URLs instead:
+    sudo yum install -y yum-utils
+    sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+    sudo yum -y install packer
 
-    * The 64-bit Linux `.zip` archive
+### Verifing the Installation
 
-            wget https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_linux_amd64.zip
+Verify that Packer was successfully installed by running the command `packer --version`. This should output the version number for this installation of Packer. For reference, this guide was last tested using version 1.7.2.
 
-    * The SHA256 checksums file
+## Creating a Template for Packer
 
-            wget https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_SHA256SUMS
+Now that Packer is installed, you can make a Packer [template](https://www.packer.io/docs/templates). A template is a file that contains the configurations needed to build a machine image. A template can be formatted in [JSON](https://www.packer.io/docs/templates/legacy_json_templates) or [HCL2](https://www.packer.io/docs/templates/hcl_templates) (Hashicorp Configuration Language). As of Packer v1.7.0, the HCL2 template format is preferred and, as such, will be used in the examples within this guide.
 
-    * The checksum signature file
-
-            wget https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_SHA256SUMS.sig
-
-### Verify the Download
-
-1. Import the HashiCorp Security GPG key (listed on the [HashiCorp Security](https://www.hashicorp.com/security.html) page under Secure Communications):
-
-        gpg --recv-keys 51852D87348FFC4C
-
-    The output should show that the key was imported:
-
-      {{< output >}}
-gpg: keybox '/home/user/.gnupg/pubring.kbx' created
-gpg: key 51852D87348FFC4C: 17 signatures not checked due to missing keys
-gpg: /home/user/.gnupg/trustdb.gpg: trustdb created
-gpg: key 51852D87348FFC4C: public key "HashiCorp Security <security@hashicorp.com>" imported
-gpg: no ultimately trusted keys found
-gpg: Total number processed: 1
-gpg:               imported: 1
-{{</ output >}}
-
-1. Verify the checksum file’s GPG signature:
-
-        gpg --verify packer*.sig packer*SHA256SUMS
-
-    The output should contain the `Good signature from "HashiCorp Security <security@hashicorp.com>"` confirmation message:
-
-      {{< output >}}
-gpg: Signature made Tue 01 Oct 2019 06:30:17 PM UTC
-gpg:                using RSA key 91A6E7F85D05C65630BEF18951852D87348FFC4C
-gpg: Good signature from "HashiCorp Security <security@hashicorp.com>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: 91A6 E7F8 5D05 C656 30BE  F189 5185 2D87 348F FC4C
-      {{</ output >}}
-
-1. Verify that the fingerprint output matches the fingerprint listed in the *Secure Communications* section of the [HashiCorp Security](https://www.hashicorp.com/security.html) page.
-
-1. Verify the .zip archive’s checksum:
-
-        sha256sum -c packer*SHA256SUMS 2>&1 | grep OK
-
-    The output should show the file's name as given in the `packer*SHA256SUMS` file:
-
-      {{< output >}}
-packer_1.4.4_linux_amd64.zip: OK
-      {{</ output >}}
-
-### Configure the Packer Environment
-
-1. Unzip `packer_*_linux_amd64.zip` to your `~/packer` directory:
-
-        unzip packer_*_linux_amd64.zip
-
-    {{< note >}}
-If you receive an error that indicates `unzip` is missing from your system, install the `unzip` package and try again.
-    {{</ note >}}
-
-1. Edit your `~./profile` shell configuration file to include the `~/packer` directory in your PATH. Then, reload the Bash profile:
-
-        echo 'export PATH="$PATH:$HOME/packer"' >> ~/.profile
-        source ~/.profile
-
-    {{< note >}}
-If you use a different shell, your shell configuration may have a different file name.
-{{< /note >}}
-
-1. Verify Packer can run by calling it with no options or arguments:
-
-        packer
-
-    {{< output >}}
-Usage: packer [--version] [--help] <command> [<args>]
-
-Available commands are:
-    build       build image(s) from template
-    console     creates a console for testing variable interpolation
-    fix         fixes templates from old versions of packer
-    inspect     see components of a template
-    validate    check that a template is valid
-    version     Prints the Packer version
-    {{</ output >}}
-
-## Use the Linode Packer Builder
-
-Now that Packer is installed on your local system, you can create a Packer *template*. A template is a JSON formatted file that contains the configurations needed to build a machine image.
-
-In this section you will create a template that uses the Linode Packer builder to create an image using Debian 9 as its base distribution. The template will also configure your system image with a new limited user account, and a public SSH key from your local computer. The additional system configuration will be completed using Packer's Ansible [*provisioner*](https://www.packer.io/docs/provisioners/index.html) and an example Ansible Playbook. A Packer provisioner is a built-in third-party integration that further configures a machine instance during the boot process and prior to taking the machine's snapshot.
+In this section, you will create a template that uses the Linode Packer builder to generate an image using Debian 10 as its base distribution. The template will also configure your system image with a new limited user account and a public SSH key from your local computer.
 
 {{< note >}}
 The steps in this section will incur charges related to deploying a [1GB Linode]((https://www.linode.com/pricing) (Nanode). The Linode will only be deployed for the duration of the time needed to create and snapshot your image and will then be deleted. See our [Billing and Payments](/docs/platform/billing-and-support/billing-and-payments/) guide for details about [hourly billing](/docs/platform/billing-and-support/billing-and-payments/#how-hourly-billing-works).
 {{</ note >}}
 
+### Template Blocks
+
+An HCL2 formatted template file typically contains several [blocks](https://www.packer.io/docs/templates/hcl_templates/blocks). A block can define a variable, specify the exact parameters for a builder plugin, or outline what should happen when the template is built. Here's a few blocks that will be used in this tutorial:
+
+- **Variable:** A `variable` block contains a single user-defined variable along with any additional parameters or values. In the section that follows, you will use a command line variable to pass your Linode account's API token to the template. A command line variable is a user-defined variable that's intentionally left blank in the template but will be defined when running the packer `build` command (ex: `-var api_token=x`, where `x` is your API Token).
+- **Source:** A `source` block defines the parameters for a builder plugin, such as the Linode Packer builder used in the example below. These sources can then be used within the `build` block. Multiple sources can be defined in a template, along you to potentially create multiple images for multiple platforms.
+- **Build:** The `build` block tells Packer what to do when the template is built. This will reference a `source` and optionally specify a `provisioner` or `post-processor`.
+
+    - **provisioners**: (*optional*) with a provisioner you can further configure your system by completing common system administration tasks, like adding users, installing and configuring software, and more. The example uses Packer's built-in Ansible provider and executes the tasks defined in the local `limited_user_account.yml` playbook. This means your Linode image will also contain anything executed by the playbook on your Linode. Packer supports several other [provisioners](https://www.packer.io/docs/provisioners/index.html), like Chef, Salt, and shell scripts.
+
 ### Access Linode and Private Images
 
-The Linode Packer Builder requires a Linode Image ID to deploy a disk from. This guide's example will use the image `linode/debian9`, but you can replace it with any other image you prefer. To list the official Linode images and your account's private images, you can curl the Linode API:
+The Linode Packer Builder requires a Linode Image ID to deploy a disk from. This guide's example will use the image `linode/debian10`, but you can replace it with any other image you prefer. To list the official Linode images and your account's private images, you can curl the Linode API:
 
     curl -H "Authorization: Bearer $TOKEN" \
         https://api.linode.com/v4/images
 
-### Create Your Template
+### Create the Template File
 
-{{< note >}}
-The Packer builder does not manage images. Once it creates an image, it will be stored on your Linode account and can be accessed and used as needed from the Linode Cloud Manager, via Linode's API v4, or using third-party tools like Terraform. Linode Images are limited to 2GB per Image and 3 Images per account.
-{{</ note >}}
+Create a file named `example.pkr.hcl` with the following content:
 
-Create a file named `example.json` with the following content:
+{{< file "~/packer/example.pkr.hcl">}}
+variable "linode_api_token" {
+  type    = string
+  default = ""
+}
+
+source "linode" "example" {
+  image             = "linode/debian10"
+  image_description = "This image was created using Packer."
+  image_label       = "packer-debian-10"
+  instance_label    = "temp-packer-debian-10"
+  instance_type     = "g6-nanode-1"
+  linode_token      = "${var.linode_api_token}"
+  region            = "us-east"
+  ssh_username      = "root"
+}
+
+build {
+  sources = ["source.linode.example"]
+}
+{{</ file >}}
+
+## Building the Image
+
+You should now have your completed template file and your Ansible Playbook file (optional) and can validate the template and finally, build your image.
+
+1. Validate the template before building your image. Replace the value of `my_linode_token` with your own Linode API v4 token.
+
+        packer validate -var 'my_linode_token=myL0ngT0kenStr1ng' example.json
+
+      If successful, you will see the following:
+
+      {{< output >}}
+Template validated successfully.
+      {{</ output >}}
+
+      {{< note >}}
+  To learn how to securely store and use your API v4 token, see the [Vault Variables](https://www.packer.io/docs/templates/user-variables.html#vault-variables) section of Packer's documentation.
+      {{</ note >}}
+
+1. You can now build your final image. Replace the value of `my_linode_token` with your own Linode API v4 token. This process may take a few minutes to complete.
+
+        packer build -var 'my_linode_token=myL0ngT0kenStr1ng' example.json
+
+      The output will provide you with your new private image's ID. In the example output the image ID is `private/7550080`. This image is now available on your Linode account to use as you desire. As an example, in the next section you will use this newly created image to deploy a new 1GB Linode (Nanode) using Linode's API v4.
+
+### Deploy a Linode with the New Image
+
+1. Issue the following curl command to deploy a 1GB Linode (Nanode) to the us-east data center using your new Image to your Linode account. Ensure you replace `private/7550080` with your own Linode Image's ID and assign your own `root_pass` and `label`.
+
+        curl -H "Content-Type: application/json" \
+          -H "Authorization: Bearer $TOKEN" \
+          -X POST -d '{
+            "image": "private/7550080",
+            "root_pass": "aComplexP@ssword",
+            "booted": true,
+            "label": "my-example-label",
+            "type": "g6-nanode-1",
+            "region": "us-east"
+          }' \
+          https://api.linode.com/v4/linode/instances
+
+    You should receive a similar response from the API:
+
+    {{< output >}}
+{"id": 17882092, "created": "2019-10-23T22:47:47", "group": "", "specs": {"gpus": 0, "transfer": 1000, "memory": 1024, "disk": 25600, "vcpus": 1}, "label": "my-example-linode", "updated": "2019-10-23T22:47:47", "watchdog_enabled": true, "image": null, "ipv4": ["192.0.2.0"], "ipv6": "2600:3c03::f03c:92ff:fe98:6d9a/64", "status": "provisioning", "tags": [], "region": "us-east", "backups": {"enabled": false, "schedule": {"window": null, "day": null}}, "hypervisor": "kvm", "type": "g6-nanode-1", "alerts": {"cpu": 90, "network_in": 10, "transfer_quota": 80, "io": 10000, "network_out": 10}}%
+    {{</ output >}}
+
+1.  If you used the Ansible provisioner, once your Linode is deployed, you should be able to SSH into your newly deployed Linode using the limited user account you created with the Ansible playbook and your public SSH key. Your Linode's IPv4 address will be available in the API response returned after creating the Linode.
+
+        ssh my-user-name@192.0.2.0
+
+## (Optional) Using Ansible as a Provisioner
+
+Edit your tempalte file and add a `provisioners` section, specifing `ansible` as the type of provisioner as well as the location of the playbook file.
 
 {{< file "~/packer/example.json">}}
 {
@@ -217,36 +226,7 @@ Create a file named `example.json` with the following content:
 }
 {{</ file >}}
 
-If you would rather not use a provisioner in your Packer template, you can use the example file below:
-{{< file "~/packer/example.json">}}
-{
-  "variables": {
-    "my_linode_token": ""
-  },
-  "builders": [{
-    "type": "linode",
-    "image": "linode/debian9",
-    "linode_token": "{{user `my_linode_token` }}",
-    "region": "us-east",
-    "instance_type": "g6-nanode-1",
-    "instance_label": "temp-linode-packer",
-    "image_label": "my-private-packer-image",
-    "image_description": "My private packer image",
-    "ssh_username": "root"
-  }]
-}
-{{</ file >}}
-
-There are three sections to the Packer template file:
-
-  * **variables**: This section allows you to further configure your template with [command-line variables, environment variables, Vault, or variable files](https://www.packer.io/docs/templates/user-variables.html). In the section that follows, you will use a command line variable to pass your Linode account's API token to the template.
-  * **builders**: The builder section contains the definition for the machine image that will be created. In the example template, you use a single builder --the [Linode builder](https://www.packer.io/docs/builders/linode.html). The builder uses the `linode/debian9` image as its base and will assign the image a label of `my-private-packer-image`. It will deploy a 1GB Linode (Nanode), take a snapshot, and create a reusable Linode Image. Refer to Packer's official documentation for a complete [Linode Builder configuration reference](https://www.packer.io/docs/builders/linode.html).
-
-    {{< note >}}
-You can use multiple builders in a single template file. This process is known as a [parallel build](https://www.packer.io/intro/getting-started/parallel-builds.html) which allows you to create multiple images for multiple platforms from a single template.
-{{</ note >}}
-
-  * **provisioners**: (*optional*) with a provisioner you can further configure your system by completing common system administration tasks, like adding users, installing and configuring software, and more. The example uses Packer's built-in Ansible provider and executes the tasks defined in the local `limited_user_account.yml` playbook. This means your Linode image will also contain anything executed by the playbook on your Linode. Packer supports several other [provisioners](https://www.packer.io/docs/provisioners/index.html), like Chef, Salt, and shell scripts.
+The additional system configuration will be completed using Packer's Ansible [*provisioner*](https://www.packer.io/docs/provisioners/index.html) and an example Ansible Playbook. A Packer provisioner is a built-in third-party integration that further configures a machine instance during the boot process and prior to taking the machine's snapshot.
 
 ### Create your Ansible Playbook (Optional)
 
@@ -285,93 +265,6 @@ $6$aISRzCJH4$nNJ/9ywhnH/raHuVCRu/unE7lX.L9ragpWgvD0rknlkbAw0pkLAwkZqlY.ahjj/AAIK
 {{</ file >}}
 
     * This Playbook will created a limited user account named `my-user-name`. You can replace `my-user-name`, the value of the variable `NORMAL_USER_NAME`, with any system username you'd like to create. It will then add a public SSH key stored on your local computer. If the public key you'd like to use is stored in a location other than `~/.ssh/id_rsa.pub`, you can update that value. Finally, the Playbook adds the new system user to the `sudoers` file.
-
-### Create your Linode Image
-
-You should now have your completed template file and your Ansible Playbook file (optional) and can validate the template and finally, build your image.
-
-1. Validate the template before building your image. Replace the value of `my_linode_token` with your own Linode API v4 token.
-
-        packer validate -var 'my_linode_token=myL0ngT0kenStr1ng' example.json
-
-      If successful, you will see the following:
-
-      {{< output >}}
-Template validated successfully.
-      {{</ output >}}
-
-      {{< note >}}
-  To learn how to securely store and use your API v4 token, see the [Vault Variables](https://www.packer.io/docs/templates/user-variables.html#vault-variables) section of Packer's documentation.
-      {{</ note >}}
-
-1. You can now build your final image. Replace the value of `my_linode_token` with your own Linode API v4 token. This process may take a few minutes to complete.
-
-        packer build -var 'my_linode_token=myL0ngT0kenStr1ng' example.json
-
-      {{< output >}}
-linode output will be in this color.
-
-==> linode: Running builder ...
-==> linode: Creating temporary SSH key for instance...
-==> linode: Creating Linode...
-==> linode: Using ssh communicator to connect: 192.0.2.0
-==> linode: Waiting for SSH to become available...
-==> linode: Connected to SSH!
-==> linode: Provisioning with Ansible...
-==> linode: Executing Ansible: ansible-playbook --extra-vars packer_build_name=linode packer_builder_type=linode -o IdentitiesOnly=yes -i /tmp/packer-provisioner-ansible136766862 /home/user/packer/limited_user_account.yml -e ansible_ssh_private_key_file=/tmp/ansible-key642969643
-    linode:
-    linode: PLAY [all] *********************************************************************
-    linode:
-    linode: TASK [Gathering Facts] *********************************************************
-    linode: ok: [default]
-    linode:
-    linode: TASK [Create a secondary, non-root user] ***************************************
-    linode: changed: [default]
-    linode:
-    linode: TASK [Add remote authorized key to allow future passwordless logins] ***********
-    linode: changed: [default]
-    linode:
-    linode: TASK [Add normal user to sudoers] **********************************************
-    linode: changed: [default]
-    linode:
-    linode: PLAY RECAP *********************************************************************
-    linode: default                    : ok=4    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
-    linode:
-==> linode: Shutting down Linode...
-==> linode: Creating image...
-Build 'linode' finished.
-
-==> Builds finished. The artifacts of successful builds are:
---> linode: Linode image: my-private-packer-image (private/7550080)
-      {{</ output >}}
-
-      The output will provide you with your new private image's ID. In the example output the image ID is `private/7550080`. This image is now available on your Linode account to use as you desire. As an example, in the next section you will use this newly created image to deploy a new 1GB Linode (Nanode) using Linode's API v4.
-
-### Deploy a Linode with your New Image
-
-1. Issue the following curl command to deploy a 1GB Linode (Nanode) to the us-east data center using your new Image to your Linode account. Ensure you replace `private/7550080` with your own Linode Image's ID and assign your own `root_pass` and `label`.
-
-        curl -H "Content-Type: application/json" \
-          -H "Authorization: Bearer $TOKEN" \
-          -X POST -d '{
-            "image": "private/7550080",
-            "root_pass": "aComplexP@ssword",
-            "booted": true,
-            "label": "my-example-label",
-            "type": "g6-nanode-1",
-            "region": "us-east"
-          }' \
-          https://api.linode.com/v4/linode/instances
-
-    You should receive a similar response from the API:
-
-    {{< output >}}
-{"id": 17882092, "created": "2019-10-23T22:47:47", "group": "", "specs": {"gpus": 0, "transfer": 1000, "memory": 1024, "disk": 25600, "vcpus": 1}, "label": "my-example-linode", "updated": "2019-10-23T22:47:47", "watchdog_enabled": true, "image": null, "ipv4": ["192.0.2.0"], "ipv6": "2600:3c03::f03c:92ff:fe98:6d9a/64", "status": "provisioning", "tags": [], "region": "us-east", "backups": {"enabled": false, "schedule": {"window": null, "day": null}}, "hypervisor": "kvm", "type": "g6-nanode-1", "alerts": {"cpu": 90, "network_in": 10, "transfer_quota": 80, "io": 10000, "network_out": 10}}%
-    {{</ output >}}
-
-1.  If you used the Ansible provisioner, once your Linode is deployed, you should be able to SSH into your newly deployed Linode using the limited user account you created with the Ansible playbook and your public SSH key. Your Linode's IPv4 address will be available in the API response returned after creating the Linode.
-
-        ssh my-user-name@192.0.2.0
 
 ## Next Steps
 

--- a/docs/guides/applications/configuration-management/packer/how-to-use-linode-packer-builder/index.md
+++ b/docs/guides/applications/configuration-management/packer/how-to-use-linode-packer-builder/index.md
@@ -19,57 +19,37 @@ contributor:
 aliases: ['/applications/configuration-management/how-to-use-linode-packer-builder/','/applications/configuration-management/packer/how-to-use-linode-packer-builder/']
 ---
 
-## Introduction
+## Introduction to Packer
 
-### What is Packer?
+[Packer](https://www.packer.io/) is a HashiCorp maintained open source tool that is used to create machine images. A machine image provides the operating system, applications, application configurations, and data files that a virtual machine instance will run once it's deployed. Packer can be used in conjunction with common configuration management tools like Chef, Puppet, or Ansible to install software to your Linode and include those configurations into your image.
 
-Packer is a HashiCorp maintained open source tool that is used to create machine images. A machine image provides the operating system, applications, application configurations, and data files that a virtual machine instance will run once it's deployed. Using a single source configuration, you can generate identical machine images. Packer can be used in conjunction with common configuration management tools like Chef, Puppet, or Ansible to install software to your Linode and include those configurations into your image.
+Packer *templates* store the configuration parameters used for building an image. This standardizes the imaging building process and ensures that everyone using that template file will always create an idential image. For instance, this can help your team maintain an [immutable infrastructure](/docs/development/ci/what-is-immutable-infrastructure/) within your [continuous delivery](/docs/development/ci/introduction-ci-cd/#what-is-continuous-delivery) pipeline.
 
-You can share your image template across your team to ensure everyone is using a uniform development and testing environment. This process will help your team maintain an [immutable infrastructure](/docs/development/ci/what-is-immutable-infrastructure/) within your [continuous delivery](/docs/development/ci/introduction-ci-cd/#what-is-continuous-delivery) pipeline.
+## The Linode Packer Builder
 
-In this guide you will complete the following steps:
+In Packer's ecosystem, [builders](https://www.packer.io/docs/builders) are responsible for building a system and generating an image from that system. Packer has multiple different types of builders, with each one being used to create images for a specific platform.
 
-* [Install Packer](#install-packer-on-ubuntu-18-04) on your computer.
-* [Create a Packer image template](#create-your-template). Optionally, the template will execute system configurations using Packer's Ansible provisioner.
-* [Generate a Linode Image](#create-your-linode-image) from your Packer template.
-* [Deploy a Linode](#deploy-a-linode-with-your-new-image) from your stored Packer image.
-
-### What is the Linode Packer Builder?
-
-In Packer's ecosystem, [builders](https://www.packer.io/docs/builders) are responsible for *building* a system and then generating an image from that system. Packer has multiple different types of builders, with each one being used to create images for a specific platform. For integration with [Linode Images](/docs/products/tools/images/), this guide will use the [Linode builder](https://www.packer.io/docs/builders/linode).
-
-When the Linode Packer builder runs, it's able to access your Linode account through the API token you created. It will use the template specified in the `build` command to create a Linode based on the image, plan type, scripts, and other parameters defined within that template. After Packer has successfully built and configured the Linode, a custom image based on that Linode's main disk will be created. This custom image is stored privately on your Linode account and can be used when creating new Linodes.
-
-{{< note >}}
-The Packer builder does not manage images. Once it creates an image, it will be stored on your Linode account and can be accessed and used as needed from the Linode Cloud Manager, via Linode's API v4, or using third-party tools like Terraform. Linode Images are limited to 2GB per Image and 3 Images per account.
-{{</ note >}}
+The [Linode builder](https://www.packer.io/docs/builders/linode) integrates Packer with the Linode platform. This allows Packer to deploy a temporary Linode on your account (using an APIv4 token), configure the system on the Linode according to the parameters in the provided template file, and then create an image based on that Linode. Essentially, this is a convient way to automatically create [Linode Images](/docs/products/tools/images/) on your acount that can be used for rapidly deploying new Linodes.
 
 ## Before You Begin
 
+This guide will walk you through the process of installing Packer, creating a  template file, building the image, and then deploying that image onto a new Linode. Going futher, it will also cover how to use the Ansible tool with Packer. Before you begin, review the following:
+
 1. Ensure you have access to [cURL](https://en.wikipedia.org/wiki/CURL) on your computer.
 
-1. Generate a Linode API v4 access token with permission to read and write Linodes. You can follow the [Get an Access Token](/docs/platform/api/getting-started-with-the-linode-api/#get-an-access-token) section of the [Getting Started with the Linode API](/docs/platform/api/getting-started-with-the-linode-api/) guide if you do not already have one.
+1. Generate a Linode API v4 access token with read/write permission for both *Linodes* and *Images*. You can follow the [Get an Access Token](/docs/platform/api/getting-started-with-the-linode-api/#get-an-access-token) section of the [Getting Started with the Linode API](/docs/platform/api/getting-started-with-the-linode-api/) guide if you do not already have one.
+
+1. *Optional:* Set a variable named `TOKEN` in your shell enviroment by running the following command. Replace *x* with your own API token.
+
+       export TOKEN=x
 
     {{< note >}}
-The example cURL commands in this guide will refer to a `$TOKEN` environment variable. For example:
-
-    curl -H "Authorization: Bearer $TOKEN" \
-        https://api.linode.com/v4/images
-
-To set this variable up in your terminal, run:
-
-    export TOKEN='<your-Linode-APIv4-token>'
-
-If you do not do this, you will need to alter these commands so that your API token is inserted wherever `$TOKEN` appears.
+Some of the example commands provided in this guide will use this variable. If you do not set this variable, you will need to modify these commands by replacing `$TOKEN` with your API token.
 {{< /note >}}
-
-1. [Create an SSH authentication key-pair](/docs/security/securing-your-server/#create-an-authentication-key-pair) if your computer does not already have one. Your SSH public key will be added to your image via an Ansible module.
-
-1. Install Ansible on your computer and familiarize yourself with basic Ansible concepts (optional). Using the [Getting Started With Ansible - Basic Installation and Setup](/docs/applications/configuration-management/getting-started-with-ansible/) guide, follow the steps in the [Install Ansible](/docs/applications/configuration-management/getting-started-with-ansible/#install-ansible) section.
 
 ## Installing Packer
 
-The following instructions will install the latest version of Packer on Mac, Ubuntu, or CentOS. For more installation methods, including installing on other operating systems or compiling from source, see [Packer's official documentation](https://www.packer.io/intro/getting-started/install.html) and the [Download Packer](https://www.packer.io/downloads) webpage.
+The following instructions will install the latest version of Packer on Mac, Ubuntu, or CentOS. For more installation methods, including installing on other operating systems or compiling from source, see [Packer's official documentation](https://www.packer.io/intro/getting-started/install.html) and the [Download Packer](https://www.packer.io/downloads) web page.
 
 ### Mac
 
@@ -94,36 +74,17 @@ To install Packer on Mac, [Homebrew](https://brew.sh/) will be used. Run the fol
 
 Verify that Packer was successfully installed by running the command `packer --version`. This should output the version number for this installation of Packer. For reference, this guide was last tested using version 1.7.2.
 
-## Creating a Template for Packer
+## Constructing a Template for Packer
 
 Now that Packer is installed, you can make a Packer [template](https://www.packer.io/docs/templates). A template is a file that contains the configurations needed to build a machine image. A template can be formatted in [JSON](https://www.packer.io/docs/templates/legacy_json_templates) or [HCL2](https://www.packer.io/docs/templates/hcl_templates) (Hashicorp Configuration Language). As of Packer v1.7.0, the HCL2 template format is preferred and, as such, will be used in the examples within this guide.
 
-In this section, you will create a template that uses the Linode Packer builder to generate an image using Debian 10 as its base distribution. The template will also configure your system image with a new limited user account and a public SSH key from your local computer.
-
 {{< note >}}
-The steps in this section will incur charges related to deploying a [1GB Linode]((https://www.linode.com/pricing) (Nanode). The Linode will only be deployed for the duration of the time needed to create and snapshot your image and will then be deleted. See our [Billing and Payments](/docs/platform/billing-and-support/billing-and-payments/) guide for details about [hourly billing](/docs/platform/billing-and-support/billing-and-payments/#how-hourly-billing-works).
+The steps in this section will incur charges related to deploying a [1GB Linode](https://www.linode.com/pricing) (Nanode). The Linode will only be deployed for the duration of the time needed to create and snapshot your image and will then be deleted. See our [Billing and Payments](/docs/platform/billing-and-support/billing-and-payments/) guide for details about [hourly billing](/docs/platform/billing-and-support/billing-and-payments/#how-hourly-billing-works).
 {{</ note >}}
 
-### Template Blocks
+### Creating the Template File
 
-An HCL2 formatted template file typically contains several [blocks](https://www.packer.io/docs/templates/hcl_templates/blocks). A block can define a variable, specify the exact parameters for a builder plugin, or outline what should happen when the template is built. Here's a few blocks that will be used in this tutorial:
-
-- **Variable:** A `variable` block contains a single user-defined variable along with any additional parameters or values. In the section that follows, you will use a command line variable to pass your Linode account's API token to the template. A command line variable is a user-defined variable that's intentionally left blank in the template but will be defined when running the packer `build` command (ex: `-var api_token=x`, where `x` is your API Token).
-- **Source:** A `source` block defines the parameters for a builder plugin, such as the Linode Packer builder used in the example below. These sources can then be used within the `build` block. Multiple sources can be defined in a template, along you to potentially create multiple images for multiple platforms.
-- **Build:** The `build` block tells Packer what to do when the template is built. This will reference a `source` and optionally specify a `provisioner` or `post-processor`.
-
-    - **provisioners**: (*optional*) with a provisioner you can further configure your system by completing common system administration tasks, like adding users, installing and configuring software, and more. The example uses Packer's built-in Ansible provider and executes the tasks defined in the local `limited_user_account.yml` playbook. This means your Linode image will also contain anything executed by the playbook on your Linode. Packer supports several other [provisioners](https://www.packer.io/docs/provisioners/index.html), like Chef, Salt, and shell scripts.
-
-### Access Linode and Private Images
-
-The Linode Packer Builder requires a Linode Image ID to deploy a disk from. This guide's example will use the image `linode/debian10`, but you can replace it with any other image you prefer. To list the official Linode images and your account's private images, you can curl the Linode API:
-
-    curl -H "Authorization: Bearer $TOKEN" \
-        https://api.linode.com/v4/images
-
-### Create the Template File
-
-Create a file named `example.pkr.hcl` with the following content:
+Create a file named `example.pkr.hcl`. The file can be stored anywhere, though you may want to create a folder called `packer` in your home directory where you can store all of your template files. Edit this file and type or paste in the following content:
 
 {{< file "~/packer/example.pkr.hcl">}}
 variable "linode_api_token" {
@@ -147,33 +108,81 @@ build {
 }
 {{</ file >}}
 
+### Understanding Template Blocks
+
+An HCL2 formatted template file typically contains several [blocks](https://www.packer.io/docs/templates/hcl_templates/blocks). A block can define a variable, specify the exact parameters for a builder plugin, or outline what should happen when the template is built. Here's a few blocks that will be used most templates:
+
+- [Variable Block](#variable-block)
+- [Source Block](#source-block-the-linode-builder)
+- [Build Block](#build-block)
+
+### Variable Block
+
+A `variable` block contains a single user-defined variable along with any additional parameters or values. There can be multiple variable blocks in a template to define multiple variables. The value of a variable can be used elsewhere in the template through the syntax `${var.variable_name}`, where *variable_name* is the name given to the variable.
+
+This example only contains one variable: `linode_api_token`. The value of this variable is intentionally left blank (`default = ""`). Instead of setting the variable within the template, it will be set through the command-line when running the `packer build` command: `packer build -var linode_api_token=x example.pkr.hcl`, where *x* is your API token.
+
+Learn more about Packer tempate variables on the [Variables](https://www.packer.io/docs/templates/hcl_templates/variables) page of Packer's documentation.
+
+### Source Block (the Linode Builder)
+
+A `source` block defines the parameters for a builder plugin. These sources can then be used within the `build` block. Multiple sources can be defined in a template, allowing you to potentially create multiple images for multiple platforms. A full list of available builders can be found on the [Builders](https://www.packer.io/docs/builders) page of Packer's documentation.
+
+The starting line of each `source` block will contain the builder plugin to be used as well as the name given to this particular source in the template. For instance, the starting line for the source in this example (`source "linode" "example" {`) specifies that the Linode builder will be used and this source will be named "example".
+
+#### Parameters for the Linode Builder
+
+This example uses the Linode Packer builder as a source. Each of the parameters within the `source` block are outlined on the [Linode Builder](https://www.packer.io/docs/builders/linode) page within Packer's documentation.
+
+- `image`: The ID of the "starter" image to use. This can be one of the official Linode images or any private custom images on your account. In this example, we'll use `linode/debian10` to specify the official Linode Debian 10 image. You can view all the images available to you by running the following curl command:
+
+      curl -H "Authorization: Bearer $TOKEN" https://api.linode.com/v4/images
+
+- `image_label` (optional): The label for the new custom image this template will generate.
+- `image_description` (optional): A brief description for the new custom image.
+- `instance_label` (optional): The label for the temporary Linode that Packer will deploy in order to create the new image.
+- `instance_type` The ID of the instance type for this temporary Linode. This template specifies `g6-nanode-1`, which is the ID for a 1GB Linode (a Nanode). In most cases, a Nanode should work well for generating images as it comes with 25GB of disk space. You can view all of the Linode types by running the following curl command:
+
+      curl https://api.linode.com/v4/linode/types
+
+- `linode_token`: The Linode API Personal Access Token that is used to provider Packer with access to your account. This is set to `${var.linode_api_token}` in the template since we're going to use a command-line variable to provide this token rather than saving it directly in the template.
+- `region`: The ID of the data center. In this template, the ID for the Newark data center is used: `us-east`. You can view all of the regions by running the following curl command:
+
+      curl https://api.linode.com/v4/regions
+
+### Build Block
+
+The `build` block tells Packer what to do when the template is built. This will reference a `source` and optionally specify a `provisioner` or `post-processor`.
+
 ## Building the Image
 
-You should now have your completed template file and your Ansible Playbook file (optional) and can validate the template and finally, build your image.
+After the template file has been saved with your desired parameters, you're now ready to build the image.
 
-1. Validate the template before building your image. Replace the value of `my_linode_token` with your own Linode API v4 token.
+1. First, validate the template by running the `packer validate` command below. If you did not set TOKEN as a variable in your shell environment, replace *$TOKEN* with your own Linode API token. If successful, no errors will be given.
 
-        packer validate -var 'my_linode_token=myL0ngT0kenStr1ng' example.json
-
-      If successful, you will see the following:
-
-      {{< output >}}
-Template validated successfully.
-      {{</ output >}}
+        packer validate -var linode_api_token=$TOKEN example.pkr.hcl
 
       {{< note >}}
-  To learn how to securely store and use your API v4 token, see the [Vault Variables](https://www.packer.io/docs/templates/user-variables.html#vault-variables) section of Packer's documentation.
+  To learn how to securely store and use your API v4 token, see the [Vault](https://www.packer.io/docs/templates/hcl_templates/functions/contextual/vault) section of Packer's documentation.
       {{</ note >}}
 
-1. You can now build your final image. Replace the value of `my_linode_token` with your own Linode API v4 token. This process may take a few minutes to complete.
+1. Build the image by running the `packer build` command below. Just like in the last step, if you did not set TOKEN as a variable in your shell environment, replace *$TOKEN* with your own Linode API token. This process may take a few minutes to complete.
 
-        packer build -var 'my_linode_token=myL0ngT0kenStr1ng' example.json
+        packer build -var linode_api_token=$TOKEN example.pkr.hcl
 
-      The output will provide you with your new private image's ID. In the example output the image ID is `private/7550080`. This image is now available on your Linode account to use as you desire. As an example, in the next section you will use this newly created image to deploy a new 1GB Linode (Nanode) using Linode's API v4.
+      The output of this command will outline each process that Packer goes through. Once finished, the last line will provide you with the ID for the new custom image.
 
-### Deploy a Linode with the New Image
+## Deploying a Linode with the New Image
 
-1. Issue the following curl command to deploy a 1GB Linode (Nanode) to the us-east data center using your new Image to your Linode account. Ensure you replace `private/7550080` with your own Linode Image's ID and assign your own `root_pass` and `label`.
+Once the Packer build process completes, a new [Custom Image](/docs/products/tools/images/) will appear on your account. This image can be deployed a few ways:
+
+- **Cloud Manager:** Use the Cloud Manager to deploy a Custom Image by following the [Deploy an Image to a New Linode](/docs/products/tools/images/guides/deploy-image-to-new-linode/) guide.
+
+- **Linode CLI:** Use the Linode CLI through the command-line by following the [Using the Linode CLI](/docs/guides/linode-cli/) guide. The [Linode Instances](/docs/guides/linode-cli/#linode-instances) section of that guide will provide example commands. The command below will deploy a new Linode in the Newark data center. Replace *mypassword* with the root password you'd like to use and *linode/debian10* with the ID of your new image.
+
+      linode-cli linodes create --root_pass mypassword --region us-east --image linode/debian10
+
+- **Linode APIv4:** Use the Linode API to programatically create a new Linode by reviewing the documenation outlined under [API > Linode Istances > Linode Create](/docs/api/linode-instances/#linode-create). The following example curl command will deploy a 1GB Linode (Nanode) to the Newark data center. Ensure you replace any necessary parameters, including replacing `linode/debain10` with your Custom Image's ID and assigning your own `root_pass` and `label`.
 
         curl -H "Content-Type: application/json" \
           -H "Authorization: Bearer $TOKEN" \
@@ -187,70 +196,30 @@ Template validated successfully.
           }' \
           https://api.linode.com/v4/linode/instances
 
-    You should receive a similar response from the API:
+## Going Further with Ansible
 
-    {{< output >}}
-{"id": 17882092, "created": "2019-10-23T22:47:47", "group": "", "specs": {"gpus": 0, "transfer": 1000, "memory": 1024, "disk": 25600, "vcpus": 1}, "label": "my-example-linode", "updated": "2019-10-23T22:47:47", "watchdog_enabled": true, "image": null, "ipv4": ["192.0.2.0"], "ipv6": "2600:3c03::f03c:92ff:fe98:6d9a/64", "status": "provisioning", "tags": [], "region": "us-east", "backups": {"enabled": false, "schedule": {"window": null, "day": null}}, "hypervisor": "kvm", "type": "g6-nanode-1", "alerts": {"cpu": 90, "network_in": 10, "transfer_quota": 80, "io": 10000, "network_out": 10}}%
-    {{</ output >}}
+Packer is extremely powerful and customizable tool for creating images. The first template outlined in this guide is a minimalist example and doesn't showcase the true potential of Packer. To take things further, this section will cover integrating Packer with Ansible. Ansible is one of many different options available for customizing an image in Packer.
 
-1.  If you used the Ansible provisioner, once your Linode is deployed, you should be able to SSH into your newly deployed Linode using the limited user account you created with the Ansible playbook and your public SSH key. Your Linode's IPv4 address will be available in the API response returned after creating the Linode.
+Ansible is an automation tool for server provisioning, configuration, and management. Before continuing, follow the [Getting Started With Ansible - Basic Installation and Setup](/docs/applications/configuration-management/getting-started-with-ansible/) guide to install Ansible and familiarize yourself with basic Ansible concepts.
 
-        ssh my-user-name@192.0.2.0
+### Creating the Ansible Playbook
 
-## (Optional) Using Ansible as a Provisioner
+An Ansible playbook outlines the tasks and scripts to be run when provisioning a server. You will create a playbook that adds a limited user account on the Linode _before_ Packer creates the final image.
 
-Edit your tempalte file and add a `provisioners` section, specifing `ansible` as the type of provisioner as well as the location of the playbook file.
+1. Use the [mkpasswd](https://linux.die.net/man/1/mkpasswd) utility (available on many Linux systems) to generate a hashed password. This will be used when configuring Ansible's [user module](https://docs.ansible.com/ansible/latest/modules/user_module.html) for your limited user account.
 
-{{< file "~/packer/example.json">}}
-{
-  "variables": {
-    "my_linode_token": ""
-  },
-  "builders": [{
-    "type": "linode",
-    "image": "linode/debian9",
-    "linode_token": "{{user `my_linode_token` }}",
-    "region": "us-east",
-    "instance_type": "g6-nanode-1",
-    "instance_label": "temp-linode-packer",
-    "image_label": "my-private-packer-image",
-    "image_description": "My private packer image",
-    "ssh_username": "root"
-  }],
-  "provisioners": [
-    {
-      "type": "ansible",
-      "playbook_file": "./limited_user_account.yml"
-    }
-  ]
-}
-{{</ file >}}
+       mkpasswd --method=sha-512
 
-The additional system configuration will be completed using Packer's Ansible [*provisioner*](https://www.packer.io/docs/provisioners/index.html) and an example Ansible Playbook. A Packer provisioner is a built-in third-party integration that further configures a machine instance during the boot process and prior to taking the machine's snapshot.
+    You will be prompted to enter a plain-text password and the utility will return a hash of the password.
 
-### Create your Ansible Playbook (Optional)
-
-In the previous section you created a Packer template that makes use of an Ansible Playbook to add system configurations to your image. Prior to building your image, you will need to create the referenced `limited_user_account.yml` Playbook. You will complete those steps in this section. If you chose not to use the Ansible provider, you can skip this section.
-
-1. The example Ansible Playbook makes use of Ansible's [user module](https://docs.ansible.com/ansible/latest/modules/user_module.html). This module requires that a hashed value be used for its `password` parameter. Use the `mkpasswd` utility to generate a hashed password that you will use in the next step.
-
-        mkpasswd --method=sha-512
-
-      You will be prompted to enter a plain-text password and the utility will return a hash of the password.
-
-      {{< output >}}
-Password:
-$6$aISRzCJH4$nNJ/9ywhnH/raHuVCRu/unE7lX.L9ragpWgvD0rknlkbAw0pkLAwkZqlY.ahjj/AAIKo071LUB0BONl.YMsbb0
-          {{</ output >}}
-
-1. In your `packer` directory, create a file with the following content. Ensure you replace the value of the `password` parameter with your own hashed password:
+1. Create the playbook file with the following content. Replace *username* with the username you'd like to add and replace `password` with the password hash generated in the previous step.
 
     {{< file "~/packer/limited_user_account.yml">}}
 ---
 - hosts: all
   remote_user: root
   vars:
-    NORMAL_USER_NAME: 'my-user-name'
+    NORMAL_USER_NAME: 'username'
   tasks:
     - name: "Create a secondary, non-root user"
       user: name={{ NORMAL_USER_NAME }}
@@ -264,7 +233,47 @@ $6$aISRzCJH4$nNJ/9ywhnH/raHuVCRu/unE7lX.L9ragpWgvD0rknlkbAw0pkLAwkZqlY.ahjj/AAIK
                   line="{{ NORMAL_USER_NAME }}"
 {{</ file >}}
 
-    * This Playbook will created a limited user account named `my-user-name`. You can replace `my-user-name`, the value of the variable `NORMAL_USER_NAME`, with any system username you'd like to create. It will then add a public SSH key stored on your local computer. If the public key you'd like to use is stored in a location other than `~/.ssh/id_rsa.pub`, you can update that value. Finally, the Playbook adds the new system user to the `sudoers` file.
+    This playbook will also add the public SSH key stored on your local computer. If the public key you'd like to use is stored in a location other than `~/.ssh/id_rsa.pub`, you can update that value. Finally, the playbook adds the new system user to the `sudoers` file.
+
+### Modifying or Creating a New Template File
+
+Edit your existing template file or create a new template file with the following content. Specifically, you'll add a `provisioner` block within the `build` block, setting `ansible` as the type of provisioner and providing the location of the playbook file you created.
+
+{{< file "~/packer/ansible-example.pkr.hcl">}}
+variable "linode_api_token" {
+  type    = string
+  default = ""
+}
+
+source "linode" "ansible-example" {
+  image             = "linode/debian10"
+  image_description = "This image was created using Packer."
+  image_label       = "packer-advanced-debian-10"
+  instance_label    = "temp-packer-debian-10"
+  instance_type     = "g6-nanode-1"
+  linode_token      = "${var.linode_api_token}"
+  region            = "us-east"
+  ssh_username      = "root"
+}
+
+build {
+  sources = ["source.linode.ansible-example"]
+
+  provisioner "ansible" {
+    playbook_file = "./limited_user_account.yml"
+  }
+}
+{{</ file >}}
+
+### Understanding the Provisioner Block
+
+A provisioner allows you to further configure your system by completing common system administration tasks, like adding users, installing and configuring software, and more. The example uses Packer's built-in Ansible provider and executes the tasks defined in the local `limited_user_account.yml` playbook. This means your Linode image will also contain anything executed by the playbook. Packer supports several other provisioners, like Chef, Salt, and shell scripts. Learn more about Packer provisioners on the [Provisioner](https://www.packer.io/docs/templates/hcl_templates/blocks/build/provisioner) page of Packer's documentation.
+
+### Building and Deploying the Image
+
+Follow the previous sections for [building the image](#building-the-image) and [deploying the image](deploying-a-linode-with-the-new-image). Once a new Linode is deployed using the newly created image, you should be able to log in to that Linode over ssh by running the following command. Replace *username* with the username you specified in the Ansible playbook and replace *192.0.2.0* with the IPv4 address of your new Linode.
+
+    ssh username@192.0.2.0
 
 ## Next Steps
 


### PR DESCRIPTION
Significant reworking of this guide, including the following changes:
- New installation instructions for Packer
- Uses the HCL2 template syntax instead of the old JSON syntax
- Explains the components of a Packet template and the parameter for the Linode Packer builder
- Separates all Ansible content into its own section
- Outlines all image deployment methods, including the Cloud Manager and CLI in addition to the API