### PR TITLE
[Release Candidate] v1.120.1

### DIFF
--- a/docs/guides/platform/marketplace/filecloud-marketplace-app/index.md
+++ b/docs/guides/platform/marketplace/filecloud-marketplace-app/index.md
@@ -17,7 +17,13 @@ contributor:
 external_resources:
 - '[FileCloud Official](https://www.getfilecloud.com/supportdocs/display/cloud/Home)'
 aliases: ['/platform/marketplace/deploy-filecloud-with-marketplace-apps/', '/platform/one-click/deploy-filecloud-with-one-click-apps/', '/guides/deploy-filecloud-with-one-click-apps/','/guides/deploy-filecloud-with-marketplace-apps/']
+_build:
+  list: false
 ---
+
+{{<caution>}}
+The FileCloud App has been temporarily removed from the Linode Marketplace due recent breaking changes. Our developers are currently working on implementing a fix. If you wish to deploy FileCloud in the meantime, you can review FileCloud's own manual installation instructions. See [Installing FileCloud Server](https://www.filecloud.com/supportdocs/display/cloud/Installing+FileCloud+Server).
+{{</caution>}}
 
 FileCloud is a cloud-based file-sharing application, similar to tools like Dropbox, that allows users to remotely access, upload, and sync hosted files.
 


### PR DESCRIPTION
Removes the FileCloud Marketplace App guide from the site's index and adds a caution note to inform users that the app has been disabled due to breaking issues. 