### PR TITLE
[Fixed] Install Python 3 on Ubuntu 20.04

### DIFF
--- a/docs/guides/development/python/how-to-install-python-on-ubuntu-20-04/index.md
+++ b/docs/guides/development/python/how-to-install-python-on-ubuntu-20-04/index.md
@@ -30,7 +30,7 @@ As of January 1, 2020, the official version of Python is Python 3. Python 2 is n
 
 ## Before You Begin
 
-1.  This guide assumes that you have access to a server or workstation running CentOS 8. To provision a Linode running CentOS 8, follow our [Getting Started](/docs/guides/getting-started/) guide.
+1.  This guide assumes that you have access to a server or workstation running Ubuntu 20.04 LTS. To provision a Linode running Ubuntu 20.04 LTS, follow our [Getting Started](/docs/guides/getting-started/) guide.
 
 1.  This guide uses `sudo` wherever possible. Complete the sections of our [Securing Your Server](/docs/guides/securing-your-server/) to create a standard user account, harden SSH access, and remove unnecessary network services.
 


### PR DESCRIPTION
Changed "CentOS 8" to "Ubuntu 20.04" in Python 3 Ubuntu 20.04 guide