### PR TITLE
 [Update] The caddy guides

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -1878,6 +1878,7 @@ wx
 xabbix
 xap
 xargs
+xcaddy
 xcalc
 xcode
 xen

--- a/docs/guides/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/guides/web-servers/caddy/compile-caddy-from-source/index.md
@@ -57,7 +57,7 @@ Install the latest version of `xcaddy`, a command line tool that downloads and b
 
         sudo mv caddy /usr/bin
 
-1. To verfiy the installation of caddy type:
+1. To verify the installation of caddy type:
        caddy version
     An output similar to the following appears:
 

--- a/docs/guides/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/guides/web-servers/caddy/compile-caddy-from-source/index.md
@@ -32,7 +32,7 @@ Install the latest version of `xcaddy`, a command line tool that downloads and b
 1. Download and install `xcaddy`:
 
         sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
-        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/xcaddy/gpg.key' | sudo apt-key add -
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/xcaddy/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-xcaddy.asc
         curl -1sLf 'https://dl.cloudsmith.io/public/caddy/xcaddy/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-xcaddy.list
         sudo apt update
         sudo apt install xcaddy
@@ -48,7 +48,7 @@ Install the latest version of `xcaddy`, a command line tool that downloads and b
 * To install Caddy with plugins use the `--with` option. For example:
 
         xcaddy build \
-          --with github.com/caddyserver/nginx-adapter
+          --with github.com/caddyserver/nginx-adapter \
           --with github.com/caddyserver/ntlm-transport@v0.1.1```
 
 1. Move the `caddy` executable from the `caddy` folder to `/usr/bin` to install:

--- a/docs/guides/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/guides/web-servers/caddy/compile-caddy-from-source/index.md
@@ -21,56 +21,46 @@ aliases: ['/web-servers/caddy/compile-caddy-from-source/']
 
 Caddy has recently updated their license, clearly defining what is considered personal or enterprise use. A commercial license is now required for commercial or enterprise use, including any installation that uses precompiled Caddy binaries. However, because the project is Apache licensed, by building it from source you have access to the original, [Apache-licensed web server](https://twitter.com/mholt6/status/908041929438371840).
 
-## Build Caddy from Source
+## Before you Begin
+
 ### Install Go
 
-1. You will need a current version of Go installed on your Linode. Complete the steps in our guide on [installing Go](/docs/development/go/install-go-on-ubuntu/).
+1. You need the latest version of Go installed on your Linode. Complete the steps in our guide on [installing Go](/docs/development/go/install-go-on-ubuntu/).
 
-1. Print your Go installation's current `$GOPATH`:
+### Install xcaddy
 
-        go env GOPATH
+Install the latest version of `xcaddy`, a command line tool that downloads and builds Caddy and its plugins for you easily.
 
-1. Set the transitional environment variable for Go modules.
+1. Download and install `xcaddy`:
 
-        cd $GOPATH/src
-        export GO111MODULE=on
+        sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/xcaddy/gpg.key' | sudo apt-key add -
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/xcaddy/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-xcaddy.list
+        sudo apt update
+        sudo apt install xcaddy
 
 ### Build Caddy
 
-* To build without plugins:
+1. Create a folder named `caddy` and go to the folder to install Caddy:
+        mkdir ~/caddy
+        cd ~/caddy
+* To build the latest version of Caddy without any plugins:
+        xcaddy build
 
-        go get github.com/caddyserver/caddy/caddy
+* To install Caddy with plugins use the `--with` option. For example:
 
-* To build custom Caddy with plugins:
-    1. Create a folder named `plugins` and add a `main.go` file with the following contents:
+        xcaddy build \
+        --with github.com/caddyserver/nginx-adapter
+        --with github.com/caddyserver/ntlm-transport@v0.1.1```
 
-        {{< file "$GOPATH/plugins/main.go" >}}
-package main
+1. Move the `caddy` executable from the `caddy` folder to `/usr/bin` to install:
 
-import (
-  "github.com/caddyserver/caddy/caddy/caddymain"
+        sudo mv caddy /usr/bin
 
-  // plug in plugins here, for example:
-  // _ "import/path/here"
-)
+1. To verfiy the installation of caddy type:
+       caddy version
+    An output similar to the following appears:
 
-func main() {
-  // optional: disable telemetry
-  // caddymain.EnableTelemetry = false
-  caddymain.Run()
-}
-    {{< /file >}}
-    1. Create a new go module for Caddy:
-
-            go mod init caddy
-    1. Download and save the packages in `$GOPATH/src/<import-path>`:
-
-            go get github.com/caddyserver/caddy
-    1. Install Caddy in `$GOPATH/bin`:
-
-            go install
-
-          {{< note >}} To install Caddy in the current directory you can run `go build`
-          {{< /note >}}
+        v2.4.4 h1:QBsN1jXEsCqRpKPBb8ebVnBNgPxwL50HINWWTuZ7evU=
 
 Caddy is now installed on your Linode. Read our guide on [Installing and Configuring Caddy](/docs/web-servers/caddy/install-and-configure-caddy-on-centos-7/) to learn more about Caddy.

--- a/docs/guides/web-servers/caddy/compile-caddy-from-source/index.md
+++ b/docs/guides/web-servers/caddy/compile-caddy-from-source/index.md
@@ -19,8 +19,6 @@ aliases: ['/web-servers/caddy/compile-caddy-from-source/']
 
 [Caddy](https://caddyserver.com/) is a fast, open-source and security-focused web server written in [Go](https://golang.org/). Caddy includes modern features such as support for virtual hosts, minification of static files, and HTTP/2. Caddy is also the first web-server that can obtain and renew SSL/TLS certificates automatically using [Let's Encrypt](https://letsencrypt.org/).
 
-Caddy has recently updated their license, clearly defining what is considered personal or enterprise use. A commercial license is now required for commercial or enterprise use, including any installation that uses precompiled Caddy binaries. However, because the project is Apache licensed, by building it from source you have access to the original, [Apache-licensed web server](https://twitter.com/mholt6/status/908041929438371840).
-
 ## Before you Begin
 
 ### Install Go
@@ -50,8 +48,8 @@ Install the latest version of `xcaddy`, a command line tool that downloads and b
 * To install Caddy with plugins use the `--with` option. For example:
 
         xcaddy build \
-        --with github.com/caddyserver/nginx-adapter
-        --with github.com/caddyserver/ntlm-transport@v0.1.1```
+          --with github.com/caddyserver/nginx-adapter
+          --with github.com/caddyserver/ntlm-transport@v0.1.1```
 
 1. Move the `caddy` executable from the `caddy` folder to `/usr/bin` to install:
 

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/index.md
@@ -42,48 +42,65 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/']
 
 ## Install Caddy
 
-1. Install the `tar` command line utility. The Caddy download script will need `tar` to complete its installation in the next step.
+1.  Install the `dnf-command(cpor)` plugin and enable `caddy`:
 
-        sudo yum install tar
+        sudo dnf install 'dnf-command(copr)'
+        sudo dnf copr enable @caddy/caddy
 
-1. Install Caddy. This will install Caddy version 1.0.4. along with the `hook.service` [plugin](https://github.com/hacdias/caddy-service), which gives you access to a systemd unit file that you can use to manage Caddy as a systemd service. See their [downloads page](https://caddyserver.com/v1/download) for more information on available Caddy versions.
+1.  Install Caddy:
 
-        curl https://getcaddy.com | bash -s personal hook.service
+        sudo dnf install caddy
 
-    Caddy will be installed to your `/usr/local/bin/caddy` directory.
+1. To verfiy the installation of caddy type:
+       caddy version
+    An output similar to the following appears:
 
-    {{< note >}}
-To learn about Caddy licensing, please read their [blog post on the topic](https://caddyserver.com/v1/blog/announcing-caddy-1_0-caddy-2-caddy-enterprise). In 2017, commercial use of Caddy and their binaries required a license, however, they have recently updated their licensing and commercial licenses are no longer required for their use.
-    {{</ note >}}
+        v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
 
-1. Add Caddy to your system's `$PATH`.
+{{< caution >}}
+Caddy has recently changed their [license](https://caddyserver.com/products/licenses). Please read over the license agreement to ensure that you are not violating the license with your project. To use Caddy without a commercial license, you may need to [compile from source](/docs/web-servers/caddy/compile-caddy-from-source).
+{{</ caution >}}
 
-        sudo echo 'export PATH=/usr/local/bin/caddy:$PATH' | sudo tee /etc/profile.d/caddy.sh
+## Allow HTTP and HTTPS Connections
 
-1. Reload your system's profile or log out and SSH back into your Linode.
+Caddy serves websites using HTTP and HTTPS protocols, so you need to allow access to the ports 80, and 443.
 
-        . /etc/profile
+        sudo firewall-cmd --permanent --zone=public --add-service=http
+        sudo firewall-cmd --permanent --zone=public --add-service=https
+        sudo firewall-cmd --reload
 
-    {{< note >}}
-You can verify that the Caddy executable is in your system's `$PATH` with the following command:
+## Add Web Content
 
-    echo $PATH
+1.  Set up a home directory, **web root**, for your website:
 
-The output should include the location of your Caddy executable:
+        sudo mkdir -p /var/www/html/example.com
 
-    /usr/local/bin/caddy:/home/example_user/.local/bin:/home/example_user/bin:/usr/local/bin/caddy:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
+1. Use SELinux’s `chcon` command to change the file security context for web content:
 
-    {{</ note >}}
+        sudo chcon -t httpd_sys_content_t /var/www/example.com -R
+        sudo chcon -t httpd_sys_rw_content_t /var/www/example.com -R
 
-1. Install Caddy as a systemd service.
+1.  Create a test page:
 
-        sudo env "PATH=$PATH" caddy -service install
+        echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/html/example.com/index.html
+
+## Configure the Caddyfile
+
+Add your hostname and web root to the Caddy configuration. Use an editor of your choice and replace `:80` with your domain name. Set the root directory of the site to `/var/www/html/example.com` Replace `example.com` with your site's domain name:
+
+{{< file "/etc/caddy/Caddyfile" caddy >}}
+example.com {
+root /var/www/html/example.com
+}
+{{< /file >}}
+
+## Start and Enable the Caddy Service
 
 1. Temporarily set SELinux to permissive mode in order to start the Caddy service.
 
         sudo setenforce 0
 
-1. Start the Caddy service:
+1.  Enable the Caddy service:
 
         sudo systemctl start caddy
 
@@ -91,103 +108,33 @@ The output should include the location of your Caddy executable:
 
         sudo systemctl status caddy
 
-    You should see a similar output:
+    An output similar to the following appears:
 
     {{< output >}}
-● caddy.service - Caddy's service
-   Loaded: loaded (/etc/systemd/system/caddy.service; enabled; vendor preset: enabled)
-   Active: active (running) since Thu 2020-03-05 14:56:45 EST; 9s ago
- Main PID: 19505 (caddy)
-    Tasks: 10 (limit: 4659)
+● caddy.service - Caddy
+   Loaded: loaded (/usr/lib/systemd/system/caddy.service; disabled; vendor preset: disabled)
+   Active: active (running) since Thu 2021-09-02 18:25:29 IST; 4s ago
+     Docs: https://caddyserver.com/docs/
+ Main PID: 19314 (caddy)
    CGroup: /system.slice/caddy.service
-           └─19505 /usr/local/bin/caddy
+           └─19314 /usr/bin/caddy run --environ --config /etc/caddy/Caddyfile...
 
-Mar 05 14:56:45 example_hostname systemd[1]: Started Caddy's service.
-Mar 05 14:56:45 example_hostname caddy[19505]: Activating privacy features... done.
-Mar 05 14:56:45 example_hostname caddy[19505]: Serving HTTP on port 2015
-Mar 05 14:56:45 example_hostname caddy[19505]: http://:2015
+Sep 02 18:25:29 caddy caddy[19314]: SHELL=/sbin/nologin
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1270738..."}
+Sep 02 18:25:29 caddy systemd[1]: Started Caddy.
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1316314...]}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1317837...0}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1324193..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1324632..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1325648..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326034..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326299..."}
+Hint: Some lines were ellipsized, use -l to show in full.
     {{</ output >}}
 
 1. Set SELinux back to enforcing mode once you have successfully started the Caddy service.
 
         sudo setenforce 1
 
-## Add Web Content
+1.  Type your domain in the browser on your local machine and you should see the test page. If everything is configured correctly, you should see a green lock symbol in the URL bar, indicating that your connection is secure.
 
-In this section, you will create the necessary directories to host your website files, set their correct permissions, and add a basic index file to your example site.
-
-{{< note >}}
-Throughout this section, replace all instances of `example.com` with your own domain.
-{{</ note >}}
-
-1.  Set up a *document root* for your website. A document root is the directory where your website files are stored.
-
-        sudo mkdir -p /var/www/example.com
-
-1. Use SELinux’s `chcon` command to change the file security context for web content:
-
-        sudo chcon -t httpd_sys_content_t /var/www/example.com -R
-        sudo chcon -t httpd_sys_rw_content_t /var/www/example.com -R
-
-1. Create a test index page for your site. Replace `example.com` with your own domain.
-
-        sudo touch /var/www/example.com/index.html
-
-1. Add the example `html` to your site's index.
-
-        sudo echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' | sudo tee /var/www/example.com/index.html
-
-## Configure the Caddyfile
-
-Now that you have your website's document root set up with example content, you are ready to configure Caddy to serve your website files to the internet. This section will create a basic Caddy configuration, which will [automatically enable HTTPS using Let's Encrypt](https://caddyserver.com/v1/).
-
-1. Create a directory to store Caddy's configuration files:
-
-        sudo mkdir -p /etc/caddy
-
-1. Using the text editor of your choice, create and edit the [Caddyfile](https://caddyserver.com/docs/caddyfile-tutorial) to serve your example site. The Caddyfile is Caddy's main configuration file. Replace `example.com` with your own domain.
-
-      {{< file "/etc/caddy/Caddyfile" >}}
-example.com {
-    root /var/www/example.com
-}
-      {{</ file >}}
-
-1. Open the firewall for traffic:
-
-        sudo firewall-cmd --zone=public --permanent --add-service=http
-        sudo firewall-cmd --zone=public --permanent --add-service=https
-        sudo firewall-cmd --reload
-
-1. Tell Caddy where to look for your Caddyfile, replace `admin@example.com` with your email address:
-
-        sudo env "PATH=$PATH" caddy -agree -conf /etc/caddy/Caddyfile -email admin@example.com &
-
-    Caddy will automatically serve your site over HTTPS using Let's Encrypt.
-
-    {{< output >}}
-Activating privacy features...
-
-2020/03/05 13:31:25 [INFO] acme: Registering account for admin@example.com
-2020/03/05 13:31:25 [INFO] [example.com] acme: Obtaining bundled SAN certificate
-2020/03/05 13:31:26 [INFO] [example.com] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/3180082162
-2020/03/05 13:31:26 [INFO] [example.com] acme: Could not find solver for: tls-alpn-01
-2020/03/05 13:31:26 [INFO] [example.com] acme: use http-01 solver
-2020/03/05 13:31:26 [INFO] [example.com] acme: Trying to solve HTTP-01
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:36 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:40 [INFO] [example.com] The server validated our request
-2020/03/05 13:31:40 [INFO] [example.com] acme: Validations succeeded; requesting certificates
-2020/03/05 13:31:41 [INFO] [example.com] Server responded with a certificate.
-done.
-
-Serving HTTP on port 80
-http://digitalnabi.com
-
-Serving HTTPS on port 443
-https://example.com
-    {{</ output >}}
-
-1. Open a web browser and visit your domain. You should see the contents of the `index.html` page that you created in Step 4 of the [Add Web Content section](#add-web-content).

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/index.md
@@ -36,7 +36,7 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/']
 
         sudo yum update
 
-1. Install the SELinux core policy Python utilities. This will give you the ability to manage SELinux settings in a fine-grained way.
+1. Install the SELinux core policy Python utilities. This gives you the ability to manage SELinux settings in a fine-grained way.
 
         sudo yum install -y policycoreutils-python-utils
 
@@ -51,7 +51,7 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/']
 
         sudo dnf install caddy
 
-1. To verfiy the installation of caddy type:
+1. To verify the installation of caddy type:
        caddy version
     An output similar to the following appears:
 

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/index.md
@@ -129,6 +129,8 @@ Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326299..."}
 Hint: Some lines were ellipsized, use -l to show in full.
     {{</ output >}}
 
+ To check the latest logs without truncation use `sudo journalctl -u caddy --no-pager | less +G`.
+
 1. Set SELinux back to enforcing mode once you have successfully started the Caddy service.
 
         sudo setenforce 1

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/index.md
@@ -57,10 +57,6 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-centos-8/']
 
         v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
 
-{{< caution >}}
-Caddy has recently changed their [license](https://caddyserver.com/products/licenses). Please read over the license agreement to ensure that you are not violating the license with your project. To use Caddy without a commercial license, you may need to [compile from source](/docs/web-servers/caddy/compile-caddy-from-source).
-{{</ caution >}}
-
 ## Allow HTTP and HTTPS Connections
 
 Caddy serves websites using HTTP and HTTPS protocols, so you need to allow access to the ports 80, and 443.
@@ -90,7 +86,8 @@ Add your hostname and web root to the Caddy configuration. Use an editor of your
 
 {{< file "/etc/caddy/Caddyfile" caddy >}}
 example.com {
-root /var/www/html/example.com
+    root * /var/www/html/example.com
+    file_server
 }
 {{< /file >}}
 

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/index.md
@@ -40,7 +40,7 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/']
 
 ## Install Caddy
 
-1.  Install the `yum-plugin-copr` plugin and enable `caddy`:
+1.  Download `caddy`:
 
         sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
         curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
@@ -55,10 +55,6 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/']
     An output similar to the following appears:
 
         v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
-
-{{< caution >}}
-Caddy has recently changed their [license](https://caddyserver.com/products/licenses). Please read over the license agreement to ensure that you are not violating the license with your project. To use Caddy without a commercial license, you may need to [compile from source](/docs/web-servers/caddy/compile-caddy-from-source).
-{{</ caution >}}
 
 ## Allow HTTP and HTTPS Connections
 
@@ -104,7 +100,8 @@ Add your hostname and web root to the Caddy configuration. Use an editor of your
 
 {{< file "/etc/caddy/Caddyfile" caddy >}}
 example.com {
-root /var/www/html/example.com
+    root * /var/www/html/example.com
+    file_server
 }
 {{< /file >}}
 

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/index.md
@@ -50,7 +50,7 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/']
         sudo apt update
         sudo apt install caddy
 
-1. To verfiy the installation of caddy type:
+1. To verify the installation of caddy type:
        caddy version
     An output similar to the following appears:
 
@@ -72,7 +72,7 @@ Rule added
 Rule added (v6)
 {{< /output >}}
 
-1. Verifdy the changes:
+1. Verify the changes:
        sudo ufw status
 
 An output similar to the following appears:

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/index.md
@@ -139,4 +139,6 @@ Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326299..."}
 Hint: Some lines were ellipsized, use -l to show in full.
     {{</ output >}}
 
+To check the latest logs without truncation use `sudo journalctl -u caddy --no-pager | less +G`.
+
 1. Open a web browser and visit your domain. You should see the contents of the `index.html`page that you created in the [Add Web Content section](#add-web-content).

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/index.md
@@ -40,65 +40,77 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-debian-10/']
 
 ## Install Caddy
 
-1. Install Caddy. This will install Caddy version 1.0.4. along with the `hook.service` [plugin](https://github.com/hacdias/caddy-service), which gives you access to a systemd unit file that you can use to manage Caddy as a systemd service. See their [downloads page](https://caddyserver.com/v1/download) for more information on available Caddy versions.
+1.  Install the `yum-plugin-copr` plugin and enable `caddy`:
 
-        curl https://getcaddy.com | bash -s personal hook.service
+        sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
 
-    Caddy will be installed to your `/usr/local/bin/caddy` directory.
+1.  Install Caddy:
+        sudo apt update
+        sudo apt install caddy
 
-    {{< note >}}
-To learn about Caddy licensing, please read their [blog post on the topic](https://caddyserver.com/v1/blog/announcing-caddy-1_0-caddy-2-caddy-enterprise). In 2017, commercial use of Caddy and their binaries required a license, however, they have recently updated their licensing and commercial licenses are no longer required for their use.
-    {{</ note >}}
+1. To verfiy the installation of caddy type:
+       caddy version
+    An output similar to the following appears:
+
+        v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
+
+{{< caution >}}
+Caddy has recently changed their [license](https://caddyserver.com/products/licenses). Please read over the license agreement to ensure that you are not violating the license with your project. To use Caddy without a commercial license, you may need to [compile from source](/docs/web-servers/caddy/compile-caddy-from-source).
+{{</ caution >}}
+
+## Allow HTTP and HTTPS Connections
+
+Caddy serves websites using HTTP and HTTPS protocols, so you need to allow access to the ports 80, and 443.
+
+        sudo ufw allow proto tcp from any to any port 80,443
+
+An output similar to the following appears:
+{{< output >}}
+Rule added
+Rule added (v6)
+{{< /output >}}
+
+1. Verifdy the changes:
+       sudo ufw status
+
+An output similar to the following appears:
+{{< output >}}
+Status: active
+
+To                         Action      From
+--                         ------      ----
+OpenSSH                    ALLOW       Anywhere
+80,443/tcp                 ALLOW       Anywhere
+OpenSSH (v6)               ALLOW       Anywhere (v6)
+80,443/tcp (v6)            ALLOW       Anywhere (v6)
+{{< /output >}}
 
 ## Add Web Content
 
-In this section, you will create the necessary directories to host your website files, set their correct permissions, and add a basic index file to your example site.
+1.  Set up a home directory, **web root**, for your website:
 
-{{< note >}}
-Throughout this section, replace all instances of `example.com` with your own domain.
-{{</ note >}}
+        sudo mkdir -p /var/www/html/example.com
 
-1.  Set up a *document root* for your website. A document root is the directory where your website files are stored.
+1.  Create a test page:
 
-        sudo mkdir -p /var/www/example.com
+        echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/html/example.com/index.html
 
-1. Change your site's document root to be owned by the `www-data` user.
-
-        sudo chown -R www-data:www-data /var/www/example.com
-
-1. Create a test index page for your site. Replace `example.com` with your own domain.
-
-        sudo touch /var/www/example.com/index.html
-
-1. Add the example `html` to your site's index.
-
-        sudo echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' | sudo tee /var/www/example.com/index.html
 
 ## Configure the Caddyfile
 
-Now that you have your website's document root set up with example content, you are ready to configure Caddy to serve your website files to the internet. This section will create a basic Caddy configuration, which will [automatically enable HTTPS using Let's Encrypt](https://caddyserver.com/v1/).
+Add your hostname and web root to the Caddy configuration. Use an editor of your choice and replace `:80` with your domain name. Set the root directory of the site to `/var/www/html/example.com` Replace `example.com` with your site's domain name:
 
-1. Create a directory to store Caddy's configuration files:
-
-        sudo mkdir -p /etc/caddy
-
-1. Update the directory's owner to be the web server user, `www-data`.
-
-        sudo chown -R www-data:www-data /etc/caddy
-
-1. Using the text editor of your choice, create and edit the [Caddyfile](https://caddyserver.com/docs/caddyfile-tutorial) to serve your example site. The Caddyfile is Caddy's main configuration file. Replace `example.com` with your own domain.
-
-      {{< file "/etc/caddy/Caddyfile" >}}
+{{< file "/etc/caddy/Caddyfile" caddy >}}
 example.com {
-    root /var/www/example.com
+root /var/www/html/example.com
 }
-      {{</ file >}}
+{{< /file >}}
 
-1. Install Caddy as a systemd service:
+## Start and Enable the Caddy Service
 
-        sudo caddy -service install
-
-1. Start the Caddy service:
+1.  Enable the Caddy service:
 
         sudo systemctl start caddy
 
@@ -106,52 +118,28 @@ example.com {
 
         sudo systemctl status caddy
 
-    You should see a similar output:
+    An output similar to the following appears:
 
     {{< output >}}
-● caddy.service - Caddy's service
-   Loaded: loaded (/etc/systemd/system/caddy.service; enabled; vendor preset: enabled)
-   Active: active (running) since Thu 2020-03-05 14:56:45 EST; 9s ago
- Main PID: 19505 (caddy)
-    Tasks: 10 (limit: 4659)
+● caddy.service - Caddy
+   Loaded: loaded (/usr/lib/systemd/system/caddy.service; disabled; vendor preset: disabled)
+   Active: active (running) since Thu 2021-09-02 18:25:29 IST; 4s ago
+     Docs: https://caddyserver.com/docs/
+ Main PID: 19314 (caddy)
    CGroup: /system.slice/caddy.service
-           └─19505 /usr/local/bin/caddy
+           └─19314 /usr/bin/caddy run --environ --config /etc/caddy/Caddyfile...
 
-Mar 05 14:56:45 example_hostname systemd[1]: Started Caddy's service.
-Mar 05 14:56:45 example_hostname caddy[19505]: Activating privacy features... done.
-Mar 05 14:56:45 example_hostname caddy[19505]: Serving HTTP on port 2015
-Mar 05 14:56:45 example_hostname caddy[19505]: http://:2015
-{{</ output >}}
-
-1. Tell Caddy where to look for your Caddyfile, replace `admin@example.com` with your email address:
-
-        caddy -agree -conf /etc/caddy/Caddyfile -email admin@example.com &
-
-    Caddy will automatically serve your site over HTTPS using Let's Encrypt.
-
-    {{< output >}}
-Activating privacy features...
-
-2020/03/05 13:31:25 [INFO] acme: Registering account for admin@example.com
-2020/03/05 13:31:25 [INFO] [example.com] acme: Obtaining bundled SAN certificate
-2020/03/05 13:31:26 [INFO] [example.com] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/3180082162
-2020/03/05 13:31:26 [INFO] [example.com] acme: Could not find solver for: tls-alpn-01
-2020/03/05 13:31:26 [INFO] [example.com] acme: use http-01 solver
-2020/03/05 13:31:26 [INFO] [example.com] acme: Trying to solve HTTP-01
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:36 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:40 [INFO] [example.com] The server validated our request
-2020/03/05 13:31:40 [INFO] [example.com] acme: Validations succeeded; requesting certificates
-2020/03/05 13:31:41 [INFO] [example.com] Server responded with a certificate.
-done.
-
-Serving HTTPS on port 443
-https://example.com
-
-Serving HTTP on port 80
-http://example.com
+Sep 02 18:25:29 caddy caddy[19314]: SHELL=/sbin/nologin
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1270738..."}
+Sep 02 18:25:29 caddy systemd[1]: Started Caddy.
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1316314...]}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1317837...0}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1324193..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1324632..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1325648..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326034..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326299..."}
+Hint: Some lines were ellipsized, use -l to show in full.
     {{</ output >}}
 
-1. Open a web browser and visit your domain. You should see the contents of the `index.html` page that you created in Step 4 of the [Add Web Content section](#add-web-content).
+1. Open a web browser and visit your domain. You should see the contents of the `index.html`page that you created in the [Add Web Content section](#add-web-content).

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
@@ -40,7 +40,7 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04
 
 ## Install Caddy
 
-1.  Install the `yum-plugin-copr` plugin and enable `caddy`:
+1.  Download `caddy`:
 
         sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
         curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
@@ -56,9 +56,6 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04
 
         v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
 
-{{< caution >}}
-Caddy has recently changed their [license](https://caddyserver.com/products/licenses). Please read over the license agreement to ensure that you are not violating the license with your project. To use Caddy without a commercial license, you may need to [compile from source](/docs/web-servers/caddy/compile-caddy-from-source).
-{{</ caution >}}
 
 ## Allow HTTP and HTTPS Connections
 
@@ -104,7 +101,8 @@ Add your hostname and web root to the Caddy configuration. Use an editor of your
 
 {{< file "/etc/caddy/Caddyfile" caddy >}}
 example.com {
-root /var/www/html/example.com
+    root * /var/www/html/example.com
+    file_server
 }
 {{< /file >}}
 

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
@@ -140,4 +140,6 @@ Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326299..."}
 Hint: Some lines were ellipsized, use -l to show in full.
     {{</ output >}}
 
+To check the latest logs without truncation use `sudo journalctl -u caddy --no-pager | less +G`.
+
 1. Open a web browser and visit your domain. You should see the contents of the `index.html`page that you created in the [Add Web Content section](#add-web-content).

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
@@ -28,9 +28,9 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04
 
 ## Before You Begin
 
-1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's [hostname](/docs/getting-started/#set-the-hostname) and [timezone](/docs/getting-started/#set-the-timezone).
+1.  Familiarize yourself with the [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's [hostname](/docs/getting-started/#set-the-hostname) and [timezone](/docs/getting-started/#set-the-timezone).
 
-1.  Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) guide to [create a standard user account](/docs/security/securing-your-server/#add-a-limited-user-account), [harden SSH access](/docs/security/securing-your-server/#harden-ssh-access), and [remove unnecessary network services](/docs/security/securing-your-server/#remove-unused-network-facing-services).
+1.  Complete the sections of the [Securing Your Server](/docs/security/securing-your-server) guide to [create a standard user account](/docs/security/securing-your-server/#add-a-limited-user-account), [harden SSH access](/docs/security/securing-your-server/#harden-ssh-access), and [remove unnecessary network services](/docs/security/securing-your-server/#remove-unused-network-facing-services).
 
 1.  Register (purchase) your site's domain name and follow our [DNS Manager Overview](/docs/networking/dns/dns-manager-overview#add-records) guide to point the domain to your Linode.
 
@@ -40,21 +40,77 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04
 
 ## Install Caddy
 
-1. Install Caddy. This will install Caddy version 1.0.4. along with the `hook.service` [plugin](https://github.com/hacdias/caddy-service), which gives you access to a systemd unit file that you can use to manage Caddy as a systemd service. See their [downloads page](https://caddyserver.com/v1/download) for more information on available Caddy versions.
+1.  Install the `yum-plugin-copr` plugin and enable `caddy`:
 
-        curl https://getcaddy.com | bash -s personal hook.service
+        sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
 
-    Caddy will be installed to your `/usr/local/bin/caddy` directory.
+1.  Install Caddy:
+        sudo apt update
+        sudo apt install caddy
 
-    {{< note >}}
-To learn about Caddy licensing, please read their [blog post on the topic](https://caddyserver.com/v1/blog/announcing-caddy-1_0-caddy-2-caddy-enterprise). In 2017, commercial use of Caddy and their binaries required a license, however, they have recently updated their licensing and commercial licenses are no longer required for their use.
-    {{</ note >}}
+1. To verfiy the installation of caddy type:
+       caddy version
+    An output similar to the following appears:
 
-1. Install Caddy as a systemd service:
+        v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
 
-        sudo caddy -service install
+{{< caution >}}
+Caddy has recently changed their [license](https://caddyserver.com/products/licenses). Please read over the license agreement to ensure that you are not violating the license with your project. To use Caddy without a commercial license, you may need to [compile from source](/docs/web-servers/caddy/compile-caddy-from-source).
+{{</ caution >}}
 
-1. Start the Caddy service:
+## Allow HTTP and HTTPS Connections
+
+Caddy serves websites using HTTP and HTTPS protocols, so you need to allow access to the ports 80, and 443.
+
+        sudo ufw allow proto tcp from any to any port 80,443
+
+An output similar to the following appears:
+{{< output >}}
+Rule added
+Rule added (v6)
+{{< /output >}}
+
+1. Verifdy the changes:
+       sudo ufw status
+
+An output similar to the following appears:
+{{< output >}}
+Status: active
+
+To                         Action      From
+--                         ------      ----
+OpenSSH                    ALLOW       Anywhere
+80,443/tcp                 ALLOW       Anywhere
+OpenSSH (v6)               ALLOW       Anywhere (v6)
+80,443/tcp (v6)            ALLOW       Anywhere (v6)
+{{< /output >}}
+
+## Add Web Content
+
+1.  Set up a home directory, **web root**, for your website:
+
+        sudo mkdir -p /var/www/html/example.com
+
+1.  Create a test page:
+
+        echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/html/example.com/index.html
+
+
+## Configure the Caddyfile
+
+Add your hostname and web root to the Caddy configuration. Use an editor of your choice and replace `:80` with your domain name. Set the root directory of the site to `/var/www/html/example.com` Replace `example.com` with your site's domain name:
+
+{{< file "/etc/caddy/Caddyfile" caddy >}}
+example.com {
+root /var/www/html/example.com
+}
+{{< /file >}}
+
+## Start and Enable the Caddy Service
+
+1.  Enable the Caddy service:
 
         sudo systemctl start caddy
 
@@ -62,95 +118,28 @@ To learn about Caddy licensing, please read their [blog post on the topic](https
 
         sudo systemctl status caddy
 
-    You should see a similar output:
+    An output similar to the following appears:
 
     {{< output >}}
-● caddy.service - Caddy's service
-   Loaded: loaded (/etc/systemd/system/caddy.service; enabled; vendor preset: enabled)
-   Active: active (running) since Thu 2020-03-05 14:56:45 EST; 9s ago
- Main PID: 19505 (caddy)
-    Tasks: 10 (limit: 4659)
+● caddy.service - Caddy
+   Loaded: loaded (/usr/lib/systemd/system/caddy.service; disabled; vendor preset: disabled)
+   Active: active (running) since Thu 2021-09-02 18:25:29 IST; 4s ago
+     Docs: https://caddyserver.com/docs/
+ Main PID: 19314 (caddy)
    CGroup: /system.slice/caddy.service
-           └─19505 /usr/local/bin/caddy
+           └─19314 /usr/bin/caddy run --environ --config /etc/caddy/Caddyfile...
 
-Mar 05 14:56:45 example_hostname systemd[1]: Started Caddy's service.
-Mar 05 14:56:45 example_hostname caddy[19505]: Activating privacy features... done.
-Mar 05 14:56:45 example_hostname caddy[19505]: Serving HTTP on port 2015
-Mar 05 14:56:45 example_hostname caddy[19505]: http://:2015
+Sep 02 18:25:29 caddy caddy[19314]: SHELL=/sbin/nologin
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1270738..."}
+Sep 02 18:25:29 caddy systemd[1]: Started Caddy.
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1316314...]}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1317837...0}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1324193..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1324632..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1325648..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326034..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326299..."}
+Hint: Some lines were ellipsized, use -l to show in full.
     {{</ output >}}
 
-## Add Web Content
-
-In this section, you will create the necessary directories to host your website files, set their correct permissions, and add a basic index file to your example site.
-
-{{< note >}}
-Throughout this section, replace all instances of `example.com` with your own domain.
-{{</ note >}}
-
-1.  Set up a *document root* for your website. A document root is the directory where your website files are stored.
-
-        sudo mkdir -p /var/www/example.com
-
-1. Change your site's document root to be owned by the `www-data` user.
-
-        sudo chown -R www-data:www-data /var/www/example.com
-
-1. Create a test index page for your site. Replace `example.com` with your own domain.
-
-        sudo touch /var/www/example.com/index.html
-
-1. Add the example `html` to your site's index.
-
-        sudo echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' | sudo tee /var/www/example.com/index.html
-
-## Configure the Caddyfile
-
-Now that you have your website's document root set up with example content, you are ready to configure Caddy to serve your website files to the internet. This section will create a basic Caddy configuration, which will [automatically enable HTTPS using Let's Encrypt](https://caddyserver.com/v1/docs/automatic-https#obtaining-certificates).
-
-1. Create a directory to store Caddy's configuration files:
-
-        sudo mkdir -p /etc/caddy
-
-1. Update the directory's owner to be the web server user, `www-data`.
-
-        sudo chown -R www-data:www-data /etc/caddy
-
-1. Using the text editor of your choice, create and edit the [Caddyfile](https://caddyserver.com/docs/caddyfile-tutorial) to serve your example site. The Caddyfile is Caddy's main configuration file. Replace `example.com` with your own domain.
-
-      {{< file "/etc/caddy/Caddyfile" >}}
-example.com {
-    root /var/www/example.com
-}
-      {{</ file >}}
-
-1. Tell Caddy where to look for your Caddyfile, replace `admin@example.com` with your email address:
-
-        caddy -agree -conf /etc/caddy/Caddyfile -email admin@example.com &
-
-    Caddy will automatically serve your site over HTTPS using Let's Encrypt.
-
-    {{< output >}}
-Activating privacy features...
-2020/03/05 13:31:25 [INFO] acme: Registering account for admin@example.com
-2020/03/05 13:31:25 [INFO] [example.com] acme: Obtaining bundled SAN certificate
-2020/03/05 13:31:26 [INFO] [example.com] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/3180082162
-2020/03/05 13:31:26 [INFO] [example.com] acme: Could not find solver for: tls-alpn-01
-2020/03/05 13:31:26 [INFO] [example.com] acme: use http-01 solver
-2020/03/05 13:31:26 [INFO] [example.com] acme: Trying to solve HTTP-01
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:26 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:36 [INFO] [example.com] Served key authentication
-2020/03/05 13:31:40 [INFO] [example.com] The server validated our request
-2020/03/05 13:31:40 [INFO] [example.com] acme: Validations succeeded; requesting certificates
-2020/03/05 13:31:41 [INFO] [example.com] Server responded with a certificate.
-done.
-
-Serving HTTPS on port 443
-https://example.com
-
-Serving HTTP on port 80
-http://example.com
-    {{</ output >}}
-
-1. Open a web browser and visit your domain. You should see the contents of the `index.html`page that you created in Step 4 of the [Add Web Content section](#add-web-content).
+1. Open a web browser and visit your domain. You should see the contents of the `index.html`page that you created in the [Add Web Content section](#add-web-content).

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
@@ -50,7 +50,7 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04
         sudo apt update
         sudo apt install caddy
 
-1. To verfiy the installation of caddy type:
+1. To verify the installation of caddy type:
        caddy version
     An output similar to the following appears:
 
@@ -72,7 +72,7 @@ Rule added
 Rule added (v6)
 {{< /output >}}
 
-1. Verifdy the changes:
+1. Verify the changes:
        sudo ufw status
 
 An output similar to the following appears:

--- a/docs/guides/web-servers/caddy/install-and-configure-caddy-on-centos-7/index.md
+++ b/docs/guides/web-servers/caddy/install-and-configure-caddy-on-centos-7/index.md
@@ -59,10 +59,6 @@ aliases: ['/web-servers/caddy/install-and-configure-caddy-on-centos-7/']
 
         v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
 
-{{< caution >}}
-Caddy has recently changed their [license](https://caddyserver.com/products/licenses). Please read over the license agreement to ensure that you are not violating the license with your project. To use Caddy without a commercial license, you may need to [compile from source](/docs/web-servers/caddy/compile-caddy-from-source).
-{{</ caution >}}
-
 ## Allow HTTP and HTTPS Connections
 
 Caddy serves websites using HTTP and HTTPS protocols, so you need to allow access to the ports 80, and 443.
@@ -87,7 +83,8 @@ Add your hostname and web root to the Caddy configuration. Use an editor of your
 
 {{< file "/etc/caddy/Caddyfile" caddy >}}
 example.com {
-root /var/www/html/example.com
+    root * /var/www/html/example.com
+    file_server
 }
 {{< /file >}}
 

--- a/docs/guides/web-servers/caddy/install-and-configure-caddy-on-centos-7/index.md
+++ b/docs/guides/web-servers/caddy/install-and-configure-caddy-on-centos-7/index.md
@@ -53,7 +53,7 @@ aliases: ['/web-servers/caddy/install-and-configure-caddy-on-centos-7/']
 
         sudo yum install caddy
 
-1. To verfiy the installation of caddy type:
+1. To verify the installation of caddy type:
        caddy version
     An output similar to the following appears:
 

--- a/docs/guides/web-servers/caddy/install-and-configure-caddy-on-centos-7/index.md
+++ b/docs/guides/web-servers/caddy/install-and-configure-caddy-on-centos-7/index.md
@@ -34,9 +34,9 @@ aliases: ['/web-servers/caddy/install-and-configure-caddy-on-centos-7/']
 
 1.  Familiarize yourself with our [Getting Started](/docs/getting-started) guide and complete the steps for setting your Linode's hostname and timezone.
 
-2.  This guide will use `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) guide to create a standard user account, harden SSH access and remove unnecessary network services.
+2.  This guide uses `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/security/securing-your-server) guide to create a standard user account, harden SSH access and remove unnecessary network services.
 
-3.  You will need to register your site's domain name and follow our [DNS Manager Overview](/docs/networking/dns/dns-manager-overview#add-records) guide to point your domain to your Linode.
+3.  You need to register your site's domain name and follow our [DNS Manager Overview](/docs/networking/dns/dns-manager-overview#add-records) guide to point your domain to your Linode.
 
 4.  Update your system:
 
@@ -44,45 +44,85 @@ aliases: ['/web-servers/caddy/install-and-configure-caddy-on-centos-7/']
 
 ## Install Caddy
 
-1.  Enable the [EPEL](https://fedoraproject.org/wiki/EPEL) repository:
+1.  Install the `yum-plugin-copr` plugin and enable `caddy`:
 
-        sudo yum install epel-release
+        sudo yum install yum-plugin-copr
+        sudo yum copr enable @caddy/caddy
 
-2.  Install Caddy:
+1.  Install Caddy:
 
         sudo yum install caddy
+
+1. To verfiy the installation of caddy type:
+       caddy version
+    An output similar to the following appears:
+
+        v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
 
 {{< caution >}}
 Caddy has recently changed their [license](https://caddyserver.com/products/licenses). Please read over the license agreement to ensure that you are not violating the license with your project. To use Caddy without a commercial license, you may need to [compile from source](/docs/web-servers/caddy/compile-caddy-from-source).
 {{</ caution >}}
+
+## Allow HTTP and HTTPS Connections
+
+Caddy serves websites using HTTP and HTTPS protocols, so you need to allow access to the ports 80, and 443.
+
+        sudo firewall-cmd --permanent --zone=public --add-service=http
+        sudo firewall-cmd --permanent --zone=public --add-service=https
+        sudo firewall-cmd --reload
+
 ## Add Web Content
 
 1.  Set up a home directory, **web root**, for your website:
 
-        sudo mkdir -p /var/www/my-website
+        sudo mkdir -p /var/www/html/example.com
 
-2.  Create a test page:
+1.  Create a test page:
 
-        echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/my-website/index.html
-
-3.  Restore the correct selinux labels on the web root:
-
-        sudo restorecon -r /var/www/my-website
+        echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/html/example.com/index.html
 
 ## Configure the Caddyfile
 
-Add your hostname and web root to the Caddy configuration. Replace `example.com` with your site's domain name:
+Add your hostname and web root to the Caddy configuration. Use an editor of your choice and replace `:80` with your domain name. Set the root directory of the site to `/var/www/html/example.com` Replace `example.com` with your site's domain name:
 
-{{< file "/etc/caddy/conf.d/my-website.conf" caddy >}}
+{{< file "/etc/caddy/Caddyfile" caddy >}}
 example.com {
-root /var/www/my-website
+root /var/www/html/example.com
 }
 {{< /file >}}
 
-## Enable the Caddy Service
+## Start and Enable the Caddy Service
 
 1.  Enable the Caddy service:
 
-        sudo systemctl enable --now caddy.service
+        sudo systemctl start caddy
 
-2.  Type your domain into a browser window on your local machine and you should see the test page. If everything is configured correctly, you should see a green lock symbol in the URL bar, indicating that your connection is secure.
+1. Verify that the service is active:
+
+        sudo systemctl status caddy
+
+    An output similar to the following appears:
+
+    {{< output >}}
+● caddy.service - Caddy
+   Loaded: loaded (/usr/lib/systemd/system/caddy.service; disabled; vendor preset: disabled)
+   Active: active (running) since Thu 2021-09-02 18:25:29 IST; 4s ago
+     Docs: https://caddyserver.com/docs/
+ Main PID: 19314 (caddy)
+   CGroup: /system.slice/caddy.service
+           └─19314 /usr/bin/caddy run --environ --config /etc/caddy/Caddyfile...
+
+Sep 02 18:25:29 caddy caddy[19314]: SHELL=/sbin/nologin
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1270738..."}
+Sep 02 18:25:29 caddy systemd[1]: Started Caddy.
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1316314...]}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1317837...0}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1324193..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1324632..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1325648..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326034..."}
+Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326299..."}
+Hint: Some lines were ellipsized, use -l to show in full.
+    {{</ output >}}
+
+1.  Type your domain into a browser window on your local machine and you should see the test page. If everything is configured correctly, you should see a green lock symbol in the URL bar, indicating that your connection is secure.

--- a/docs/guides/web-servers/caddy/install-and-configure-caddy-on-centos-7/index.md
+++ b/docs/guides/web-servers/caddy/install-and-configure-caddy-on-centos-7/index.md
@@ -122,4 +122,6 @@ Sep 02 18:25:29 caddy caddy[19314]: {"level":"info","ts":1630587329.1326299..."}
 Hint: Some lines were ellipsized, use -l to show in full.
     {{</ output >}}
 
+To check the latest logs without truncation use `sudo journalctl -u caddy --no-pager | less +G`.
+
 1.  Type your domain into a browser window on your local machine and you should see the test page. If everything is configured correctly, you should see a green lock symbol in the URL bar, indicating that your connection is secure.


### PR DESCRIPTION
Updated the following caddy guides:
- https://www.linode.com/docs/guides/how-to-install-and-configure-caddy-on-ubuntu-18-04/
- https://www.linode.com/docs/guides/how-to-install-and-configure-caddy-on-debian-10/
- https://www.linode.com/docs/guides/how-to-install-and-configure-caddy-on-centos-8/
- https://www.linode.com/docs/guides/compile-caddy-from-source/
- https://www.linode.com/docs/guides/install-and-configure-caddy-on-centos-7/

Fixes: https://github.com/linode/docs/issues/4572