### PR TITLE
Deprecated Debian 7, Ubuntu 14.04, and CentOS 6 guides

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -28,6 +28,7 @@ Akaunting
 aker
 alef
 alertmanager
+alex
 alexey
 alfano
 alives

--- a/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-debian-7/index.md
+++ b/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-debian-7/index.md
@@ -20,6 +20,7 @@ relations:
         keywords:
             - distribution: Debian 7
 aliases: ['/applications/cloud-storage/owncloud-debian-7/','/guides/owncloud-debian-7/']
+deprecated: true
 ---
 
 ownCloud is an open source platform that allows easy access to files from multiple locations and platforms. It's compatible with most major operating systems and mobile devices. With ownCloud you can store files on your Linode and then access them wherever you go.

--- a/docs/guides/databases/mongodb/creating-a-mongodb-replication-set-on-debian-7-wheezy/index.md
+++ b/docs/guides/databases/mongodb/creating-a-mongodb-replication-set-on-debian-7-wheezy/index.md
@@ -24,6 +24,7 @@ relations:
         keywords:
             - distribution: Debian 7
 tags: ["debian","database","nosql"]
+deprecated: true
 ---
 
 MongoDB is an open-source, non-SQL database engine. MongoDB is scalable and an alternative to the standard relational database management system (RDBMS). A replication set is used for redundancy and to provide access to your data in the event of a node failure.

--- a/docs/guides/databases/mysql/how-to-install-mysql-on-centos-6/index.md
+++ b/docs/guides/databases/mysql/how-to-install-mysql-on-centos-6/index.md
@@ -1,5 +1,6 @@
 ---
 slug: how-to-install-mysql-on-centos-6
+deprecated: true
 author:
   name: Alex Fornuto
   email: afornuto@linode.com

--- a/docs/guides/databases/mysql/how-to-install-mysql-on-debian-7/index.md
+++ b/docs/guides/databases/mysql/how-to-install-mysql-on-debian-7/index.md
@@ -24,6 +24,7 @@ relations:
         keywords:
             - distribution: Debian 7
 tags: ["debian","database","mysql"]
+deprecated: true
 ---
 
 ![How to Install MySQL on Debian 7](How_to_Install_MySQL_on_Debian_7_smg.jpg)

--- a/docs/guides/databases/mysql/install-mysql-on-ubuntu-14-04/index.md
+++ b/docs/guides/databases/mysql/install-mysql-on-ubuntu-14-04/index.md
@@ -1,5 +1,6 @@
 ---
 slug: install-mysql-on-ubuntu-14-04
+deprecated: true
 author:
   name: Alex Fornuto
   email: afornuto@linode.com

--- a/docs/guides/databases/mysql/install-mysql-phpmyadmin-debian-7/index.md
+++ b/docs/guides/databases/mysql/install-mysql-phpmyadmin-debian-7/index.md
@@ -21,6 +21,7 @@ relations:
         keywords:
             - distribution: Debian 7
 tags: ["debian","database","mysql","php"]
+deprecated: true
 ---
 
 ![Install MySQL with phpMyAdmin on Debian](How_to_Install_MySQL_with_phpMyAdmin_on_Debian_7_smg.jpg)

--- a/docs/guides/databases/mysql/install-mysql-phpmyadmin-ubuntu-14-04/index.md
+++ b/docs/guides/databases/mysql/install-mysql-phpmyadmin-ubuntu-14-04/index.md
@@ -1,5 +1,6 @@
 ---
 slug: install-mysql-phpmyadmin-ubuntu-14-04
+deprecated: true
 author:
     name: Linode
     email: docs@linode.com

--- a/docs/guides/databases/mysql/managing-mysql-with-phpmyadmin-on-centos-6-4/index.md
+++ b/docs/guides/databases/mysql/managing-mysql-with-phpmyadmin-on-centos-6-4/index.md
@@ -1,5 +1,6 @@
 ---
 slug: managing-mysql-with-phpmyadmin-on-centos-6-4
+deprecated: true
 author:
     name: Linode
     email: docs@linode.com

--- a/docs/guides/development/clojure/clojure-deployment-with-immutant-and-wildfly-on-ubuntu-14-04/index.md
+++ b/docs/guides/development/clojure/clojure-deployment-with-immutant-and-wildfly-on-ubuntu-14-04/index.md
@@ -1,5 +1,6 @@
 ---
 slug: clojure-deployment-with-immutant-and-wildfly-on-ubuntu-14-04
+deprecated: true
 author:
     name: Linode Community
     email: docs@linode.com
@@ -24,11 +25,6 @@ external_resources:
   - '[Script to install JBoss Wildfly 10.x as service in Linux](https://gist.github.com/sukharevd/6087988)'
 audiences: ["beginner"]
 concentrations: ["Web Applications"]
-relations:
-    platform:
-        key:  clojure-immutant-wildfly
-        keywords:
-            - distribution: Ubuntu 14.04
 ---
 
 Clojure is a general-purpose programming language with an emphasis on functional programming. It is a dialect of the Lisp programming language running on the Java Virtual Machine (JVM). While Clojure allows you to write elegant and concise code, its ability to make use of the existing JVM infrastructure, such as libraries, tools and application servers, makes it also a very practical choice.

--- a/docs/guides/development/frameworks/yesod/yesod-nginx-mysql-on-debian-7-wheezy/index.md
+++ b/docs/guides/development/frameworks/yesod/yesod-nginx-mysql-on-debian-7-wheezy/index.md
@@ -26,6 +26,7 @@ relations:
         key: yesod-nginx-mysql
         keywords:
             - distribution: Debian 7
+deprecated: true
 ---
 
 

--- a/docs/guides/development/ror/ruby-on-rails-with-nginx-on-debian-7-wheezy/index.md
+++ b/docs/guides/development/ror/ruby-on-rails-with-nginx-on-debian-7-wheezy/index.md
@@ -27,6 +27,7 @@ relations:
         key: ruby-on-rails-nginx
         keywords:
             - distribution: Debian 7
+deprecated: true
 ---
 
 Ruby on Rails is a popular rapid development web framework that allows web designers and developers to implement fully featured dynamic web applications using the Ruby programming language. This guide describes the required process for deploying Ruby on Rails with Passenger and the Nginx web server on Debian 7 (Wheezy). For the purposes of this tutorial, it is assumed that you've followed the steps outlined in our [getting started guide](/docs/getting-started/), that your system is up to date, and that you've logged into your Linode as root via SSH.

--- a/docs/guides/email/citadel/email-with-citadel-on-ubuntu-14-04/index.md
+++ b/docs/guides/email/citadel/email-with-citadel-on-ubuntu-14-04/index.md
@@ -1,6 +1,6 @@
 ---
 slug: email-with-citadel-on-ubuntu-14-04
-deprecated: false
+deprecated: true
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-6/index.md
+++ b/docs/guides/email/postfix/email-with-postfix-dovecot-and-mysql-on-centos-6/index.md
@@ -1,5 +1,6 @@
 ---
 slug: email-with-postfix-dovecot-and-mysql-on-centos-6
+deprecated: true
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/email/zimbra/zimbra-on-ubuntu-14-04/index.md
+++ b/docs/guides/email/zimbra/zimbra-on-ubuntu-14-04/index.md
@@ -1,5 +1,6 @@
 ---
 slug: zimbra-on-ubuntu-14-04
+deprecated: true
 author:
     name: Linode Community
     email: docs@linode.com

--- a/docs/guides/security/upgrading/how-to-upgrade-to-debian-7-wheezy/index.md
+++ b/docs/guides/security/upgrading/how-to-upgrade-to-debian-7-wheezy/index.md
@@ -1,6 +1,6 @@
 ---
 slug: how-to-upgrade-to-debian-7-wheezy
-deprecated: yes
+deprecated: true
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/tools-reference/file-transfer/transfer-files-with-cyberduck-on-mac-os-x/index.md
+++ b/docs/guides/tools-reference/file-transfer/transfer-files-with-cyberduck-on-mac-os-x/index.md
@@ -3,7 +3,7 @@ slug: transfer-files-with-cyberduck-on-mac-os-x
 author:
   name: Linode
   email: docs@linode.com
-deprecated: yes
+deprecated: true
 description: 'Securely copying files to and from your Linode with Cyberduck, a free and open source file transfer client for Mac OS X systems.'
 keywords: ["cyberduck", "ftp", "mac os scp", "sftp", "mac os sftp program", "mac os ftp"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/guides/tools-reference/file-transfer/transfer-files-with-filezilla-on-ubuntu-9-10-desktop/index.md
+++ b/docs/guides/tools-reference/file-transfer/transfer-files-with-filezilla-on-ubuntu-9-10-desktop/index.md
@@ -3,7 +3,7 @@ slug: transfer-files-with-filezilla-on-ubuntu-9-10-desktop
 author:
   name: Linode
   email: docs@linode.com
-deprecated: yes
+deprecated: true
 description: 'Securely copying files to and from your Linode with Filezilla, a free and open source file transfer client for Linux desktop systems.'
 keywords: ["filezilla", "ftp", "linux scp", "sftp", "linux sftp program", "linux ftp"]
 tags: ["ubuntu"]

--- a/docs/guides/tools-reference/file-transfer/transfer-files-with-winscp-on-windows/index.md
+++ b/docs/guides/tools-reference/file-transfer/transfer-files-with-winscp-on-windows/index.md
@@ -3,7 +3,7 @@ slug: transfer-files-with-winscp-on-windows
 author:
   name: Linode
   email: docs@linode.com
-deprecated: yes
+deprecated: true
 description: 'Securely copying files to and from your Linode with WinSCP, a free and open source file transfer client for Microsoft Windows systems.'
 keywords: ["winscp", "ftp", "windows scp", "sftp", "windows sftp program"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/guides/web-servers/apache/apache-and-modwsgi-on-ubuntu-14-04-precise-pangolin/index.md
+++ b/docs/guides/web-servers/apache/apache-and-modwsgi-on-ubuntu-14-04-precise-pangolin/index.md
@@ -1,5 +1,6 @@
 ---
 slug: apache-and-modwsgi-on-ubuntu-14-04-precise-pangolin
+deprecated: true
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/web-servers/apache/apache-web-server-on-centos-6/index.md
+++ b/docs/guides/web-servers/apache/apache-web-server-on-centos-6/index.md
@@ -1,5 +1,6 @@
 ---
 slug: apache-web-server-on-centos-6
+deprecated: true
 author:
   name: Alex Fornuto
   email: afornuto@linode.com

--- a/docs/guides/web-servers/apache/apache-web-server-on-ubuntu-14-04/index.md
+++ b/docs/guides/web-servers/apache/apache-web-server-on-ubuntu-14-04/index.md
@@ -1,5 +1,6 @@
 ---
 slug: apache-web-server-on-ubuntu-14-04
+deprecated: true
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/web-servers/apache/running-fastcgi-php-fpm-on-debian-7-with-apache/index.md
+++ b/docs/guides/web-servers/apache/running-fastcgi-php-fpm-on-debian-7-with-apache/index.md
@@ -24,6 +24,7 @@ relations:
         key: install-fastcgi-php-fpm
         keywords:
             - distribution: Debian 7
+deprecated: true
 ---
 
 ![Running mod_fastcgi and PHP-FPM on Debian 7 (Wheezy) with Apache](running-mod-fastcgi-and-php-fpm-debian-7-apache.png)

--- a/docs/guides/web-servers/lamp/lamp-on-centos-6/index.md
+++ b/docs/guides/web-servers/lamp/lamp-on-centos-6/index.md
@@ -1,5 +1,6 @@
 ---
 slug: lamp-on-centos-6
+deprecated: true
 author:
   name: Alex Fornuto
   email: afornuto@linode.com

--- a/docs/guides/web-servers/lamp/lamp-on-ubuntu-14-04/index.md
+++ b/docs/guides/web-servers/lamp/lamp-on-ubuntu-14-04/index.md
@@ -1,5 +1,6 @@
 ---
 slug: lamp-on-ubuntu-14-04
+deprecated: true
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/web-servers/lamp/lamp-server-on-debian-7-wheezy/index.md
+++ b/docs/guides/web-servers/lamp/lamp-server-on-debian-7-wheezy/index.md
@@ -23,6 +23,7 @@ relations:
         key: install-lamp-stack
         keywords:
             - distribution: Debian 7
+deprecated: true
 ---
 
 A LAMP (Linux, Apache, MySQL, PHP) stack is a common web stack used to prepare servers for hosting web content. This guide shows you how to install a LAMP stack on a Debian 7 (Wheezy) Linode.

--- a/docs/guides/web-servers/squid/squid-http-proxy-centos-6-4/index.md
+++ b/docs/guides/web-servers/squid/squid-http-proxy-centos-6-4/index.md
@@ -1,5 +1,6 @@
 ---
 slug: squid-http-proxy-centos-6-4
+deprecated: true
 author:
   name: Alex Fornuto
   email: afornuto@linode.com

--- a/docs/guides/websites/cms/wordpress/install-wordpress-using-wp-cli-on-ubuntu-14-04/index.md
+++ b/docs/guides/websites/cms/wordpress/install-wordpress-using-wp-cli-on-ubuntu-14-04/index.md
@@ -1,5 +1,6 @@
 ---
 slug: install-wordpress-using-wp-cli-on-ubuntu-14-04
+deprecated: true
 author:
     name: Linode Community
     email: docs@linode.com


### PR DESCRIPTION
Some guides that target the following distributions were not marked as deprecated. This PR fixes that.

- CentOS 6 (no longer available on Linode's platform)
- Debian 7 (no longer available on Linode's platform)
- Ubuntu 14.04 (no longer available on Linode's platform)