### PR TITLE
[Update] Self-Hosting the bitwarden_rs Password Manager

### DIFF
--- a/docs/guides/security/authentication/self-hosted-password-management-with-bitwarden-rs/index.md
+++ b/docs/guides/security/authentication/self-hosted-password-management-with-bitwarden-rs/index.md
@@ -19,7 +19,7 @@ contributor:
 aliases: ["security/authentication/self-hosted-password-management-with-bitwarden-rs/", "security/authentication/how-to-self-host-the-bitwarden-rs-password-manager/"]
 ---
 
-The [Vaultwarden](https://github.com/dani-garcia/vaultwarden) project (formerly known as bitwarden_rs) provides a lightweight, single-process, API-compatible service alternative to [Bitwarden](https://bitwarden.com/)  . [Vaultwarden](https://bitwarden.com/)is an open source password management application that can be self-hosted and run on your infrastructure. By running the vaultwarden service, you can use Bitwarden browser extensions and mobile applications backed by your server.
+The [Vaultwarden](https://github.com/dani-garcia/vaultwarden) project (formerly known as bitwarden_rs) provides a lightweight, single-process, API-compatible service alternative to [Bitwarden](https://bitwarden.com/). [Vaultwarden](https://bitwarden.com/) is an open source password management application that can be self-hosted and run on your infrastructure. By running the vaultwarden service, you can use Bitwarden browser extensions and mobile applications backed by your server.
 
 {{< note >}}
 By self-hosting your password manager, you are assuming responsibility for the security and resiliency of sensitive information stored within Vaultwarden. Before storing important information and credentials within the application, ensure that you are confident with the security of the server. Also, take the necessary backup measures mentioned in this tutorial.
@@ -115,7 +115,7 @@ This section outlines how to download the Vaultwarden Docker image, setup volume
 
 External clients communicate with Caddy, which manages reverse proxying websocket traffic. Caddy also provisions and renews TLS certificates through Let's Encrypt automatically. The caddy images come in many flavors, each designed for a specific use case.
 
-caddy:<version>
+caddy:&lt;version&gt;
 
 This is the de facto image. If you are unsure about your needs, you probably want to use this one. It is designed to be used both as a throw away container. To mount source code and start the container to start the app. Also, as the base to build other images using this.
 


### PR DESCRIPTION
- Updated the instruction to use vaultwarden
- Updated the commands to use Caddy Server as reverse proxy
- Validated the steps in the guide
- Fixes https://github.com/linode/docs/issues/4573