### PR TITLE
Change configuration to enable "bundles" taxonomy

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@ baseURL = "https://www.linode.com/docs/"
 languageCode = "en-us"
 title = "Linode Guides & Tutorials"
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+# disableKinds = ["taxonomy", "taxonomyTerm"]
 themeDir = ".."
 rssLimit = 30
 summaryLength = 15
@@ -17,6 +17,9 @@ enableGitInfo = true
 [outputs]
 # The JSON is for the search index. We build this on every build to make sure we have the image thumbnails in sync.
 home = ["HTML", "JSON", "RSS"]
+
+[taxonomies]
+bundle = "bundles"
 
 [frontmatter]
 lastmod = [":git", "lastmod", "date", "publishDate"]


### PR DESCRIPTION
I have tested this locally by checking out linode/linode-docs-theme/pull/89

This must be merged along with that pull request, or we'll get a build error that looks like this:
```
ERROR 2021/07/23 11:24:24 list.html for page "bundles" should not be used...
```

