### PR TITLE
[Update] How to Use Paramiko and Python to SSH into a Server

### DIFF
--- a/docs/guides/development/python/use-paramiko-python-to-ssh-server/index.md
+++ b/docs/guides/development/python/use-paramiko-python-to-ssh-server/index.md
@@ -66,7 +66,7 @@ password = "YOUR_PASSWORD"
 client = paramiko.client.SSHClient()
 client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 client.connect(host, username=username, password=password)
-stdin, _stdout,_stderr = client.exec_command("df")
+_stdin, _stdout,_stderr = client.exec_command("df")
 print(stdout.read().decode())
 client.close()
 {{< /file >}}


### PR DESCRIPTION
- updated the example 1 for python 3 based on the comment in feedback: "python 3 complained on example 1 that stdin is not defined, renamed it to _stdin and it worked"