### PR TITLE
[Update] Linode Support

### DIFF
--- a/docs/guides/platform/billing-and-support/support/index.md
+++ b/docs/guides/platform/billing-and-support/support/index.md
@@ -80,8 +80,6 @@ If you are having difficulty logging in to the Linode Cloud Manager and opening 
 
 - **+1 (855) 454-6633** (North America toll-free)
 
-- **+91 000-800-919-0534** (India toll-free)
-
 If your call is diverted to voicemail, please leave a detailed message explaining your problem. Your call will be returned as quickly as possible.
 
 ## Reporting Abuse


### PR DESCRIPTION
Removed the India Toll Free number to match the rest of our contact pages. We removed it because of reliability issues we were seeing when customers used that number. 