### PR TITLE
[Update] Install WordPress on Ubuntu 20.04

### DIFF
--- a/docs/guides/websites/cms/wordpress/how-to-install-wordpress-ubuntu-2004/index.md
+++ b/docs/guides/websites/cms/wordpress/how-to-install-wordpress-ubuntu-2004/index.md
@@ -54,7 +54,7 @@ To satisfy these requirements, you can set up a LAMP (Linux, Apache, MySQL, and 
 
 1. Install and configure a LAMP or LEMP stack. For either stack, make sure that you are installing at least PHP version **7.4**. This is the default on Ubuntu 20.04. Additionally, make sure to replace all version numbers in the below guides with the number of the version you are installing.
 
-    - To create a LAMP stack, follow the [How to Install a LAMP Stack on Ubuntu 18.04](/docs/guides/how-to-install-a-lamp-stack-on-ubuntu-18-04/) guide.
+    - To create a LAMP stack, follow the [How to Install a LAMP Stack on Ubuntu 20.04](/docs/guides/how-to-install-a-lamp-stack-on-ubuntu-20-04/) guide.
 
     - To create a LEMP stack, follow the [How to Install the LEMP Stack on Ubuntu 18.04](/docs/guides/how-to-install-the-lemp-stack-on-ubuntu-18-04/) guide.
 


### PR DESCRIPTION
Updated based on a comment in the feedback for documents:

Need to reference https://www.linode.com/docs/guides/how-to-install-a-lamp-stack-on-ubuntu-20-04/ instead of what is currently referenced which is https://www.linode.com/docs/guides/how-to-install-a-lamp-stack-on-ubuntu-18-04/
The newer lamp stack instructions have different steps for mysql which are needed to successfully deploy a database for 20 04