### PR TITLE
Adjusted lastmod assignment within configuration file

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,7 @@ enableGitInfo = true
 home = ["HTML", "JSON", "RSS"]
 
 [frontmatter]
-lastmod = [":git", "lastmod", "date", "publishDate"]
+lastmod = ["lastmod", "date", "publishDate", ":git"]
 publishDate = ["published", "publishDate", "date"]
 
 [params]


### PR DESCRIPTION
This PR fixes the dates displayed within our guides.

### Problem

Currently, Hugo uses the date from GitHub ([https://gohugo.io/variables/git/#lastmod](https://gohugo.io/variables/git/#lastmod)) to decide when an article was last modified. It does **not** used the `modified` parameter in the front matter. This results in most of the dates listed on our guides to be incorrect:

- Guides that were last edited mid-week and released on a Friday will be listed as "Updated on [Friday's date]" instead of "Published (or Updated) on [publish/modified date in front matter]"
- All guides published and last updated prior to October 7th of 2020 (most of our guides) have an "Updated October 7th 2020" instead of the proper updated or published date, which could be years in the past. This gives the false impression to users (and Google) that the content was updated recently.

### Fix

This PR adjusts the `lastmod` assignment order in the configuration file to prioritize the "lastmod" / "modified" (an alias of lastmod) front matter parameter ahead of the information from git.

See [Configure Dates](https://gohugo.io/getting-started/configuration/#configure-dates) in Hugo's documentation for details on adjusting this.

### Bug or feature?

It seems like the modified parameter was purposefully deprecated in favor of the git date. See PR #2284. I don't believe we should use this as large changes to our git repository (like the new docs site) or small changes to front matter or copy on guides could dramatically alter the dates when, in reality, the guides haven't really been updated as it concerns our customers or search engines. Keeping the dates just within the front matter adds a lot more control over this.

### Important dates

Here are the dates I think we should emphasize on a document, in order of importance.

- **Content was modified.** *Obtained from front matter `modified` date.* Provides users a reference for when the content was last meaningfully updated.
- **Content was published.** *Obtained from font matter `published` date.* Provides users a reference for when the content was initially published.
- **Page was modified.** *Obtained from last modified date in git.* Potentially used to signal to search engines that the page should be re-crawled. This could likely be within structured data and at the bottom of the page.