### PR TITLE
[New] Uninstall Deprecated Linode CLI using API v3

### DIFF
--- a/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
+++ b/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
@@ -48,7 +48,7 @@ If using Mac OSx, the Linode CLI was most likely installed using the `brew` pack
 
 ### Other Distros
 
-If the Linode Cli was [installed manually](/docs/guides/using-the-linode-cli-api-v3/#manual-installation-for-linux-all-distros), then all configurations files and modules can also be removed manually. The primary relevant files can ususally be uninstalled using the following commands:
+If the Linode Cli was [installed manually](/docs/guides/using-the-linode-cli-api-v3/#manual-installation-for-linux-all-distros), then all configurations files and modules can also be removed manually. The primary relevant files can usually be uninstalled using the following commands:
 
         unlink /usr/local/bin/linode
         unlink /usr/local/bin/linode-account

--- a/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
+++ b/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
@@ -18,7 +18,7 @@ tags: ["linode platform"]
 aliases: ['/platform/api/upgrade-to-linode-api-v4/']
 ---
 
-Following the release of the [Linode API v4](https://www.linode.com/docs/api/), both the Linode API v3 and [earlier versions of the CLI](/docs/guides/using-the-linode-cli-api-v3/) using that API version have been deprecated. While earlier versions remained functional for some time, they have officially been deprecated and can not be leveraged to use the full extent of the Linode Platform.
+Following the release of the [Linode API v4](/docs/api/), both the Linode API v3 and [earlier versions of the CLI](/docs/guides/using-the-linode-cli-api-v3/) using that API version have been deprecated. While earlier versions remained functional for some time, they have officially been deprecated and can not be leveraged to use the full extent of the Linode Platform.
 
 To ensure that all users continue to use a currently supported version of the API in their production pipelines, it is recommended that users upgrade to the newest version of the Linode CLI as soon as they are able. This guide walks you through uninstalling the old version of the CLI. After the old version has been removed, you can follow the instructions within the [Linode CLI Overview](/docs/guides/linode-cli/#install-the-cli) guide to install the latest version.
 

--- a/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
+++ b/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
@@ -1,0 +1,92 @@
+---
+slug: uninstall-linode-api-cli-v3
+author:
+  name: Linode
+  email: docs@linode.com
+description: 'The new Linode API includes a number of additional features and changes from previous API versions. This guide is intended to help existing users uninstall the previous version of the CLI in preparation of upgrading to the new version of the CLI using APIv4.'
+keywords: ["api","linode api", "cli"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+modified: 2021-01-19
+modified_by:
+  name: Linode
+title: 'Uninstalling the Deprecated Linode CLI using API v3'
+published: 2021-01-19
+external_resources:
+ - '[Linode API Documentation](https://developers.linode.com)'
+ - '[Deprecated CLI Github](https://github.com/linode/cli)'
+tags: ["linode platform"]
+aliases: ['/platform/api/upgrade-to-linode-api-v4/']
+---
+
+Following the release of [Version 4 of the Linode API](https://www.linode.com/docs/api/) both Version 3 of the Linode API and an [earlier version of the CLI](/docs/guides/using-the-linode-cli-api-v3/) have been deprecated. While the earlier version of the Linode CLI that relies on v3 of the Linode API has up to this point still been available to users, it has officially been deprecated and can not be leveraged to use the full extent of the Linode Platform.
+
+In order to best ensure that all users are able to continue to use a working and current configuration of the Linode API in their production pipelines, it is recommended that users upgrade to the newest version of the Linode CLI as soon as they are able.
+
+## In this Guide
+
+This guide serves to empower you to remove the deprecated version of the Linode CLI and install the newest version.
+
+## Uninstall the Linode CLI
+
+### Debian and Ubuntu
+
+In most cases, the Linode CLI was most likely installed using the `apt` package manager. If the package was installed via this method, the deprecated version of the Linode CLI can be similarly removed via the `apt` package manager using the following command:
+
+        sudo apt remove linode-cli
+
+### Fedora
+
+If using Fedora, the Linode CLI was most likely installed using the `dnf` package manager. If the package was installed via this method, the deprecated version of the Linode CLI can be similarly removed via the `dnf` package manager using the following command:
+
+        dnf remove linode-cli
+
+### Mac OSx
+
+If using Mac OSx, the Linode CLI was most likely installed using the `brew` package manager. If the package was installed via this method, the deprecated version of the Linode CLI can be similarly removed via the `brew` package manager using the following command:
+
+        brew uninstall linode-cli
+
+### Other Distros
+
+If the linode Cli was [installed manually](/docs/guides/using-the-linode-cli-api-v3/#manual-installation-for-linux-all-distros), then all configurations files and modules can also be removed manually. The primary relevant files can ususally be uninstalled using the following commands:
+
+        unlink /usr/local/bin/linode
+        unlink /usr/local/bin/linode-account
+        unlink /usr/local/bin/linode-domain
+        unlink /usr/local/bin/linode-linode
+        unlink /usr/local/bin/linode-nodebalancer
+        unlink /usr/local/bin/linode-stackscript
+        unlink /usr/local/share/man/man1/linode-account.1
+        unlink /usr/local/share/man/man1/linode-domain.1
+        unlink /usr/local/share/man/man1/linode-linode.1
+        unlink /usr/local/share/man/man1/linode-nodebalancer.1
+        unlink /usr/local/share/man/man1/linode-stackscript.1
+        unlink /usr/local/share/man/man1/linode.1
+        unlink /usr/local/share/perl5/Linode/CLI.pm
+        unlink /usr/local/share/perl5/Linode/CLI/Object.pm
+        unlink /usr/local/share/perl5/Linode/CLI/Object/Account.pm
+        unlink /usr/local/share/perl5/Linode/CLI/Object/Domain.pm
+        unlink /usr/local/share/perl5/Linode/CLI/Object/Linode.pm
+        unlink /usr/local/share/perl5/Linode/CLI/Object/Nodebalancer.pm
+        unlink /usr/local/share/perl5/Linode/CLI/Object/Stackscript.pm
+        unlink /usr/local/share/perl5/Linode/CLI/SystemInfo.pm
+        unlink /usr/local/share/perl5/Linode/CLI/Util.pm
+        unlink /usr/local/lib64/perl5/auto/Linode/CLI/.packlist
+
+{{< note >}}
+In some cases, the path of some configuration files installed manually may be along a slightly different than the ones outlined in this guide. An audit may be necessary to for complete removal of the Linode CLI in cases where a manual installation was performed.
+{{< /note >}}
+
+Additionally, if they are no longer needed, users may remove the following perl modules using their tooling of choice:
+
+        JSON
+        LWP:UserAgent
+        Mozilla::CA
+        Try::Tiny
+        WebService::Linode
+
+
+## Next Steps
+
+Once the deprecated version of the Linode CLI has been safely removed, the newest version of the Linode CLI should be installed using Python3.
+More information on this process can be found on our [Overview of the Linode CLI Guide](/docs/guides/linode-cli/).

--- a/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
+++ b/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
@@ -48,7 +48,7 @@ If using Mac OSx, the Linode CLI was most likely installed using the `brew` pack
 
 ### Other Distros
 
-If the linode Cli was [installed manually](/docs/guides/using-the-linode-cli-api-v3/#manual-installation-for-linux-all-distros), then all configurations files and modules can also be removed manually. The primary relevant files can ususally be uninstalled using the following commands:
+If the Linode Cli was [installed manually](/docs/guides/using-the-linode-cli-api-v3/#manual-installation-for-linux-all-distros), then all configurations files and modules can also be removed manually. The primary relevant files can ususally be uninstalled using the following commands:
 
         unlink /usr/local/bin/linode
         unlink /usr/local/bin/linode-account

--- a/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
+++ b/docs/guides/platform/api/uninstall-linode-api-cli-v3/index.md
@@ -6,11 +6,11 @@ author:
 description: 'The new Linode API includes a number of additional features and changes from previous API versions. This guide is intended to help existing users uninstall the previous version of the CLI in preparation of upgrading to the new version of the CLI using APIv4.'
 keywords: ["api","linode api", "cli"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2021-01-19
+modified: 2022-02-25
 modified_by:
   name: Linode
 title: 'Uninstalling the Deprecated Linode CLI using API v3'
-published: 2021-01-19
+published: 2022-02-25
 external_resources:
  - '[Linode API Documentation](https://developers.linode.com)'
  - '[Deprecated CLI Github](https://github.com/linode/cli)'
@@ -18,75 +18,68 @@ tags: ["linode platform"]
 aliases: ['/platform/api/upgrade-to-linode-api-v4/']
 ---
 
-Following the release of [Version 4 of the Linode API](https://www.linode.com/docs/api/) both Version 3 of the Linode API and an [earlier version of the CLI](/docs/guides/using-the-linode-cli-api-v3/) have been deprecated. While the earlier version of the Linode CLI that relies on v3 of the Linode API has up to this point still been available to users, it has officially been deprecated and can not be leveraged to use the full extent of the Linode Platform.
+Following the release of the [Linode API v4](https://www.linode.com/docs/api/), both the Linode API v3 and [earlier versions of the CLI](/docs/guides/using-the-linode-cli-api-v3/) using that API version have been deprecated. While earlier versions remained functional for some time, they have officially been deprecated and can not be leveraged to use the full extent of the Linode Platform.
 
-In order to best ensure that all users are able to continue to use a working and current configuration of the Linode API in their production pipelines, it is recommended that users upgrade to the newest version of the Linode CLI as soon as they are able.
-
-## In this Guide
-
-This guide serves to empower you to remove the deprecated version of the Linode CLI and install the newest version.
+To ensure that all users continue to use a currently supported version of the API in their production pipelines, it is recommended that users upgrade to the newest version of the Linode CLI as soon as they are able. This guide walks you through uninstalling the old version of the CLI. After the old version has been removed, you can follow the instructions within the [Linode CLI Overview](/docs/guides/linode-cli/#install-the-cli) guide to install the latest version.
 
 ## Uninstall the Linode CLI
 
-### Debian and Ubuntu
+### Uninstall Through a Package Manager
 
-In most cases, the Linode CLI was most likely installed using the `apt` package manager. If the package was installed via this method, the deprecated version of the Linode CLI can be similarly removed via the `apt` package manager using the following command:
+If the Linode CLI was installed through a package manager, it can be uninstalled through the same package manager. Follow the instructions below for your operating system.
+
+-   **Ubuntu and Debian:** Use the following command to uninstall the Linode CLI through the [APT package manager](/docs/guides/apt-package-manager/):
 
         sudo apt remove linode-cli
 
-### Fedora
+-   **Fedora:** Use the following command to uninstall the Linode CLI through the [DNF package manager](/docs/guides/dnf-package-manager/):
 
-If using Fedora, the Linode CLI was most likely installed using the `dnf` package manager. If the package was installed via this method, the deprecated version of the Linode CLI can be similarly removed via the `dnf` package manager using the following command:
+        sudo dnf remove linode-cli
 
-        dnf remove linode-cli
-
-### Mac OSx
-
-If using Mac OSx, the Linode CLI was most likely installed using the `brew` package manager. If the package was installed via this method, the deprecated version of the Linode CLI can be similarly removed via the `brew` package manager using the following command:
+-   **MacOS:** Use the following command to uninstall the Linode CLI through brew:
 
         brew uninstall linode-cli
 
-### Other Distros
+### Uninstall Manually
 
-If the Linode Cli was [installed manually](/docs/guides/using-the-linode-cli-api-v3/#manual-installation-for-linux-all-distros), then all configurations files and modules can also be removed manually. The primary relevant files can usually be uninstalled using the following commands:
+If the Linode CLI was [installed manually](/docs/guides/using-the-linode-cli-api-v3/#manual-installation-for-linux-all-distros), then all configurations files and modules can also be removed manually. The primary relevant files can usually be uninstalled using the following commands:
 
-        unlink /usr/local/bin/linode
-        unlink /usr/local/bin/linode-account
-        unlink /usr/local/bin/linode-domain
-        unlink /usr/local/bin/linode-linode
-        unlink /usr/local/bin/linode-nodebalancer
-        unlink /usr/local/bin/linode-stackscript
-        unlink /usr/local/share/man/man1/linode-account.1
-        unlink /usr/local/share/man/man1/linode-domain.1
-        unlink /usr/local/share/man/man1/linode-linode.1
-        unlink /usr/local/share/man/man1/linode-nodebalancer.1
-        unlink /usr/local/share/man/man1/linode-stackscript.1
-        unlink /usr/local/share/man/man1/linode.1
-        unlink /usr/local/share/perl5/Linode/CLI.pm
-        unlink /usr/local/share/perl5/Linode/CLI/Object.pm
-        unlink /usr/local/share/perl5/Linode/CLI/Object/Account.pm
-        unlink /usr/local/share/perl5/Linode/CLI/Object/Domain.pm
-        unlink /usr/local/share/perl5/Linode/CLI/Object/Linode.pm
-        unlink /usr/local/share/perl5/Linode/CLI/Object/Nodebalancer.pm
-        unlink /usr/local/share/perl5/Linode/CLI/Object/Stackscript.pm
-        unlink /usr/local/share/perl5/Linode/CLI/SystemInfo.pm
-        unlink /usr/local/share/perl5/Linode/CLI/Util.pm
-        unlink /usr/local/lib64/perl5/auto/Linode/CLI/.packlist
+    unlink /usr/local/bin/linode
+    unlink /usr/local/bin/linode-account
+    unlink /usr/local/bin/linode-domain
+    unlink /usr/local/bin/linode-linode
+    unlink /usr/local/bin/linode-nodebalancer
+    unlink /usr/local/bin/linode-stackscript
+    unlink /usr/local/share/man/man1/linode-account.1
+    unlink /usr/local/share/man/man1/linode-domain.1
+    unlink /usr/local/share/man/man1/linode-linode.1
+    unlink /usr/local/share/man/man1/linode-nodebalancer.1
+    unlink /usr/local/share/man/man1/linode-stackscript.1
+    unlink /usr/local/share/man/man1/linode.1
+    unlink /usr/local/share/perl5/Linode/CLI.pm
+    unlink /usr/local/share/perl5/Linode/CLI/Object.pm
+    unlink /usr/local/share/perl5/Linode/CLI/Object/Account.pm
+    unlink /usr/local/share/perl5/Linode/CLI/Object/Domain.pm
+    unlink /usr/local/share/perl5/Linode/CLI/Object/Linode.pm
+    unlink /usr/local/share/perl5/Linode/CLI/Object/Nodebalancer.pm
+    unlink /usr/local/share/perl5/Linode/CLI/Object/Stackscript.pm
+    unlink /usr/local/share/perl5/Linode/CLI/SystemInfo.pm
+    unlink /usr/local/share/perl5/Linode/CLI/Util.pm
+    unlink /usr/local/lib64/perl5/auto/Linode/CLI/.packlist
 
 {{< note >}}
-In some cases, the path of some configuration files installed manually may be along a slightly different than the ones outlined in this guide. An audit may be necessary to for complete removal of the Linode CLI in cases where a manual installation was performed.
+In some cases, the path of some configuration files installed manually may be slightly different than the ones outlined in this guide. An audit may be necessary to for complete removal of the Linode CLI in cases where a manual installation was performed.
 {{< /note >}}
 
-Additionally, if they are no longer needed, users may remove the following perl modules using their tooling of choice:
+Additionally, if they are no longer needed, users may remove the following Perl modules using their tooling of choice:
 
-        JSON
-        LWP:UserAgent
-        Mozilla::CA
-        Try::Tiny
-        WebService::Linode
+    JSON
+    LWP:UserAgent
+    Mozilla::CA
+    Try::Tiny
+    WebService::Linode
 
+## Install the Latest Linode CLI Version
 
-## Next Steps
-
-Once the deprecated version of the Linode CLI has been safely removed, the newest version of the Linode CLI should be installed using Python3.
+Once the deprecated version of the Linode CLI has been safely removed, the newest version of the Linode CLI should be installed using Python 3.
 More information on this process can be found on our [Overview of the Linode CLI Guide](/docs/guides/linode-cli/).


### PR DESCRIPTION
- Guides users towards upgrading to the newest version of the Linode CLI if they have not yet already upgraded 