### PR TITLE
Dynamically wait for Hugo to start in docs404 job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,8 +104,29 @@ jobs:
       with:
         hugo-version: '0.83.1'
     - name: Start Hugo server
-      run: hugo server&
-    - name: Wait for server
-      run: sleep 20
+      run: |
+        # Start Hugo in background:
+        hugo server &
+
+        # Wait for server to start
+        # (or possibly fail to start):
+        while true
+        do
+            # Check if the server is responding on 1313,
+            # which means that the Hugo build finished.
+            if nc -z localhost 1313
+            then
+                exit 0
+            fi
+
+            # Check if the Hugo process is still running.
+            # If not, then the server failed to build.
+            if ! pgrep hugo > /dev/null
+            then
+                exit 1
+            fi
+
+            sleep 1
+        done
     - name: Run tests
       run: python ./ci/docs404.py


### PR DESCRIPTION
This PR introduces a loop into the docs404 GHA that waits for Hugo to finish building before running the 404 scraping script. This is useful because we previously waited a static amount of time after starting Hugo (20 seconds); however, Hugo sometimes needed longer than this set time, and the docs404 test would fail in this situation.

- The script sleeps 1 second on each interval
- On each interval, it checks if the server is responding on port 1313 and exits the loop if it gets a response. 
- If there is no server response, but the Hugo process isn't running anymore, then we can infer that Hugo failed to build because of some fatal error. The loop exits and we set exit code 1 for the GHA so that it doesn't proceed to the 404 scraping script. https://github.com/linode/docs/pull/5277 tests this scenario.
- The success or failure output from Hugo is printed to the GHA logs