### PR TITLE
[Fix] Updated aliases for Plesk and Plex Marketplace App guides

### DIFF
--- a/docs/guides/platform/marketplace/plesk-marketplace-app/index.md
+++ b/docs/guides/platform/marketplace/plesk-marketplace-app/index.md
@@ -18,7 +18,7 @@ external_resources:
  - '[Plesk Support](https://support.plesk.com/hc/en-us)'
  - '[Plesk Documentation](https://docs.plesk.com/en-US/obsidian/)'
  - '[Plesk Help Center](https://support.plesk.com/hc/en-us/categories/201413825-Technical-Questions)'
-aliases: ['/platform/marketplace/deploying-plesk-with-marketplace-apps/', '/platform/marketplace/deploying-plesk-with-marketplace-apps/','/guides/deploying-plesk-with-marketplace-apps/','/platform/one-click/deploy-plex-with-one-click-apps/','/guides/deploy-plex-with-one-click-apps/']
+aliases: ['/platform/marketplace/deploying-plesk-with-marketplace-apps/', '/platform/marketplace/deploying-plesk-with-marketplace-apps/','/guides/deploying-plesk-with-marketplace-apps/','/platform/one-click/deploy-plesk-with-one-click-apps/','/guides/deploy-plesk-with-one-click-apps/']
 ---
 
 [Plesk](https://www.plesk.com) is a leading WordPress and website management platform and control panel. Plesk lets you build and manage multiple websites from a single dashboard to configure web services, email, and other applications. Plesk features hundreds of extensions, plus a complete WordPress toolkit. Use the Plesk Marketplace App to manage websites hosted on your Linode.

--- a/docs/guides/platform/marketplace/plex-marketplace-app/index.md
+++ b/docs/guides/platform/marketplace/plex-marketplace-app/index.md
@@ -15,7 +15,7 @@ modified_by:
 title: "Deploying Plex Media Server through the Linode Marketplace"
 external_resources:
 - '[Plex Support Articles](https://support.plex.tv/articles/)'
-aliases: ['/platform/marketplace/deploy-plex-with-marketplace-apps/', '/platform/marketplace/deploy-plex-with-one-click-apps/', '/guides/deploy-plex-with-one-click-apps/', '/guides/deploy-plex-with-marketplace-apps/']
+aliases: ['/platform/marketplace/deploy-plex-with-marketplace-apps/', '/platform/marketplace/deploy-plex-with-one-click-apps/', '/guides/deploy-plex-with-one-click-apps/', '/guides/deploy-plex-with-marketplace-apps/','/platform/one-click/deploy-plex-with-one-click-apps/','/platform/one-click/deploy-plex-with-one-click-apps/']
 ---
 
 [Plex](https://www.plex.tv/) is a feature-rich streaming platform that allows you to organize and stream your own digital video and audio to your devices. This guide shows you how to deploy the [**Plex Media Server**](https://hub.docker.com/r/plexinc/pms-docker/) using Linode's Plex Marketplace App, upload media to your Plex Server, and connect to it from a Plex client application. Your Plex Media Server could benefit from large amounts of disk space, so consider using our [Block Storage](/docs/platform/block-storage/how-to-use-block-storage-with-your-linode) service with this app.


### PR DESCRIPTION
The following link in the Cloud Manager for the Plex Marketplace App guide is redirecting to the *Plesk* Marketplace App guide:

```
https://linode.com/docs/platform/one-click/deploy-plex-with-one-click-apps/
->
https://www.linode.com/docs/guides/plesk-marketplace-app/
```
This PR fixes the aliases for both guides.