### PR TITLE
Change to Custom Images pricing

### DIFF
--- a/docs/guides/platform/disk-images/linode-images/index.md
+++ b/docs/guides/platform/disk-images/linode-images/index.md
@@ -8,7 +8,7 @@ keywords: ["linode Images", "imagize"]
 tags: ["linode platform","cloud manager"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/linode-images/','/platform/disk-images/linode-images/','/platform/disk-images/linode-images-classic-manager/','/platform/linode-images/','/platform/disk-images/linode-images-new-manager/']
-modified: 2021-08-17
+modified: 2021-09-01
 modified_by:
   name: Linode
 published: 2014-09-25
@@ -19,9 +19,9 @@ Linode's **Images** service allows users to store custom disk images in the Clou
 
 ## Pricing and Availability
 
-Images are currently available at no charge to Linode customers and can be deployed across [all regions](https://www.linode.com/global-infrastructure/).
-
 {{< content "images-ga-pricing-update-shortguide" >}}
+
+Custom Images cost $0.10/GB per month and are available across [all regions](https://www.linode.com/global-infrastructure/).
 
 ## Types of Images
 

--- a/docs/products/tools/images/_index.md
+++ b/docs/products/tools/images/_index.md
@@ -16,9 +16,9 @@ Images can be created and deployed across [all regions](https://www.linode.com/g
 
 ## Pricing
 
-Images are currently available at no charge to Linode customers.
+Custom Images has transitioned to a paid service beginning September 1st, 2021. Custom Images now cost $0.10/GB per month. Keep in mind that Custom Images generated from an uploaded image file are billed based on the _uncompressed_ size of that image.
 
-{{< content "images-ga-pricing-update-shortguide" >}}
+Recovery Images, generated automatically after a Linode is deleted, are provided as a free courtesy service.
 
 ## Features
 

--- a/docs/products/tools/images/_shortguides/images-ga-pricing-update-shortguide/index.md
+++ b/docs/products/tools/images/_shortguides/images-ga-pricing-update-shortguide/index.md
@@ -6,5 +6,5 @@ show_on_rss_feed: false
 ---
 
 {{< note >}}
-**Pricing change:** Beginning September 1, 2021, Images will transition to a paid service with a cost of $0.10/GB per month for each Custom Image stored on an account. Recovery Images, generated automatically after a Linode is deleted, will continue to be provided at no cost.
+**Pricing change:** Starting on September 1, 2021, Custom Images has transitioned to a paid service with a cost of $0.10/GB per month for each Custom Image stored on an account. Recovery Images, generated automatically after a Linode is deleted, will continue to be provided at no cost. See [Images > Pricing](/docs/products/tools/images/#pricing) for additional details.
 {{</ note >}}

--- a/docs/products/tools/images/_shortguides/upload-image-requirements-shortguide/index.md
+++ b/docs/products/tools/images/_shortguides/upload-image-requirements-shortguide/index.md
@@ -12,6 +12,6 @@ show_on_rss_feed: false
 
 - **Maximum file size is 5GB:** The maximum size for an image file is 5GB (compressed).
 
-- **Pricing considerations:** Once pricing goes into effect, you will be charged for the *uncompressed* size of the Image.
+- **Pricing considerations:** Custom Images are billed based on the *uncompressed* size of the uploaded image file.
 
 - **For compatibility, use unpartitioned disks formatted with ext3 or ext4 file systems:** [Network Helper](/docs/guides/network-helper/) and other Linode Helpers are compatible with non-partitioned image files formatted using the ext3 or ext4 file systems. Partitioned disks and other file systems may be used, but some manual configuration may be required.


### PR DESCRIPTION
Custom Images transitioned to a paid service on September 1st, 2021. This PR covers updating our documentation to reflect the new pricing.

- [Updated] Images > Overview
- [Updated] Images Tutorial
- [Updated] `images-ga-pricing-update-shortguide`