### PR TITLE
Hide three guides from Explore Docs menu:

### DIFF
--- a/docs/guides/find-this-guide-on-github/index.md
+++ b/docs/guides/find-this-guide-on-github/index.md
@@ -8,11 +8,14 @@ keywords: []
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/web-servers/nginx/perl-fastcgi/ubuntu-9-10-karmic/','/websites/apache/apache-2-web-server-on-ubuntu-9-04-jaunty/','/databases/postgresql/fedora-14/','/web-servers/apache/apache-2-web-server-on-ubuntu-9-04-jaunty/','/websites/nginx/nginx-and-phpfastcgi-on-ubuntu-9-10-karmic/','/email/postfix/postfix-dovecot-and-system-user-accounts-on-debian-6-squeeze/','/web-servers/nginx/php-fastcgi/ubuntu-9-10-karmic/','/websites/puppet/manage-and-automate-systems-configuration-with-puppet/','/web-servers/nginx/installation/ubuntu-9-10-karmic/','/server-monitoring/munin/ubuntu-12-04-precise-pangolin/','/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-10-maverick/','/email/postfix/postfix-dovecot-and-system-user-accounts-on-ubuntu-10-04-lucid/','/email/postfix/dovecot-system-users-ubuntu-10-04-lucid/','/email/postfix/dovecot-system-users-debian-6-squeeze/','/databases/mysql/standalone-mysql-server/','/uptime/monitoring/monitoring-server-with-munin-on-ubuntu-12-04-precise-pangolin/','/application-stacks/puppet/automation/','/websites/nginx/nginx-and-perlfastcgi-on-ubuntu-9-10-karmic/','/web-servers/nginx/nginx-and-phpfastcgi-on-ubuntu-9-10-karmic/','/email/postfix/dovecot-system-users-ubuntu-10-10-maverick/','/uptime/monitoring/deploy-munin-to-monitor-servers-on-ubuntu-12-04/','/web-servers/apache/installation/ubuntu-9-04-jaunty/']
 published: 2017-11-14
-modified: 2017-11-14
+modified: 2021-09-07
 modified_by:
   name: Linode
 title: Deprecated Guide
 show_on_rss_feed: false
+_build:
+  list: false
+noindex: true
 ---
 
 ## Looks like you're trying to find a deprecated guide.

--- a/docs/guides/linode-writers-formatting-guide/index.md
+++ b/docs/guides/linode-writers-formatting-guide/index.md
@@ -15,6 +15,8 @@ show_on_rss_feed: false
 external_resources:
  - '[GitHub Beginners Guide](/docs/github-guide)'
  - '[Red Hat Writing Style Guide](http://stylepedia.net/)'
+_build:
+  list: false
 ---
 
 ![Linode Writer's Formatting Guide](linode-writers-formatting-guide.png "Linode Writer's Formatting Guide")

--- a/docs/guides/search/index.md
+++ b/docs/guides/search/index.md
@@ -13,6 +13,8 @@ modified_by:
   name: Steven Jacobs
 title: "Search Linode Docs"
 show_on_rss_feed: false
+_build:
+  list: false
 ---
 
 <!--


### PR DESCRIPTION
These guides were appearing in Explore Docs menu, but don’t need to:

- /docs/guides/find-this-guide-on-github/
- /docs/guides/linode-writers-formatting-guide/
- /docs/guides/search/

![guides in explore docs menu that should be hidden](https://user-images.githubusercontent.com/255491/132405918-0fe0666c-5dd8-40f3-9742-4e4cac41a20c.png)

Note that these menu items do not appear when loading the docs home page, but they do on other pages (like https://www.linode.com/docs/guides/). They also appear after a delay, after the other items in the menu show up.