### PR TITLE
[Update] How to Install and Configure FastCGI and PHP-FPM

### DIFF
--- a/docs/guides/web-servers/apache/how-to-install-and-configure-fastcgi-and-php-fpm-on-centos-8/index.md
+++ b/docs/guides/web-servers/apache/how-to-install-and-configure-fastcgi-and-php-fpm-on-centos-8/index.md
@@ -79,7 +79,7 @@ listen = /var/run/php-fpm/www.sock
 listen = /var/run/php-fpm/www.sock
     {{< /file >}}
 
-1.  If the `listen = 127.0.0.1:9000` is not already uncommented, do so now:
+1.  If the `listen = 127.0.0.1` is not already uncommented, do so now:
 
     {{< file "/etc/php-fpm.d/www.conf" >}}
 listen.allowed_clients = 127.0.0.1
@@ -195,7 +195,7 @@ listen = /var/run/php-fpm/example.com.sock
          AddType  application/x-httpd-php         .php
          AddHandler application/x-httpd-php .php
          Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
-         ProxyPassMatch " ^/(.*\.php(/.*)?)$" "unix:listen = /var/run/php-fpm/example.com.sock|fcgi://localhost/var/www/html/example.com/public_html/"
+         ProxyPassMatch " ^/(.*\.php(/.*)?)$" "unix:/run/php-fpm/example.com.sock|fcgi://localhost/var/www/html/example.com/public_html/"
      </IfModule>
 </VirtualHost>
 {{< /file >}}

--- a/docs/guides/web-servers/apache/how-to-install-and-configure-fastcgi-and-php-fpm-on-debian-10/index.md
+++ b/docs/guides/web-servers/apache/how-to-install-and-configure-fastcgi-and-php-fpm-on-debian-10/index.md
@@ -86,10 +86,10 @@ listen = /run/php/php7.3-fpm.sock
 listen = /var/run/php/php7.3-fpm.sock
     {{< /file >}}
 
-1.  If the `listen = 127.0.0.1:9000` is not already uncommented, do so now.
+1.  If the `listen = 127.0.0.1` is not already uncommented, do so now.
 
     {{< file "/etc/php/7.3/fpm/pool.d/www.conf" >}}
-listen = 127.0.0.1:9000
+listen = 127.0.0.1
     {{< /file >}}
 
 1.  Restart the `php-fpm` daemon for these changes to take effect.
@@ -197,7 +197,7 @@ listen = /var/run/php/php7.3-fpm_example.com.sock
          AddType  application/x-httpd-php         .php
          AddHandler application/x-httpd-php .php
          Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
-         ProxyPassMatch " ^/(.*\.php(/.*)?)$" "unix:listen = /var/run/php/php7.3-fpm_example.com.sock|fcgi://localhost/var/www/html/example.com/public_html/"
+         ProxyPassMatch " ^/(.*\.php(/.*)?)$" "unix:/run/php/php7.3-fpm_example.com.sock|fcgi://localhost/var/www/html/example.com/public_html/"
      </IfModule>
 </VirtualHost>
 {{< /file >}}
@@ -206,6 +206,10 @@ listen = /var/run/php/php7.3-fpm_example.com.sock
 1.  Check the configuration file for errors.
 
         sudo apache2ctl configtest
+
+{{< note >}}
+ If Apache continues to use apache handler, then Pass use `apache: a2enconf php7.3-fpm` and `a2dismod php7.3`.
+{{< /note >}}
 
 1.  If there were no errors, restart Apache.
 

--- a/docs/guides/web-servers/apache/how-to-install-and-configure-fastcgi-and-php-fpm-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/apache/how-to-install-and-configure-fastcgi-and-php-fpm-on-ubuntu-18-04/index.md
@@ -86,10 +86,10 @@ listen = /run/php/php7.2-fpm.sock
 listen = /var/run/php/php7.2-fpm.sock
     {{< /file >}}
 
-1.  If the `listen = 127.0.0.1:9000` is not already uncommented, do so now.
+1.  If the `listen = 127.0.0.1` is not already uncommented, do so now.
 
     {{< file "/etc/php/7.2/fpm/pool.d/www.conf" >}}
-listen = 127.0.0.1:9000
+listen = 127.0.0.1
     {{< /file >}}
 
 1.  Restart the `php-fpm` daemon for these changes to take effect.
@@ -198,7 +198,7 @@ listen = /var/run/php/php7.2-fpm_example.com.sock
          AddType  application/x-httpd-php         .php
          AddHandler application/x-httpd-php .php
          Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
-         ProxyPassMatch " ^/(.*\.php(/.*)?)$" "unix:listen = /var/run/php/php7.2-fpm_example.com.sock|fcgi://localhost/var/www/html/example.com/public_html/"
+         ProxyPassMatch " ^/(.*\.php(/.*)?)$" "unix:/run/php/php7.2-fpm_example.com.sock|fcgi://localhost/var/www/html/example.com/public_html/"
      </IfModule>
 </VirtualHost>
 {{< /file >}}


### PR DESCRIPTION
 - updated the steps for php-fpm on centos 8, debian 10, and ubuntu 18.04
- fixes [ 3380](https://github.com/linode/docs/issues/3380)
- fixes [ 3353](https://github.com/linode/docs/issues/3353)
- fixes [ 3543](https://github.com/linode/docs/issues/3543)