### PR TITLE
[Hotfix] v1.74.3

### DIFF
--- a/_vendor/github.com/linode/linode-docs-theme/assets/js/main/helpers/helpers.js
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/js/main/helpers/helpers.js
@@ -108,34 +108,6 @@ export function waitUntil(condition) {
 	});
 }
 
-// Function borrowed from https://stackoverflow.com/questions/123999/how-can-i-tell-if-a-dom-element-is-visible-in-the-current-viewport/7557433#7557433
-export function isElementInViewport(el) {
-	var rect = el.getBoundingClientRect();
-
-	return (
-		rect.top >= 0 &&
-		rect.left >= 0 &&
-		rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-		rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-	);
-}
-
-// getOffsetTop returns the distance from container down to el.
-export function getOffsetTop(container, el) {
-	var distance = 0;
-
-	if (el.offsetParent) {
-		while (true) {
-			distance += el.offsetTop;
-			el = el.offsetParent;
-			if (!el || el === container) {
-				break;
-			}
-		}
-	}
-	return distance < 0 ? 0 : distance;
-}
-
 export function isMobile() {
 	return document.documentElement.clientWidth < 768;
 }

--- a/_vendor/github.com/linode/linode-docs-theme/assets/js/main/navigation/explorer.js
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/js/main/navigation/explorer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { getOffsetTop, isElementInViewport, isMobile, sendEvent, toggleBooleanClass } from '../helpers/index';
+import { isMobile, sendEvent, toggleBooleanClass } from '../helpers/index';
 import { newDispatcher } from '../search/index';
 import { newCreateHref } from './create-href';
 
@@ -39,9 +39,6 @@ export function newSearchExplorerController(searchConfig) {
 	};
 
 	const setOpenStatus = function(self, open) {
-		if (!open) {
-			self.softTransitions = false;
-		}
 		debug('setOpenStatus', open, self.initState);
 		if (open) {
 			prepare(self);
@@ -69,119 +66,6 @@ export function newSearchExplorerController(searchConfig) {
 		}
 	};
 
-	const scrollToActive = function(self, nodeInfo) {
-		let offset = 30; // Add some space above.
-		let threshold = 200; // Avoid scrolling short distances if the item is in viewport.
-
-		var isDone = false;
-		var container = self.$el.parentNode;
-
-		const scroll = function(what, to) {
-			if (to >= 0 && container.scrollTop !== to) {
-				container.scrollTop = to;
-			}
-
-			debug('scroll', what, to);
-
-			isDone = true;
-		};
-
-		if (!nodeInfo.branchKey) {
-			scroll('home', 0);
-			return;
-		}
-
-		let li = self.$refs[nodeInfo.branchKey];
-		if (!li) {
-			scroll('li not found:' + nodeInfo.branchKey, -1);
-			return;
-		}
-
-		// Select the active branch or leaf node.
-		let selector = nodeInfo.isBranch ? 'div > div a' : '.is-active-page';
-
-		setTimeout(function() {
-			// We have no simple way of knowing when the left menu is finished rendered,
-			// but we want to at least try to scroll down to the active node,
-			// and as soon as possible.
-			let retries = [ 0, 200, 500, 1000, 2000 ];
-			for (let i = 0; i < retries.length; i++) {
-				let sleep = retries[i];
-
-				setTimeout(function() {
-					if (isDone) {
-						return;
-					}
-
-					let active = li.querySelector(selector);
-
-					if (active && active.getBoundingClientRect().top) {
-						let container = self.$el.parentNode;
-						let scrollTop = getOffsetTop(container, active);
-						if (scrollTop) {
-							// If we're near the top, we might as well go all the way.
-							if (scrollTop < 100) {
-								scroll('near the top', 0);
-								return;
-							}
-
-							scrollTop = scrollTop - offset;
-
-							let oldScrollTop = self.scrollTop;
-
-							// If the active element is in viewport and
-							// within the threshold distance, we just
-							// keep the current scrollTop.
-							if (oldScrollTop && threshold && isElementInViewport(active)) {
-								let change =
-									oldScrollTop < scrollTop ? scrollTop - oldScrollTop : oldScrollTop - scrollTop;
-
-								if (change < threshold) {
-									// Avoid minor scroll changes.
-									scroll('less than threshold', -1);
-									return;
-								}
-							}
-
-							scroll('scroll', scrollTop);
-						}
-					} else if (i + 1 === retries.length) {
-						scroll('timed out', 0);
-					}
-				}, sleep);
-			}
-		}, 0);
-	};
-
-	const getActiveNodeInfo = function() {
-		let info = window.lnPageInfo;
-		if (!info) {
-			return null;
-		}
-
-		let isBranch = info.kind !== 'page';
-
-		if (info.kind === 'home') {
-			return {
-				isBranch: isBranch,
-				branchKey: ''
-			};
-		} else if (info.type === 'sections' || info.type === 'api') {
-			// Dynamic section, fetch the node key from the location.
-			return {
-				isBranch: isBranch,
-				branchKey: router.sectionsFromPath().join(' > ')
-			};
-		} else if (info.sectionsEntries) {
-			return {
-				isBranch: isBranch,
-				branchKey: info.sectionsEntries.join(' > ')
-			};
-		}
-
-		return null;
-	};
-
 	// initStates represents the state of the loading of the initial data set.
 	// We may get filtered search results before we've finished with the initial build,
 	// and we need to prevent those building before we're ready.
@@ -189,8 +73,9 @@ export function newSearchExplorerController(searchConfig) {
 		INITIAL: 0,
 		OPENING: 1,
 		SEARCH_READY: 2,
-		LOADING: 3,
-		LOADED: 4
+		DATA_LOADED: 3,
+		LOADING: 4,
+		LOADED: 5
 	};
 
 	var templates = {};
@@ -230,7 +115,7 @@ export function newSearchExplorerController(searchConfig) {
 	};
 
 	// May be set on initial load to expand to a given node.
-	var onLoadNodeInfo = null;
+	var activeNodeKey = '';
 
 	return {
 		data: data,
@@ -242,43 +127,40 @@ export function newSearchExplorerController(searchConfig) {
 		// onSearchReady is called when the search system is ready.
 		// Note that this does not necessarily mean that a search has been performed.
 		onSearchReady: function() {
-			if (this.initState < initStates.SEARCH_READY) {
-				this.initState = initStates.SEARCH_READY;
-				if (onLoadNodeInfo && onLoadNodeInfo.branchKey) {
-					// Load everything in one query.
-					let sections = onLoadNodeInfo.branchKey.split(' > ');
-					let sectionName = sections[0];
-					let sectionConfig = { config: searchConfig.sections[sectionName] };
-					let currentKey = [];
-					let queries = [];
-					sections.forEach((section) => {
-						currentKey.push(section);
-						queries.push({ key: currentKey.join(' > '), section: sectionConfig });
-					});
-					dispatcher.searchNodes({
-						data: queries
-					});
-				}
+			switch (this.initState) {
+				case initStates.INITIAL:
+					this.initState = initStates.SEARCH_READY;
+					break;
+				case initStates.OPENING:
+					if (activeNodeKey != '') {
+						// Load everything in one query.
+						let sectionName = activeNodeKey.split('>')[0].trim();
+						dispatcher.searchNodes({
+							data: [ { key: activeNodeKey, section: { config: searchConfig.sections[sectionName] } } ]
+						});
+					} else {
+						dispatcher.searchBlank();
+					}
+					break;
 			}
 		},
 
-		// Receives the initial data set once.
+		// Receives the initial, blank, result set with all the initial
+		// facets and their counts.
 		receiveDataInit: function(data) {
-			this.receiveData(data, true);
+			debug('receiveDataInit', data, this.open, this.initState);
+			this.data.searchState = data;
+			this.initState = initStates.DATA_LOADED;
+			this.load();
 		},
 
 		// Receives an updated result set based on a query or a filter applied.
 		// Note that we cannot apply this until the initial data set is loaded.
-		receiveData: function(data, isBlank = false) {
-			debug('receiveData', data, this.open, this.initState, isBlank);
-			if (this.initState === initStates.LOADING) {
+		receiveData: function(data) {
+			debug('receiveData', data, this.open, this.initState);
+			if (this.initState < initStates.LOADED) {
 				return;
 			}
-
-			if (!isBlank && !data.blankSearch.isLoaded()) {
-				return;
-			}
-
 			this.data.searchState = data;
 			this.isSearchFiltered = data.query.isFiltered() || data.mainSearch.results.isSectionDisabled();
 			this.load();
@@ -317,22 +199,16 @@ export function newSearchExplorerController(searchConfig) {
 		},
 
 		load: function() {
-			let shouldScroll = onLoadNodeInfo && this.initState < initStates.LOADED;
 			this.loadIf(this.open);
-			if (shouldScroll) {
-				var self = this;
-				var onLoadNodeInfoCopy = onLoadNodeInfo;
-				self.$nextTick(function() {
-					scrollToActive(self, onLoadNodeInfoCopy);
-				});
-			}
-
-			// Only needed on inital page load,
-			onLoadNodeInfo = null;
 		},
 
 		loadIf: function(open) {
 			if (!open) {
+				return;
+			}
+
+			if (this.initState < initStates.DATA_LOADED) {
+				// It will eventually get here.
 				return;
 			}
 
@@ -346,10 +222,24 @@ export function newSearchExplorerController(searchConfig) {
 			}
 
 			this.initState = initStates.LOADING;
-
 			this.buildNodes();
 			this.filterNodes();
-			this.initState = initStates.LOADED;
+			var self = this;
+			this.$nextTick(function() {
+				self.initState = initStates.LOADED;
+			});
+		},
+
+		// Turbolinks replaces the body that we may have changed, so restore the
+		// explorer state when navigating to a new page.
+		onTurbolinksBeforeRender: function(data) {
+			if (this.open && isMobile()) {
+				// Always close the left side tree menu when navigating away on mobile.
+				this.open = false;
+			}
+			toggleBooleanClass('explorer-open', data.newBody, this.open);
+			let nav = this.$el.parentNode;
+			this.scrollTop = nav.scrollTop;
 		},
 
 		onHashchange: function() {
@@ -360,74 +250,9 @@ export function newSearchExplorerController(searchConfig) {
 			}
 		},
 
-		onTurbolinksBeforeVisit: function(data) {
-			this.scrollTop = this.$el.parentNode.scrollTop;
-		},
-
-		// Turbolinks replaces the body that we may have changed, so restore the
-		// explorer state when navigating to a new page.
-		onTurbolinksBeforeRender: function(data) {
-			if (this.open && isMobile()) {
-				// Always close the left side tree menu when navigating away on mobile.
-				this.open = false;
-			}
-
-			if (this.initState >= initStates.LOADED && !this.isMenuNavigation) {
-				let branchKey = data.newBody.dataset.branch;
-				if (branchKey === 'sections') {
-					branchKey = router.sectionsFromPath().join(' > ');
-				}
-
-				this.setActiveBranch(branchKey);
-			}
-
-			toggleBooleanClass('explorer-open', data.newBody, this.open);
-		},
-
 		onTurbolinksRender: function(data) {
-			if (document.documentElement.hasAttribute('data-turbolinks-preview')) {
-				return;
-			}
-
-			let isMenuNavigation = this.isMenuNavigation;
-			this.isMenuNavigation = false;
-
-			if (!isMenuNavigation) {
-				// This is a navigation by link.
-				// The node was opened in the before-render event.
-				let activeNodeInfo = getActiveNodeInfo();
-				if (activeNodeInfo) {
-					var self = this;
-					this.$nextTick(function() {
-						scrollToActive(self, activeNodeInfo);
-					});
-				}
-			} else {
-				this.$el.parentNode.scrollTop = this.scrollTop;
-			}
-		},
-
-		setActiveBranch: function(nodeKey) {
-			for (let k in this.data.nodes) {
-				let n = this.data.nodes[k];
-
-				if (n.disabled) {
-					continue;
-				}
-
-				if (nodeKey.startsWith(n.key)) {
-					if (!n.open) {
-						n.toggleOpen();
-					} else {
-						n.pages.forEach((p) => {
-							// Force a rerender of the leaf nodes to get correct active state.
-							n.dirty++;
-						});
-					}
-				} else if (n.open) {
-					n.open = false;
-				}
-			}
+			let navEl = this.$el.parentNode;
+			navEl.scrollTop = this.scrollTop;
 		},
 
 		render: function() {
@@ -473,16 +298,16 @@ export function newSearchExplorerController(searchConfig) {
 				};
 				self.target = self.$refs['explorer'];
 
-				// Open the explorer menu on load when not on mobile.
-				let shouldOpen = !isMobile();
+				let isOpenOnLoad = document.body.classList.contains('is-explorer-open');
+
+				if (page.type === 'api') {
+					activeNodeKey = page.href.substr(1).slice(0, -1).split('/').slice(1).join(' > ');
+				}
 
 				// Prepare the DOM templates. The final render of the nodes is performed lazily on expansion.
 				self.render();
 
-				if (shouldOpen) {
-					// Do opacity transitions only on initial load.
-					self.softTransitions = true;
-					onLoadNodeInfo = getActiveNodeInfo();
+				if (isOpenOnLoad) {
 					setOpenStatus(self, true);
 				}
 			};
@@ -502,6 +327,7 @@ export function newSearchExplorerController(searchConfig) {
 			}
 
 			let n = {
+				dirty: true, // Used for lazy expansion
 				section: opts.section,
 				level: opts.level, // Starting at 1
 				ordinal: ordinal,
@@ -510,7 +336,6 @@ export function newSearchExplorerController(searchConfig) {
 				key: opts.key,
 				href: opts.href,
 				count: opts.count,
-				dirty: 0,
 				icon: opts.level === 1 ? opts.section.config.explorer_icon : '',
 				sections: [],
 				pages: [], // Leaf nodes
@@ -519,8 +344,6 @@ export function newSearchExplorerController(searchConfig) {
 				kind: opts.kind ? opts.kind : 'section',
 				isGhostSection: opts.isGhostSection
 			};
-
-			let self = this;
 
 			n.children = function() {
 				if (this.pages.length === 0) {
@@ -562,8 +385,6 @@ export function newSearchExplorerController(searchConfig) {
 				}
 
 				if (this.href) {
-					self.isMenuNavigation = true;
-
 					let href = this.href;
 
 					if (this.isLeaf()) {
@@ -784,11 +605,10 @@ export function newSearchExplorerController(searchConfig) {
 				return null;
 			}
 
-			if (this.initState < initStates.BLANK_LOADED || !this.data.searchState.mainSearch.isLoaded()) {
-				debug('getResults: blank');
+			if (this.initState == initStates.LOADING || !this.data.searchState.mainSearch.isLoaded()) {
 				return this.data.searchState.blankSearch.results;
 			}
-			debug('getResults: main');
+
 			return this.data.searchState.mainSearch.results;
 		},
 
@@ -819,16 +639,16 @@ export function newSearchExplorerController(searchConfig) {
 				n.pages = pages;
 			};
 
-			if (this.initState > initStates.BLANK_LOADED && this.data.searchState.searchOpts.isNodeToggle) {
+			if (this.data.searchState.searchOpts.isNodeToggle) {
 				for (let [ key, val ] of this.data.searchState.expandedNodes.entries()) {
-					if (val && val.searchResult && val.searchResult.hits && val.searchResult.hits.length > 0) {
+					if (val && val.searchResult && val.searchResult.hits) {
 						let hits = val.searchResult.hits;
 						let n = this.data.nodes[key];
 						addPagesToNode(n, hits);
 					}
 				}
 				// No need to update everything.
-				if (!onLoadNodeInfo) {
+				if (activeNodeKey === '') {
 					return;
 				}
 			}
@@ -873,8 +693,8 @@ export function newSearchExplorerController(searchConfig) {
 					}
 				}
 
-				if (!n.disabled && onLoadNodeInfo && onLoadNodeInfo.branchKey.startsWith(n.key)) {
-					n.open = true;
+				if (!n.disabled && activeNodeKey && activeNodeKey.startsWith(n.key)) {
+					n.toggleOpen(true);
 				}
 
 				if (!seen.has(n.key)) {
@@ -899,25 +719,9 @@ export function newSearchExplorerController(searchConfig) {
 					n.pages = [];
 				}
 			}
-		},
 
-		// Tailwind transition classes for opening of the explorer.
-		transitions: function() {
-			if (this.softTransitions) {
-				// The regular transform looks jittery when applied on the original load.
-				// So only apply a short opacity transition here:
-				return {
-					enter: 'transition-opacityt duration-200 sm:duration-500',
-					enterStart: 'opacity-0',
-					enterEnd: 'opacity-100'
-				};
-			}
-
-			return {
-				enter: 'transition-transform transition-opacity ease-out duration-500 sm:duration-700',
-				enterStart: 'opacity-0 transform mobile:-translate-x-8 sm:-translate-y-8',
-				enterEnd: 'opacity-100 transform mobile:translate-x-0 sm:translate-y-0'
-			};
+			// Only activate this on first build.
+			activeNodeKey = '';
 		}
 	};
 }

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/_default/baseof.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/_default/baseof.html
@@ -33,7 +33,7 @@
      is-not-toc-open
      is-not-search-panel-open
      is-not-search-panel_filters-open
-     is-not-search-input-open" data-branch="{{ delimit .SectionsEntries ` > ` }}">
+     is-not-search-input-open">
   
   {{ partial "sections/after-body-start.html" . }}
   

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/navigation/explorer.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/navigation/explorer.html
@@ -1,10 +1,10 @@
 {{ partial "sections/navigation/explorer-icons.html" .}}
 <div id="explorer-component" class="explorer box-border" x-data="lnc.NewSearchExplorerController()" x-init="init(lnPageInfo)"
   @nav:toggle.document="receiveToggle($event.detail)" @search:ready.document="onSearchReady()" @search:results-blank.once.document="receiveDataInit($event.detail);" @search:results.document="receiveData($event.detail);"
-  @hashchange.window="onHashchange();" @turbolinks:before-visit.document="onTurbolinksBeforeVisit($event.data);"  @turbolinks:before-render.document="onTurbolinksBeforeRender($event.data);" @turbolinks:render.document="onTurbolinksRender($event.data);"
+  @hashchange.window="onHashchange();" @turbolinks:before-render.document="onTurbolinksBeforeRender($event.data);" @turbolinks:render.document="onTurbolinksRender($event.data);"
   @click.away="closeIfMobile()" data-turbolinks-permanent>
-  <nav class="h-full block top-0 overflow-x-hidden" x-show="isOpen()" :x-transition:enter="transitions().enter"
-  :x-transition:enter-start="transitions().enterStart" :x-transition:enter-end="transitions().enterEnd">
+  <nav class="h-full block top-0 overflow-x-hidden" x-show="isOpen()" x-transition:enter="transition-transform transition-opacity ease-out duration-500 sm:duration-700"
+  x-transition:enter-start="opacity-0 transform mobile:-translate-x-8 sm:-translate-y-8" x-transition:enter-end="opacity-100 transform mobile:translate-x-0 sm:translate-y-0">
     <div x-show.transition="isSearchFiltered" class="pl-5 md:pl-6 h-8 bg-black flex items-center text-xs font-semibold" data-testid="search-filter-status" x-cloak>
       <div class="bg-brand rounded-full h-1 w-1 mr-2"></div>
       <div class="text-white">
@@ -27,7 +27,7 @@
     <li class="explorer__node" x-bind:class="{
       'explorer__node--after-first': node.level > 1,
       'pl-6': node.level === 2
-    }" x-show.transition.200ms="!node.hidden" :data-testid="`li-${ node.level }`" :x-ref="node.key">
+    }" x-show.transition.200ms="!node.hidden" :data-testid="`li-${ node.level }`">
       <div class="explorer__node__inner" :data-testid="`node-${ node.key }`">
         <div x-bind:class="{ 
           'explorer__row--first pl-container bg-white border-b-gray text-gray-900' : (node.level===1), 
@@ -64,7 +64,7 @@
             <template x-if="node.isPage()">
               <a @click="data.dirty++; node.onClick($event);" x-html="node.title"  :class="{
                 'text-textcolor': !node.isActive(),
-                'text-brand font-semibold is-active-page': node.isActive(),
+                'text-brand font-semibold': node.isActive(),
               }" class="py-1-5 page-link mr-2 text-xs capitalize cursor-pointer no-underline active:text-brand hover:text-gray-900 focus:outline-none"></a>
             </template>
           </div>
@@ -96,7 +96,7 @@
             </template>
           </div>
         </div>
-        <ul class="node-tree h-full" x-show.transition.in.opacity="node.open" x-bind:class="{
+        <ul class="node-tree h-full" x-show="node.open"  x-bind:class="{
           'py-2': node.level === 1,
           'py-1': node.level > 1,
           'border-l-2 pl-3': node.level > 1,

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/linode/linode-docs-theme v0.0.0-20210820112345-a2baf178f527
+# github.com/linode/linode-docs-theme v0.0.0-20210826174807-d3dd6d268c4b
 # github.com/linode/linode-website-partials v0.0.0-20210802175028-9d88cb1b72bd
 # github.com/gohugoio/hugo-mod-jslibs/alpinejs v0.8.0
 # github.com/alpinejs/alpine v2.8.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/bep/hugo-jslibs/turbolinks v0.1.2 // indirect
 	github.com/bep/linodedocs v0.0.0-20210212231859-10aa00d2e096
 	github.com/linode/linode-api-docs/v4 v4.102.0 // indirect
-	github.com/linode/linode-docs-theme v0.0.0-20210820112345-a2baf178f527 // indirect
+	github.com/linode/linode-docs-theme v0.0.0-20210826174807-d3dd6d268c4b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ github.com/linode/linode-docs-theme v0.0.0-20210813142342-28e7a3d9aefa h1:COGxlK
 github.com/linode/linode-docs-theme v0.0.0-20210813142342-28e7a3d9aefa/go.mod h1:DNdrF/DiqJGG9JwPpVqv30JXHUH0MCfSaVBwA4oULRg=
 github.com/linode/linode-docs-theme v0.0.0-20210820112345-a2baf178f527 h1:PZ38vyVm5CwsywuBBVSwRNw1mwpjVYUHD/RW3G1yNgg=
 github.com/linode/linode-docs-theme v0.0.0-20210820112345-a2baf178f527/go.mod h1:DNdrF/DiqJGG9JwPpVqv30JXHUH0MCfSaVBwA4oULRg=
+github.com/linode/linode-docs-theme v0.0.0-20210826174807-d3dd6d268c4b h1:OGtkwcdgMLON+LwJT0tqh9oJca/5dd5HImFVsTg5FC0=
+github.com/linode/linode-docs-theme v0.0.0-20210826174807-d3dd6d268c4b/go.mod h1:DNdrF/DiqJGG9JwPpVqv30JXHUH0MCfSaVBwA4oULRg=
 github.com/linode/linode-website-partials v0.0.0-20200907163220-d3856e759e21/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/linode/linode-website-partials v0.0.0-20200921210751-887bbecdd5dd/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/linode/linode-website-partials v0.0.0-20201001182036-fe8965a45b3c h1:j2j0WYHnoSEsGg7790A+gNQqKYIXGTi/i1FHTwt9zBM=


### PR DESCRIPTION
Theme updates:

- Revert: 'explorer: Initially open and focused on visited page'

A bug was introduced by this previous theme update. When the bug is present, the Explore Docs menu is empty for mobile viewports.

After this reversion, the Explore Docs menu will still appear on page load for the docs home page and API endpoint pages. It will not appear on page load for individual guides or other pages.