### PR TITLE
remove commas from install command list

### DIFF
--- a/docs/guides/websites/cms/drupal/how-to-install-drush-on-debian-10/index.md
+++ b/docs/guides/websites/cms/drupal/how-to-install-drush-on-debian-10/index.md
@@ -62,7 +62,7 @@ The developers of Drush recommend installing Drush using [Composer](https://getc
 
 1. Composer has a few PHP dependencies it needs in order to run. Install them on your Debian system:
 
-        sudo apt install php-dom, php-zip, unzip, php-gd, php-mbstring
+        sudo apt install php-dom php-zip unzip php-gd php-mbstring
 
 ## Install Drush Globally
 


### PR DESCRIPTION
[drush on debian 10](https://www.linode.com/docs/websites/cms/drupal/drush-drupal/how-to-install-drush-on-debian-10) doc has:

```
sudo apt install php-dom, php-zip, unzip, php-gd, php-mbstring
```

which results in `unable to locate` errors:

```
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package php-dom,
E: Unable to locate package php-zip,
E: Unable to locate package unzip,
E: Unable to locate package php-gd,
```

this PR fixes that

(also, 👋 )