### PR TITLE
Updated VLAN guides with correct button text

### DIFF
--- a/docs/guides/platform/vlan/getting-started-with-vlans/index.md
+++ b/docs/guides/platform/vlan/getting-started-with-vlans/index.md
@@ -107,7 +107,7 @@ By default, the public IP address (and, if added, the private IP address) of the
 
     See the [Assigning an IPAM Address](#assigning-an-ipam-address) section on this page for more information about IPAM and examples of valid IPAM addresses.
 
-1. Click on the **Edit Configuration** button towards the bottom of this form to save the changes.
+1. Click on the **Save Changes** button towards the bottom of this form to save the changes.
 
 1. Once the configuration profile has been updated, select the **Boot** or **Reboot** button next to the edited configuration profile on the following page. This will reboot using the edited configuration profile and apply the new VLAN configuration to the Linode.
 

--- a/docs/products/networking/vlans/get-started/index.md
+++ b/docs/products/networking/vlans/get-started/index.md
@@ -54,6 +54,6 @@ Adding a VLAN to an existing Linode is done by editing the Linode's existing Con
 
 1. If using [Network Helper](https://www.linode.com/docs/guides/network-helper/) to manage the Linode's internal network configuration (the default for most new Linodes), enter an *IPAM Address*. Doing so will allow the newly created Linode to automatically communicate with other Linodes attached to the same VLAN. The IPAM address should be unique to avoid conflicts in the case other machines share the same address. An example of a valid IPAM address is `10.0.0.1/24`.
 
-1. If editing an existing configuration, click on the **Edit Configuration** button to save the changes and attach the VLAN. If creating a new configuration, change any other settings as needed and click **Add Configuration** to create the new configuration profile.
+1. If editing an existing configuration, click on the **Save Changes** button to save the changes and attach the VLAN. If creating a new configuration, change any other settings as needed and click **Add Configuration** to create the new configuration profile.
 
 1. Once saved, the list of configuration profiles will be updated. Select the **Boot** button next to the desired configuration profile. This will reboot using the specified configuration and will attach the VLAN to the Linode.

--- a/docs/products/networking/vlans/guides/detach-a-linode-from-your-vlan/index.md
+++ b/docs/products/networking/vlans/guides/detach-a-linode-from-your-vlan/index.md
@@ -20,7 +20,7 @@ If the Linode no longer requires access a VLAN's private network, the VLAN can b
 
 1. Locate the network interface corresponding to the VLAN you wish to remove. From that interface's drop down menu, select *None* to detach the VLAN from this Linode. If no other network interface is set to *Public Interface*, that option may also be selected to provide public internet access to this Linode.
 
-1. Click on the **Edit Configuration** button to confirm the changes to the configuration profile.
+1. Click on the **Save Changes** button to confirm the changes to the configuration profile.
 
 1. [Reboot the Linode](/docs/products/tools/cloud-manager/guides/cloud-reboot-linode/) to save your changes and completely remove the VLAN configuration. Linodes that have had their configuration profiles updated but have not been rebooted will still be configured to use the VLAN. A reboot is required for any change to take place.
 


### PR DESCRIPTION
A Cloud Manager release changed the button text on the Edit Configuration panel from **Edit Configuration** to **Save Changes**. This PR adds minor updates to three VLAN guides to correct that button text.