### PR TITLE
Added alias to Jitsi Marketplace doc

### DIFF
--- a/docs/guides/platform/marketplace/how-to-deploy-jitsi-with-marketplace-apps/index.md
+++ b/docs/guides/platform/marketplace/how-to-deploy-jitsi-with-marketplace-apps/index.md
@@ -20,7 +20,7 @@ external_resources:
 - '[About Jitsi](https://jitsi.org/about/)'
 - '[Jitsi Documentation](https://jitsi.github.io/handbook/docs/intro)'
 - '[Scale Your Jitsi Setup](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-scalable)'
-aliases: ['/platform/marketplace/how-to-deploy-jitsi-with-marketplace-apps/', '/platform/one-click/how-to-deploy-jitsi-with-one-click-apps/']
+aliases: ['/platform/marketplace/how-to-deploy-jitsi-with-marketplace-apps/', '/platform/one-click/how-to-deploy-jitsi-with-one-click-apps/','/platform/one-click/deploy-jitsi-with-one-click-apps/']
 ---
 
 ## Jitsi Marketplace App


### PR DESCRIPTION
Cloud Manager is pointing to an old URL for the Jitsi Marketplace App guide. Added that URL as an alias so users are redirected to the correct page.