### PR TITLE
Update Minecraft download link to use working URL

### DIFF
--- a/docs/guides/platform/marketplace/deploying-minecraft-with-marketplace-apps/index.md
+++ b/docs/guides/platform/marketplace/deploying-minecraft-with-marketplace-apps/index.md
@@ -89,7 +89,7 @@ When you've provided all required Linode Options, click on the **Create** button
 
 ## Getting Started after Deployment
 
-Ensure that you have [installed Minecraft](https://my.minecraft.net/store/minecraft/) on your personal computer and created a Minecraft user account before getting started with this section.
+Ensure that you have [installed Minecraft](https://www.minecraft.net/en-us/get-minecraft) on your personal computer and created a Minecraft user account before getting started with this section.
 
 After Minecraft has finished installing on your Linode, you are able to access your Minecraft server by copying your Linode's IPv4 address and entering it in the Multiplayer menu on your personal computer's Minecraft installation. To find your Linode's IPv4 address:
 


### PR DESCRIPTION
This is a simple PR to update the Minecraft link in the Minecraft Marketplace App guide. The existing link appears to not resolve, but this one is tested and working.