### PR TITLE
fix `kubectl logs` command

### DIFF
--- a/docs/guides/kubernetes/beginners-guide-to-kubernetes-part-4-controllers/index.md
+++ b/docs/guides/kubernetes/beginners-guide-to-kubernetes-part-4-controllers/index.md
@@ -219,7 +219,7 @@ You should see an output like the following:
 
 You can use the name of the Pod to inspect its output by consulting the log file for the Pod:
 
-    kubectl get logs hello-world-4jzdm
+    kubectl logs hello-world-4jzdm
 
 To delete the Job, and its Pod, issue the `delete` command:
 


### PR DESCRIPTION
The current command results in `error: the server doesn't have a resource type "logs"`.