### PR TITLE
[Update] Install and Configure the Caddy Web Server on Ubuntu 18.04

### DIFF
--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
@@ -46,12 +46,14 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04
         curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
         curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
 
-1.  Install Caddy:
-        sudo apt update
-        sudo apt install caddy
+2.  Install Caddy:
 
-1. To verify the installation of caddy type:
+         sudo apt update -y && sudo apt install caddy
+
+3. To verify the installation of caddy type:
+       
        caddy version
+       
     An output similar to the following appears:
 
         v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=

--- a/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04/index.md
@@ -8,6 +8,7 @@ keywords: ['web server','caddy','https','Caddyfile']
 tags: ["web server","ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2020-03-05
+modified: 2022-02-04
 modified_by:
   name: Linode
 title: "How to Install and Configure the Caddy Web Server on Ubuntu 18.04"
@@ -36,43 +37,46 @@ aliases: ['/web-servers/caddy/how-to-install-and-configure-caddy-on-ubuntu-18-04
 
 1.  Update your system:
 
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt update && sudo apt upgrade
 
 ## Install Caddy
 
-1.  Download `caddy`:
+1.  Download Caddy:
 
         sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
         curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
         curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
 
-2.  Install Caddy:
+1.  Install Caddy:
 
-         sudo apt update -y && sudo apt install caddy
+        sudo apt update && sudo apt install caddy
 
-3. To verify the installation of caddy type:
-       
-       caddy version
-       
-    An output similar to the following appears:
+1.  To verify the installation of Caddy, run the following command:
 
-        v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
+        caddy version
 
+    This should output a message similar to the text below:
+
+    {{<output>}}
+v2.4.3 h1:Y1FaV2N4WO3rBqxSYA8UZsZTQdN+PwcoOcAiZTM8C0I=
+{{</output>}}
 
 ## Allow HTTP and HTTPS Connections
 
 Caddy serves websites using HTTP and HTTPS protocols, so you need to allow access to the ports 80, and 443.
 
-        sudo ufw allow proto tcp from any to any port 80,443
+    sudo ufw allow proto tcp from any to any port 80,443
 
 An output similar to the following appears:
+
 {{< output >}}
 Rule added
 Rule added (v6)
 {{< /output >}}
 
-1. Verify the changes:
-       sudo ufw status
+1.  Verify the changes:
+
+        sudo ufw status
 
 An output similar to the following appears:
 {{< output >}}
@@ -96,7 +100,6 @@ OpenSSH (v6)               ALLOW       Anywhere (v6)
 
         echo '<!doctype html><head><title>Caddy Test Page</title></head><body><h1>Hello, World!</h1></body></html>' > /var/www/html/example.com/index.html
 
-
 ## Configure the Caddyfile
 
 Add your hostname and web root to the Caddy configuration. Use an editor of your choice and replace `:80` with your domain name. Set the root directory of the site to `/var/www/html/example.com` Replace `example.com` with your site's domain name:
@@ -114,7 +117,7 @@ example.com {
 
         sudo systemctl start caddy
 
-1. Verify that the service is active:
+1.  Verify that the service is active:
 
         sudo systemctl status caddy
 


### PR DESCRIPTION
the formatting was off, but also I was running as it without success. After some testing, I was able to get Caddy to install with the command I added.