### PR TITLE
[Update] Configuring Failover on a Compute Instance

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -33,6 +33,7 @@ alexa
 alexey
 alfano
 alives
+allifs
 allmasquerade
 allowlist
 allowlisting
@@ -234,6 +235,7 @@ characterwise
 chatbot
 chatbots
 chatrooms
+chcon
 cheatsheet
 checkmarx
 checksummed
@@ -391,6 +393,7 @@ dbdir
 dbfiles
 dbname
 dbserver
+dcid
 dcs
 deadman
 deallocation

--- a/docs/guides/networking/linode-network/ip-failover/index.md
+++ b/docs/guides/networking/linode-network/ip-failover/index.md
@@ -145,7 +145,7 @@ Next, we need to configure the failover software on *each* Compute Instance. For
 
 1.  Download and install the [lelastic](https://github.com/linode/lelastic) utility from GitHub by running the following commands:
 
-        curl -LO https://github.com/linode/lelastic/releases/download/v0.0.3/lelastic.gz
+        curl -LO https://github.com/linode/lelastic/releases/download/v0.0.4/lelastic.gz
         gunzip lelastic.gz
         chmod 755 lelastic
         sudo mv lelastic /usr/local/bin/


### PR DESCRIPTION
The lelastic utility will soon support CentOS/RHEL. The pre-release of this new version has been tested and this PR updates all relevant documentation.

**Update:** lelastic has been updated and version incremented to `v0.0.4`