### PR TITLE
doc: Adjusting The Copy Disk Command

### DIFF
--- a/docs/products/storage/block-storage/guides/boot-from-a-volume/index.md
+++ b/docs/products/storage/block-storage/guides/boot-from-a-volume/index.md
@@ -32,9 +32,9 @@ Create a Block Storage Volume and attach it to the desired target Compute Instan
 
 1.  Run `fdisk -l` to confirm the Compute Instance's primary disk and Block Storage Volume are available as `dev/sda` and `dev/sdc`, respectively.
 
-1.  Run the following `pv` command to copy the contents of the primary disk to the Block Storage Volume. Respectively, the options `-pte` output a progress meter, the elapsed time, and the estimated time remaining.
+1.  Run the following `dd` command to copy the contents of the primary disk to the Block Storage Volume. Respectively, the option `status` output progress.
 
-        pv -pte < /dev/sda > /dev/sdc
+        dd if=/dev/sda of=/dev/sdc bs=74K conv=noerror,sync status=progress
 
 ## Set the Block Storage Volume as the Primary Disk and Reboot
 


### PR DESCRIPTION
Hey there!

Happy 🌮  Tuesday!

I really enjoy'd leveraging this guide, it was a breeze to walk through.

I did notice however that after I had run the disk redirect:
```
        pv -pte < /dev/sda > /dev/sdc
```
that the command finished successfully for me.
After powering down and rebooting having the block storage device as my /dev/sda via the Linode's configuration - yet I  was receiving a GRUB bootloader error of:
```
 error: variable 'prefix' isn't set
 ```
 
I pivoted, reverting the boot config, leveraged just doing "dd" aka "disk destroy" back in LISH, to copy over the contents of the virtual disk to a block storage device, powered down, modified root_device to be /dev/sda but that pointing to the block_storage device, and then was able to see a successful (tad 'slower' [as expected ;P ]) boot from the Linode as it uses the block_storage volume as it's main volume.

I'd dig being able to get more eyes 👀  on this though, I wouldn't want to encourage a merge of this doc in if it isn't tested by others by a cross comparison of the redirect vs "dd".
_hence, why I'm just making this a draft pr_ 

All these docs/guides are stellar! 
Super open to iterate or make any adjustments to it!