### PR TITLE
Remove noindex from Bundles top level page

### DIFF
--- a/docs/bundles/_index.md
+++ b/docs/bundles/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Guide Bundles
-noindex: true
 ---
 
 Check out Linode's curated collections of Linux guides and tutorials.


### PR DESCRIPTION
- The noindex frontmatter makes sure Google doesn't index the page
- This was put in place originally because we didn't have any bundle content to start, and the page was empty.
- Once we start adding bundle content, this PR should be merged, so that we can have it indexed again.

---

Tagging with **Do Not Merge** until we start adding bundle content