### PR TITLE
Updating doc language to match updated Cloud Manager language

### DIFF
--- a/docs/products/networking/dns-manager/get-started/index.md
+++ b/docs/products/networking/dns-manager/get-started/index.md
@@ -19,12 +19,12 @@ If you don't know what DNS records to add to your new domain, the DNS Manager ca
 Creating a domain also creates its corresponding domain zone.
 {{</ note >}}
 
-1.  From the **Domains** section, click on **Add a Domain**. The **Add a New Domain** panel appears, and this panel displays a form for your domain's information.
+1.  From the **Domains** section, click on **Create Domain**. The **Create Domain** panel appears, and this panel displays a form for your domain's information.
 
-1. If you want to add a *slave zone* instead of a master zone, click the **Slave** radio button.
+1. If you want to add a *secondary zone* instead of a primary zone, click the **Secondary** radio button.
 
    {{< note >}}
-In order for Linode's DNS servers to function as slaves, your DNS master server must notify and allow AXFR requests from the following IP addresses:
+In order for Linode's DNS servers to function as secondaries, your DNS primary server must notify and allow AXFR requests from the following IP addresses:
 
     104.237.137.10
     65.19.178.10


### PR DESCRIPTION
Cleaned up a few references to old terminology (master/slave to primary/secondary) and changed the name of the button, Add a Domain > Create Domain