### PR TITLE
[Release Candidate] v1.71.2

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -1865,6 +1865,7 @@ xcode
 xen
 xenial
 xerus
+Xfce
 xkcd
 xlsx
 xlsxwriter

--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -641,6 +641,7 @@ httpchk
 httpd
 https
 huginn
+Hugo
 hulu
 hvc0
 hybla

--- a/docs/guides/applications/cloud-storage/install-nextcloud-talk/index.md
+++ b/docs/guides/applications/cloud-storage/install-nextcloud-talk/index.md
@@ -26,7 +26,7 @@ Nextcloud 14 is a cloud storage platform that offers users the ability to self-h
 
 You will need a Linode with Docker CE installed to follow along with the steps in this guide.
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ## Install Nextcloud 14 and Talk
 

--- a/docs/guides/applications/cloud-storage/use-block-storage-volume-with-nextcloud/index.md
+++ b/docs/guides/applications/cloud-storage/use-block-storage-volume-with-nextcloud/index.md
@@ -31,7 +31,7 @@ Nextcloud is a cloud storage platform that allows you to store and access your f
 
 ### Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Docker Compose
 

--- a/docs/guides/applications/configuration-management/salt/test-salt-locally-with-kitchen-salt/index.md
+++ b/docs/guides/applications/configuration-management/salt/test-salt-locally-with-kitchen-salt/index.md
@@ -58,7 +58,7 @@ Kitchen runs on Ruby. The following commands will install the Ruby version contr
 
 ## Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ## Install KitchenSalt
 

--- a/docs/guides/applications/containers/deploying-microservices-with-docker/index.md
+++ b/docs/guides/applications/containers/deploying-microservices-with-docker/index.md
@@ -47,7 +47,7 @@ This guide is written for a non-root user. Commands that require elevated privil
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/applications/containers/docker-container-communication/index.md
+++ b/docs/guides/applications/containers/docker-container-communication/index.md
@@ -32,7 +32,7 @@ Configuring the containers to communicate with each other and the host machine c
 
 You will need a Linode with Docker CE installed to follow along with the steps in this guide.
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ## Example Node.js Application
 

--- a/docs/guides/applications/containers/how-to-use-docker-compose/index.md
+++ b/docs/guides/applications/containers/how-to-use-docker-compose/index.md
@@ -32,7 +32,7 @@ Generally the containers in an application built using Docker Compose will all r
 
 You will need a Linode with Docker CE installed to follow along with the steps in this guide.
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/applications/containers/installing-docker-shortguide/index.md
+++ b/docs/guides/applications/containers/installing-docker-shortguide/index.md
@@ -1,0 +1,28 @@
+---
+# Shortguide: Instructions on installing Docker
+
+headless: true
+show_on_rss_feed: false
+
+# Ignore the below front matter. It is included to comply with existing tests.
+
+slug: installing-docker-shortguide
+title: "Shortguide"
+description: "Shortguide"
+keywords: ["shortguide"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2021-08-09
+author:
+  name: Linode
+  email: docs@linode.com
+modified_by:
+  name: Linode
+---
+
+To install Docker CE (Community Edition), follow the instructions within one of the guides below:
+
+- [Installing and Using Docker on Ubuntu and Debian](/docs/guides/installing-and-using-docker-on-ubuntu-and-debian/)
+
+- [Installing and Using Docker on CentOS and Fedora](/docs/guides/installing-and-using-docker-on-centos-and-fedora/)
+
+For complete instructions on even more Linux distributions, reference the [Install Docker Engine](https://docs.docker.com/engine/install/) section of Docker's official documentation.

--- a/docs/guides/applications/containers/node-js-web-server-deployed-within-docker/index.md
+++ b/docs/guides/applications/containers/node-js-web-server-deployed-within-docker/index.md
@@ -24,7 +24,7 @@ Node.js is a server-side, JavaScript package, often used for various cloud appli
 
 ## Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ## Download the Docker Node.js Server Image
 The Docker Hub user page for Linode can be accessed [here](https://hub.docker.com/u/linode/). Select the **server-node-js** image for configuration information.

--- a/docs/guides/applications/messaging/how-to-install-mastodon-on-debian-10/index.md
+++ b/docs/guides/applications/messaging/how-to-install-mastodon-on-debian-10/index.md
@@ -80,7 +80,7 @@ Mastodon can be installed using its included [Docker Compose](https://docs.docke
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/applications/messaging/how-to-install-mastodon-on-ubuntu-2004/index.md
+++ b/docs/guides/applications/messaging/how-to-install-mastodon-on-ubuntu-2004/index.md
@@ -78,7 +78,7 @@ Mastodon can be installed using its included [Docker Compose](https://docs.docke
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/applications/messaging/install-mastodon-on-ubuntu-1604/index.md
+++ b/docs/guides/applications/messaging/install-mastodon-on-ubuntu-1604/index.md
@@ -86,7 +86,7 @@ When Certbot is run, you generally pass a command with the [`--deploy-hook` opti
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/applications/remote-desktop/remote-desktop-using-apache-guacamole-on-docker/index.md
+++ b/docs/guides/applications/remote-desktop/remote-desktop-using-apache-guacamole-on-docker/index.md
@@ -37,11 +37,9 @@ Apache Guacamole is an HTML5 application useful for accessing a remote desktop t
 This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you’re not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.
 {{< /note >}}
 
-
 ## Install Docker
-The installation method presented here will install the latest version of Docker. Consult the official documentation to install a specific version or if Docker EE is needed.
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ## Initialize Guacamole Authentication with MySQL
 MySQL will be used in this guide, but PostgreSQL and MariaDB are supported alternatives.

--- a/docs/guides/development/tips-and-tricks/use-a-linode-for-web-development-on-remote-devices/index.md
+++ b/docs/guides/development/tips-and-tricks/use-a-linode-for-web-development-on-remote-devices/index.md
@@ -62,7 +62,7 @@ By using Docker, you can ensure that your development is fully portable: contain
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Portainer
 

--- a/docs/guides/development/version-control/install-gitlab-with-docker/index.md
+++ b/docs/guides/development/version-control/install-gitlab-with-docker/index.md
@@ -86,7 +86,7 @@ Once your changes have propagated, you can move forward with the installation.
 ### Install Docker
 You must have Docker installed on your Linode to continue.
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ## Install the GitLab EE Image
 

--- a/docs/guides/kubernetes/deploy-container-image-to-kubernetes/index.md
+++ b/docs/guides/kubernetes/deploy-container-image-to-kubernetes/index.md
@@ -390,7 +390,7 @@ spec:
     - The `spec` key defines the Hugo site service object's desired behavior. It will create a service that exposes TCP port `80` on any pod with the `app: hugo-site` label.
     - The exposed container port is defined by the `targetPort:80` key-value pair.
 
-1. Create the service for your hugo site:
+1. Create the service for your Hugo site:
 
         kubectl create -f clientx/k8s-hugo/service-hugo.yaml
 
@@ -442,7 +442,7 @@ spec:
       - `imagePullPolicy: Always` means that the container image will be pulled every time the pod is started.
       - `containerPort: 80` states the port number to expose on the pod's IP address. The system does not rely on this field to expose the container port, instead, it provides information about the network connections a container uses.
 
-1. Create the deployment for your hugo site:
+1. Create the deployment for your Hugo site:
 
         kubectl create -f clientx/k8s-hugo/deployment.yaml
 

--- a/docs/guides/kubernetes/deploy-container-image-to-kubernetes/index.md
+++ b/docs/guides/kubernetes/deploy-container-image-to-kubernetes/index.md
@@ -72,7 +72,7 @@ Development of your Hugo site and Docker image will take place locally on your p
 
             brew install hugo
 
-1. {{< content "install-docker-ce" >}}
+1. {{< content "installing-docker-shortguide" >}}
 
 ## Create a Hugo Site
 

--- a/docs/guides/kubernetes/how-to-deploy-a-static-site-on-linode-kubernetes-engine/index.md
+++ b/docs/guides/kubernetes/how-to-deploy-a-static-site-on-linode-kubernetes-engine/index.md
@@ -75,7 +75,7 @@ To perform some of the commands in this guide you need to have Git installed on 
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Sign up for a Docker Hub Account
 

--- a/docs/guides/kubernetes/how-to-deploy-kubernetes-on-linode-with-rancher-2-x/index.md
+++ b/docs/guides/kubernetes/how-to-deploy-kubernetes-on-linode-with-rancher-2-x/index.md
@@ -66,7 +66,8 @@ The Rancher web application will run on a Linode in your Cloud Manager account. 
 You will be able to create Kubernetes clusters in any Linode data center from the Rancher UI, even if your Rancher Linode is located in a different region.
 {{< /note >}}
 
-1.  The Rancher web application is run inside a Docker container, so you will also need to install Docker CE on your Linode. Follow the instructions for [installing Docker CE on Ubuntu 18.04](/docs/applications/containers/install-docker-ce-ubuntu-1804) and then return to this guide.
+1.  The Rancher web application is run inside a Docker container, so you will also need to install Docker CE on your Linode. Follow the instructions for [Installing and Using Docker on Ubuntu and Debian
+](/docs/guides/installing-and-using-docker-on-ubuntu-and-debian/) and then return to this guide.
 
 You will also need to generate an API token and prepare a domain zone:
 

--- a/docs/guides/kubernetes/how-to-deploy-nginx-on-a-kubernetes-cluster/index.md
+++ b/docs/guides/kubernetes/how-to-deploy-nginx-on-a-kubernetes-cluster/index.md
@@ -173,7 +173,7 @@ If you are unable to ping any of your hosts by their hostnames or private IPs:
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install kubeadm, kubectl, and kubelet
 

--- a/docs/guides/kubernetes/how-to-setup-a-private-docker-registry-with-lke-and-object-storage/index.md
+++ b/docs/guides/kubernetes/how-to-setup-a-private-docker-registry-with-lke-and-object-storage/index.md
@@ -29,7 +29,7 @@ This guide was written using [Kubernetes version 1.17](https://v1-17.docs.kubern
 
 1. [Deploy a LKE Cluster](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/). This example was written using a node pool with two [2 GB nodes](https://www.linode.com/pricing/). Depending on the workloads you will be deploying on your cluster, you may consider using nodes with higher resources.
 
-1. Install [Helm 3](/docs/kubernetes/how-to-install-apps-on-kubernetes-with-helm-3/#install-helm), [kubectl](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/#install-kubectl), and [Docker](/docs/applications/containers/install-docker-ce-ubuntu-1804/) to your local environment.
+1. Install [Helm 3](/docs/kubernetes/how-to-install-apps-on-kubernetes-with-helm-3/#install-helm), [kubectl](/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/#install-kubectl), and [Docker](/docs/guides/installing-and-using-docker-on-ubuntu-and-debian/) to your local environment.
 
     {{< note >}}
 For Docker installation instructions on other operating systems, see [Docker's official documentation](https://docs.docker.com/get-docker/).

--- a/docs/guides/quick-answers/linux/drupal-with-docker-compose/index.md
+++ b/docs/guides/quick-answers/linux/drupal-with-docker-compose/index.md
@@ -39,7 +39,7 @@ Using the Drupal and PostgreSQL images from Docker Hub offers the following bene
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/quick-answers/linux/wordpress-with-docker-compose/index.md
+++ b/docs/guides/quick-answers/linux/wordpress-with-docker-compose/index.md
@@ -42,7 +42,7 @@ The WordPress and MySQL images are maintained on Docker Hub by their respective 
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/security/basics/docker-security-essentials/index.md
+++ b/docs/guides/security/basics/docker-security-essentials/index.md
@@ -7,7 +7,7 @@ og_description: 'This guide shows how to secure your Docker containers. Learn ho
 keywords: ["docker security", "docker container security", "docker security best practices"]
 tags: ["security", "docker"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2021-03-26
+modified: 2021-08-09
 modified_by:
   name: Linode
 published: 2021-03-26
@@ -26,13 +26,7 @@ Docker utilizes the host OS Kernel, which makes Docker containers more efficient
 
 ## Prerequisites and Requirements
 
-In order to secure Docker containers, you need to have a Linux server with the following services running:
-
-- Docker
-
-For a quick an easy way to install Docker on Linode, check out our guide on [How to Deploy Docker with Marketplace Apps](/docs/guides/deploying-docker-with-marketplace-apps/).
-
-Otherwise, you can find instructions on how to manually install Docker in our guide on [How to Install Docker CE on Ubuntu 18.04](/docs/guides/install-docker-ce-ubuntu-1804/).
+In order to secure Docker containers, you need to have a Linux server with Docker running. For a quick an easy way to install Docker on Linode, check out our guide on [How to Deploy Docker with Marketplace Apps](/docs/guides/deploying-docker-with-marketplace-apps/). Otherwise, you can find instructions on how to manually install Docker in our guide on [Installing and Using Docker on Ubuntu and Debian](/docs/guides/installing-and-using-docker-on-ubuntu-and-debian/).
 
 {{< note >}}
 This demonstration has been performed on Ubuntu 18.04. All techniques demonstrated are distribution agnostic with the exception of package names and package managers.

--- a/docs/guides/uptime/monitoring/install-graphite-and-grafana/index.md
+++ b/docs/guides/uptime/monitoring/install-graphite-and-grafana/index.md
@@ -35,7 +35,7 @@ Both Docker and Docker Compose are necessary to complete this guide.
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/websites/cms/drupal/how-to-install-drupal-with-docker-compose-debian-10/index.md
+++ b/docs/guides/websites/cms/drupal/how-to-install-drupal-with-docker-compose-debian-10/index.md
@@ -48,7 +48,7 @@ Using the Drupal and PostgreSQL images from Docker Hub offers the following bene
 
 ### Install Docker
 
-{{< content "how-to-install-docker-ce-on-debian-10" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/websites/cms/drupal/how-to-install-drupal-with-docker-compose-ubuntu-18-04/index.md
+++ b/docs/guides/websites/cms/drupal/how-to-install-drupal-with-docker-compose-ubuntu-18-04/index.md
@@ -48,7 +48,7 @@ Using the Drupal and PostgreSQL images from Docker Hub offers the following bene
 
 ### Install Docker
 
-{{< content "install-docker-ce-ubuntu-1804" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/websites/cms/ghost/how-to-install-ghost-cms-with-docker-compose-on-ubuntu-18-04/index.md
+++ b/docs/guides/websites/cms/ghost/how-to-install-ghost-cms-with-docker-compose-on-ubuntu-18-04/index.md
@@ -70,7 +70,7 @@ In your deployment, the web server will run in its own container, and the Certbo
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/guides/websites/cms/wordpress/how-to-speed-up-a-wordpress-website/index.md
+++ b/docs/guides/websites/cms/wordpress/how-to-speed-up-a-wordpress-website/index.md
@@ -52,7 +52,7 @@ To install the test environment, you will need a Linode which does not have any 
 
 ### Install Docker
 
-{{< content "install-docker-ce" >}}
+{{< content "installing-docker-shortguide" >}}
 
 ### Install Docker Compose
 

--- a/docs/products/storage/object-storage/_index.md
+++ b/docs/products/storage/object-storage/_index.md
@@ -17,8 +17,9 @@ Object Storage is available within the follow data centers.
 
 | Data Center | Cluster ID |
 | ------------| --------------------- |
-| Newark | us-east-1 |
-| Frankfurt | eu-central-1 |
+| Atlanta, GA, USA | us-southeast-1 |
+| Frankfurt, Germany | eu-central-1 |
+| Newark, NJ, USA | us-east-1 |
 | Singapore | ap-south-1 |
 
 Cluster IDs correspond with the Object Storage Cluster located in each data center. They are used when [formatting URLs](#object-storage-urls) and integrating Object Storage with tools such as the [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli), [s3cmd](/docs/products/storage/object-storage/guides/s3cmd), [s4cmd](/docs/products/storage/object-storage/guides/s4cmd), and [Cyberduck](/docs/products/storage/object-storage/guides/cyberduck).

--- a/docs/products/storage/object-storage/_shortguides/object-storage-create-bucket-shortguide/index.md
+++ b/docs/products/storage/object-storage/_shortguides/object-storage-create-bucket-shortguide/index.md
@@ -33,7 +33,7 @@ The Cloud Manager provides a web interface for creating buckets. To create a buc
 
 1.  Add a label for the bucket. See the [Bucket Name](/docs/platform/object-storage/how-to-use-object-storage/#bucket-names) section for rules on naming the bucket.
 
-1.  Choose a cluster location for the bucket to reside in.
+1.  Choose a region (cluster) for the bucket to reside in. See the Availability section on the [Object Storage Overview](/docs/products/storage/object-storage/) page for a list of available regions.
 
     {{< content "object-storage-cluster-shortguide" >}}
 

--- a/docs/products/storage/object-storage/_shortguides/object-storage-ga-shortguide/index.md
+++ b/docs/products/storage/object-storage/_shortguides/object-storage-ga-shortguide/index.md
@@ -6,5 +6,5 @@ show_on_rss_feed: false
 ---
 
 {{< note >}}
-Linode's Object Storage is available in the Newark, Frankfurt, and Singapore data centers. For more availability details and billing information, see the [Object Storage Overview](/docs/products/storage/object-storage/) product documentation.
+Linode's Object Storage is available in our Atlanta (USA),  Frankfurt (Germany), Newark (USA), and Singapore data centers. For more availability details and billing information, see the [Object Storage Overview](/docs/products/storage/object-storage/) product documentation.
 {{</ note >}}

--- a/docs/products/storage/object-storage/_shortguides/object-storage-ga-shortguide/index.md
+++ b/docs/products/storage/object-storage/_shortguides/object-storage-ga-shortguide/index.md
@@ -6,5 +6,5 @@ show_on_rss_feed: false
 ---
 
 {{< note >}}
-Linode's Object Storage is available in our Atlanta (USA),  Frankfurt (Germany), Newark (USA), and Singapore data centers. For more availability details and billing information, see the [Object Storage Overview](/docs/products/storage/object-storage/) product documentation.
+Linode's Object Storage is available in our Atlanta (USA), Frankfurt (Germany), Newark (USA), and Singapore data centers. For more availability details and billing information, see the [Object Storage Overview](/docs/products/storage/object-storage/) product documentation.
 {{</ note >}}


### PR DESCRIPTION
- Object Storage is now live in Atlanta. As part of this launch, the availability section in the Object Storage Overview product documentation and elsewhere has been updated.
- A fix for the missing `install-docker-ce` shortguide is included, which creates a new shortguide and updates all references within our guides.