### PR TITLE
fixed typo in new workspace command when creating a cluster

### DIFF
--- a/docs/guides/kubernetes/how-to-migrate-from-k8s-alpha-to-terraform/index.md
+++ b/docs/guides/kubernetes/how-to-migrate-from-k8s-alpha-to-terraform/index.md
@@ -219,7 +219,7 @@ module "k8s" {
 
 1.  Initialize and apply your new Terraform configuration:
 
-        terrform workspace new mynewcluster
+        terraform workspace new mynewcluster
         terraform init
         terraform apply
 


### PR DESCRIPTION
Command was "terrform workspace new mynewcluster" but should have been "terraform workspace new mynewcluster". Fixed typo 