### PR TITLE
Update index.md

### DIFF
--- a/docs/guides/platform/manager/what-are-the-cloud-manager-events-and-activity-feeds/index.md
+++ b/docs/guides/platform/manager/what-are-the-cloud-manager-events-and-activity-feeds/index.md
@@ -67,4 +67,4 @@ The Linode Activity Feed is similar to your Account's [Events Page](#Events-Page
 
     ![cloud manager events](cloud-manager-events.png)
 
-1. The list of events will contain the entire history of the life of your Linode and will continue to populate with past entries as you scroll down the page. When there are no entries left, you'll see the text "No more events to show" at the bottom of the page.
+1. The list of events will contain the history for the past 90 days of the life of your Linode. When there are no entries left, you'll see the text "No more events to show" at the bottom of the page.


### PR DESCRIPTION
The activity feed of a Linode is basically a filtered event list, obtained from the events-list(https://www.linode.com/docs/api/account/#events-list) API endpoint. This endpoint has a limitation of 90 days of history.