### PR TITLE
Demonstrating that deprecated guides can show up in /docs/whatsnew/

### DIFF
--- a/docs/guides/databases/mysql/use-mysql-relational-databases-on-debian-5-lenny/index.md
+++ b/docs/guides/databases/mysql/use-mysql-relational-databases-on-debian-5-lenny/index.md
@@ -21,6 +21,8 @@ relations:
 tags: ["debian","database","mysql"]
 ---
 
+test update, do not merge
+
 MySQL is a popular database management system, used as the data storage provider for thousands of web and server applications. This guide will help beginners get started with MySQL on a Debian Lenny Linode. For purposes of this tutorial, we'll assume you've followed the steps outlined in our [getting started guide](/docs/getting-started/), that your system is up to date, and that you've logged into your Linode as root via SSH.
 
 ## Installing MySQL


### PR DESCRIPTION
Do not merge, going to use this as an example for a docs theme issue. This PR should be closed when this theme issue is resolved: https://github.com/linode/linode-docs-theme/issues/170