### PR TITLE
Theme updates

### DIFF
--- a/_vendor/github.com/linode/linode-docs-theme/assets/js/main/navigation/explorer.js
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/js/main/navigation/explorer.js
@@ -56,7 +56,7 @@ export function newSearchExplorerController(searchConfig) {
 			indexName: searchConfig.sections_merged.index,
 			filters: filters,
 			facetFilters: facetFilters.concat(facetFilters, sectionFilter),
-			params: `query=${encodeURIComponent(query.q)}&hitsPerPage=${maxLeafNodes}`
+			params: `query=${encodeURIComponent(query.lndq)}&hitsPerPage=${maxLeafNodes}`
 		};
 	};
 

--- a/_vendor/github.com/linode/linode-docs-theme/assets/js/main/navigation/nav.js
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/js/main/navigation/nav.js
@@ -31,7 +31,10 @@ const onNavSearchResults = function(self, val, oldVal) {
 		let newSearch = !isTopResultsPage();
 		if (newSearch) {
 			let queryString = queryHandler.queryToQueryString(self.$store.search.query);
-			self.$store.nav.pushState('/docs/topresults/?' + queryString);
+			if (queryString) {
+				queryString += "?"
+			}
+			self.$store.nav.pushState('/docs/topresults/' + queryString);
 		}
 	}
 };
@@ -76,7 +79,9 @@ export function newNavController(weglot_api_key) {
 				this.$store.nav.searchResults.open = true;
 			}
 			this.$store.search.query = queryHandler.queryFromLocation();
-			this.$watch('$store.search.query.q', (val) => {
+			this.$watch('$store.search.query.lndq', (val, oldVal) => {
+				this.$store.search.query.lndqCleared = oldVal && !val;
+
 				// Navigate back to page 0 when the user changes the text input.
 				if (this.$store.search.query.p) {
 					this.$store.search.query.p = 0;

--- a/_vendor/github.com/linode/linode-docs-theme/assets/js/main/search/query.ts
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/js/main/search/query.ts
@@ -1,3 +1,4 @@
+import { isTopResultsPage } from '.';
 import { normalizeSpace } from '../helpers/index';
 
 export interface Query {
@@ -5,8 +6,8 @@ export interface Query {
 	// Starts at 0.
 	p: number;
 
-	// q holds the free text query usually fetched from the search input box.
-	q: string;
+	// lndq holds the free text query usually fetched from the search input box.
+	lndq: string;
 
 	// facet filters.
 	filters: Map<string, string[]>;
@@ -24,22 +25,23 @@ export interface Query {
 	isFiltered(): boolean;
 }
 
+// Only used to validate query parameters.
+const filterAttributes = [ 'docType', 'category', 'tags' ];
+
 const setQueryValues = function(q: Query, key: string, values: string[]) {
 	// Legacy values.
 	if (key === 'sections' || key === 'section.lvl0') {
 		key = 'docType';
 	}
-
-	switch (key) {
-		default:
-			q.filters.set(key, values);
+	if (filterAttributes.includes(key)) {
+		q.filters.set(key, values);
 	}
 };
 
 export const newQuery = function(): Query {
 	return {
 		p: 0,
-		q: '',
+		lndq: '',
 		filters: new Map<string, string[]>(),
 
 		addFilter(key: string, value: string) {
@@ -70,13 +72,24 @@ export const newQuery = function(): Query {
 		},
 
 		isFiltered() {
-			return this.q || this.hasFilter();
+			return this.lndq || this.hasFilter();
 		}
 	};
 };
 
 export class QueryHandler {
 	constructor() {}
+
+	isQueryParam(k: string): boolean {
+		switch (k) {
+			case 'p':
+				return true;
+			case 'lndq':
+				return true;
+			default:
+				return filterAttributes.includes(k);
+		}
+	}
 
 	queryFromLocation(): Query {
 		if (!window.location.search) {
@@ -95,8 +108,14 @@ export class QueryHandler {
 						q.p = 0;
 					}
 					break;
+				case 'lndq':
+					q.lndq = normalizeSpace(v);
+					break;
 				case 'q':
-					q.q = normalizeSpace(v);
+					if (isTopResultsPage()) {
+						// legacy
+						q.lndq = normalizeSpace(v);
+					}
 					break;
 				default:
 					setQueryValues(q, k, v.split(','));
@@ -105,17 +124,55 @@ export class QueryHandler {
 		return q;
 	}
 
+	queryAndLocationToQueryString(q: Query): string {
+		let search = '';
+		let currentURL = new URL(window.location.toString());
+
+		// Preserve non-search-related query params.
+		currentURL.searchParams.forEach((v, k) => {
+			if (!this.isQueryParam(k)) {
+				search = addTrailingAnd(search);
+				search += `${k}=${v}`;
+			}
+		});
+
+		let queryString = this.queryToQueryString(q);
+
+		if (!queryString) {
+			return search;
+		}
+
+
+		if (search) {
+			queryString += '&' + search;
+		}
+
+		return queryString;
+	}
+
 	queryToQueryString(q: Query): string {
-		var queryString = `q=${encodeURIComponent(q.q)}`;
+		let queryString = '';
+		if (q.lndq) {
+			queryString = `lndq=${encodeURIComponent(q.lndq)}`;
+		}
 
 		if (q.p) {
-			queryString = queryString.concat(`&p=${q.p}`);
+			queryString = addTrailingAnd(queryString);
+			queryString = queryString.concat(`p=${q.p}`);
 		}
 
 		q.filters.forEach((values, key) => {
-			queryString = queryString.concat(`&${key}=${encodeURIComponent(values.join(',').toLowerCase())}`);
+			queryString = addTrailingAnd(queryString);
+			queryString = queryString.concat(`${key}=${encodeURIComponent(values.join(',').toLowerCase())}`);
 		});
 
 		return queryString;
 	}
+}
+
+function addTrailingAnd(s: string) {
+	if (s && !s.endsWith('&')) {
+		s += '&';
+	}
+	return s;
 }

--- a/_vendor/github.com/linode/linode-docs-theme/assets/js/main/search/search-store.js
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/js/main/search/search-store.js
@@ -42,11 +42,13 @@ export function newSearchStore(searchConfig, Alpine) {
 		// The blank (needed for the explorer and section metadata) and the main search result.
 		results: results,
 
-		updateLocationWithQuery(state = null) {
+		updateLocationWithQuery() {
 			let href = window.location.pathname + window.location.hash;
-			if (this.query.isFiltered() || this.query.p > 0) {
-				href += '?' + queryHandler.queryToQueryString(this.query);
+			let search = queryHandler.queryAndLocationToQueryString(this.query);
+			if (search) {
+				href += '?' + search;
 			}
+
 			// See https://github.com/hotwired/turbo/issues/163#issuecomment-933691878
 			history.replaceState({ turbo: {} }, null, href);
 		},
@@ -230,7 +232,7 @@ export function newSearchStore(searchConfig, Alpine) {
 
 		if (query) {
 			hitsPerPage = sectionConfig.hits_per_page || searchConfig.hits_per_page || 20;
-			q = encodeURIComponent(query.q);
+			q = encodeURIComponent(query.lndq);
 			facetFilters = query.toFacetFilters();
 			attributesToHighlight = [ 'title', 'excerpt', ...filteringFacetNames ];
 			page = query.p;

--- a/_vendor/github.com/linode/linode-docs-theme/assets/js/main/sections/sections/list.js
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/js/main/sections/sections/list.js
@@ -29,7 +29,7 @@ export function newSectionsController(searchConfig) {
 			create: (query) => {
 				let filters = `section.lvl${self.data.lvl}:'${self.key}'`;
 
-				encodeURIComponent(query.q);
+				encodeURIComponent(query.lndq);
 
 				let request = {
 					page: 0,
@@ -37,7 +37,7 @@ export function newSectionsController(searchConfig) {
 					facets: [ 'section.*' ],
 					filters: filters,
 					facetFilters: query.toFacetFilters(),
-					params: `query=${query.q}`
+					params: `query=${query.lndq}`
 				};
 
 				return {

--- a/_vendor/github.com/linode/linode-docs-theme/assets/jsconfig.json
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/jsconfig.json
@@ -1,5 +1,6 @@
 {
  "compilerOptions": {
+ "lib": ["es2015", "dom"],
   "baseUrl": ".",
   "paths": {
    "*": [

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/input.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/input.html
@@ -4,7 +4,7 @@
       <use href="#icon--search"></use>
     </svg>
   </span>
-  <input type="text" autocomplete="off" spellcheck="false" aria-label="search" x-model="$store.search.query.q"
+  <input type="text" autocomplete="off" spellcheck="false" aria-label="search" x-model="$store.search.query.lndq"
     placeholder="Search Linode" class="search-input w-full pl-3 focus:outline-none focus:ring-transparent focus:border-red-300 border-none" data-testid="search-input"
     @focusin="setFocus(true);" @focusout="setFocus(false);" 
   >

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/list.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/list.html
@@ -4,7 +4,7 @@
     <h2 class="text-3xl">
       No Results
     </h2>
-    <p x-text="`There are no results for &quot;${$store.search.query.q}&quot;. Check your spelling or try clearing any filters.`"></p>
+    <p x-text="`There are no results for &quot;${$store.search.query.lndq}&quot;. Check your spelling or try clearing any filters.`"></p>
   </div>
 </template>
 

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/panel.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/panel.html
@@ -11,10 +11,10 @@
           <h1 class="block font-bold leading-tight tracking-tight text-4xl text-titlecolor w-full mb-4">
             Search Results
           </h1>
-          <p class="text-2xl" x-show="$store.search.query.q">
-            <span x-show="$store.search.query.q" x-text="$store.search.results.main.result.stats.totalNbHits" data-testid="search-nb-hits"></span>&nbspresults matching&nbsp<span class="font-bold" x-text="`${'“' + $store.search.query.q + '”'}`"></span>
+          <p class="text-2xl" x-show="$store.search.query.lndq">
+            <span x-show="$store.search.query.lndq" x-text="$store.search.results.main.result.stats.totalNbHits" data-testid="search-nb-hits"></span>&nbspresults matching&nbsp<span class="font-bold" x-text="`${'“' + $store.search.query.lndq + '”'}`"></span>
           </p>
-          <p class="text-2xl" x-show="!$store.search.query.q" >
+          <p class="text-2xl" x-show="!$store.search.query.lndq" >
             <span x-text="$store.search.results.main.result.stats.totalNbHits"></span>&nbspresults</span>
           </p>
         </div>

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/linode/linode-docs-theme v0.0.0-20211208181104-3e92e5157da7
+# github.com/linode/linode-docs-theme v0.0.0-20211222180920-20905e1f0476
 # github.com/linode/linode-website-partials v0.0.0-20211108192240-e7da4cf1e95c
 # github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.401.201
 # github.com/gohugoio/hugo-mod-jslibs/turbo/v7 v7.0.0-20211006154215-97cb50aae023

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/bep/hugo-jslibs/turbolinks v0.1.2 // indirect
 	github.com/bep/linodedocs v0.0.0-20210212231859-10aa00d2e096
 	github.com/linode/linode-api-docs/v4 v4.111.0 // indirect
-	github.com/linode/linode-docs-theme v0.0.0-20211208181104-3e92e5157da7 // indirect
+	github.com/linode/linode-docs-theme v0.0.0-20211222180920-20905e1f0476 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,8 @@ github.com/linode/linode-docs-theme v0.0.0-20211112170556-9506e31833d8 h1:ZEt+ip
 github.com/linode/linode-docs-theme v0.0.0-20211112170556-9506e31833d8/go.mod h1:yr8ub7SvYQ5AMV8vyndEkn3HXL/jCKF42R2E21ozDys=
 github.com/linode/linode-docs-theme v0.0.0-20211208181104-3e92e5157da7 h1:29qPjAPXhbrbQNmNOQiqH0DwuooLGCClbSSmjsccRks=
 github.com/linode/linode-docs-theme v0.0.0-20211208181104-3e92e5157da7/go.mod h1:yr8ub7SvYQ5AMV8vyndEkn3HXL/jCKF42R2E21ozDys=
+github.com/linode/linode-docs-theme v0.0.0-20211222180920-20905e1f0476 h1:UFqa/h5GAYYyRAb5S3jK2OAWnu/Ued1E2j9Am/hJWaA=
+github.com/linode/linode-docs-theme v0.0.0-20211222180920-20905e1f0476/go.mod h1:yr8ub7SvYQ5AMV8vyndEkn3HXL/jCKF42R2E21ozDys=
 github.com/linode/linode-website-partials v0.0.0-20200907163220-d3856e759e21/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/linode/linode-website-partials v0.0.0-20200921210751-887bbecdd5dd/go.mod h1:e68x+kyP45JvsnatClDG16z9uAQ/Fg8gBDwpI6KMNI0=
 github.com/linode/linode-website-partials v0.0.0-20201001182036-fe8965a45b3c h1:j2j0WYHnoSEsGg7790A+gNQqKYIXGTi/i1FHTwt9zBM=


### PR DESCRIPTION
- For search queries (e.g. the /docs/topresults/ page), use 'lndq'
  instead of 'q' for the search term in the URL. This helps avoid
  name collisions for marketing links that also use the 'q' param.