### PR TITLE
updated passlib .encrypt funct to non-depreicated version

### DIFF
--- a/docs/guides/applications/configuration-management/ansible/running-ansible-playbooks/index.md
+++ b/docs/guides/applications/configuration-management/ansible/running-ansible-playbooks/index.md
@@ -122,7 +122,7 @@ When creating a limited user account you are required to create a host login pas
 
 1. Create a password hash using passlib. Replace `myPlainTextPassword` with the password you'd like to use to access your Linode.
 
-        sudo python -c "from passlib.hash import sha512_crypt; print (sha512_crypt.encrypt('myPlainTextPassword'))"
+        sudo python -c "from passlib.hash import sha512_crypt; print (sha512_crypt.hash('myPlainTextPassword'))"
 
     A similar output will appear displaying a hash of your password:
     {{< output >}}


### PR DESCRIPTION
Received this error regarding an old version of passlib:
```
<string>:1: DeprecationWarning: the method passlib.handlers.sha2_crypt.sha512_crypt.encrypt() is deprecated as of Passlib 1.7, and will be removed in Passlib 2.0, use .hash() instead.
```
So I swapped out .encrypt for .hash and I did not get a depreciation warning.