### PR TITLE
[Update] Configuring IP Failover over BGP using FRR (Advanced)

### DIFF
--- a/docs/guides/networking/linode-network/ip-failover-bgp-frr/index.md
+++ b/docs/guides/networking/linode-network/ip-failover-bgp-frr/index.md
@@ -156,19 +156,28 @@ coalesce-time 1000
 bgp bestpath as-path multipath-relax
 neighbor RS peer-group
 neighbor RS remote-as external
+neighbor RS ebgp-multihop 10
 neighbor RS capability extended-nexthop
 neighbor 2600:3c0f:[DC_ID]:34::1 peer-group RS
 neighbor 2600:3c0f:[DC_ID]:34::2 peer-group RS
 neighbor 2600:3c0f:[DC_ID]:34::3 peer-group RS
 neighbor 2600:3c0f:[DC_ID]:34::4 peer-group RS
+
 address-family ipv4 unicast
   network [SHARED_IP]/32 route-map [ROLE]
   redistribute static
 exit-address-family
+
+address-family ipv6 unicast
+  network [SHARED_IPV6]/64 route-map [ROLE]
+  redistribute static
+exit-address-family
+
 route-map primary permit 10
 set community 65000:1
 route-map secondary permit 10
 set community 65000:2
+ipv6 nht resolve-via-default
 {{</ file >}}
 
 1.  Restart the FRR service:

--- a/docs/guides/networking/linode-network/ip-failover-bgp-frr/index.md
+++ b/docs/guides/networking/linode-network/ip-failover-bgp-frr/index.md
@@ -7,6 +7,7 @@ description: "Learn how to use Linode's IP Sharing feature to configure IP failo
 keywords: ['IP failover','elastic IP','frr','bgp']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-01-11
+modified: 2022-03-11
 modified_by:
   name: Linode
 title: "Configuring IP Failover over BGP using FRR (Advanced)"


### PR DESCRIPTION
Adds IPv6 sharing support to FRR guide.