### PR TITLE
updated the port numbers

### DIFF
--- a/docs/guides/security/authentication/how-to-self-host-the-vaultwarden-password-manager/index.md
+++ b/docs/guides/security/authentication/how-to-self-host-the-vaultwarden-password-manager/index.md
@@ -131,13 +131,13 @@ example.com {
   encode gzip
 
   # The negotiation endpoint is also proxied to Rocket
-  reverse_proxy /notifications/hub/negotiate 0.0.0.0:8080
+  reverse_proxy /notifications/hub/negotiate 0.0.0.0:80
 
   # Notifications redirected to the websockets server
   reverse_proxy /notifications/hub 0.0.0.0:3012
 
   # Send all other traffic to the regular Vaultwarden endpoint
-  reverse_proxy 0.0.0.0:8080
+  reverse_proxy 0.0.0.0:80
 }
 {{< /file >}}
 
@@ -153,7 +153,7 @@ The site name you choose in this file must match the desired URL that Vaultwarde
 
 1. Start another Docker container to run a persistent `caddy` daemon.
 
-        sudo docker run -d -p 8080:80 -p 443:443 --name caddy -v /etc/Caddyfile:/etc/caddy/Caddyfile -v /etc/caddy:/root/.local/share/caddy --restart on-failure caddy:2
+        sudo docker run -d -p 80:80 -p 443:443 --name caddy -v /etc/Caddyfile:/etc/caddy/Caddyfile -v /etc/caddy:/root/.local/share/caddy --restart on-failure caddy:2
 
 1. View the logs of the Caddy container in order to confirm that a Let's Encrypt certificate has been provisioned for the chosen domain.
 


### PR DESCRIPTION
Fixes: [5309](https://github.com/linode/docs/issues/5309)

Validated and tested the steps with the new port numbers and it works.

```
rajie@caddy:~$ sudo docker run -d -p 80:80 -p 443:443 --name caddy -v /etc/Caddyfile:/etc/caddy/Caddyfile -v /etc/caddy:/root/.local/share/caddy --restart on-failure caddy:2
ac4aaf5d08068fee9606b0ec36bb2986561b0b670ad971809631ed13cd7afa27
rajie@caddy:~$ sudo docker logs caddy
{"level":"info","ts":1649243173.3180423,"msg":"using provided configuration","config_file":"/etc/caddy/Caddyfile","config_adapter":"caddyfile"}
{"level":"warn","ts":1649243173.3193927,"msg":"input is not formatted with 'caddy fmt'","adapter":"caddyfile","file":"/etc/caddy/Caddyfile","line":2}
{"level":"info","ts":1649243173.3204315,"logger":"admin","msg":"admin endpoint started","address":"tcp/localhost:2019","enforce_origin":false,"origins":["localhost:2019","[::1]:2019","127.0.0.1:2019"]}
{"level":"info","ts":1649243173.3215308,"logger":"http","msg":"server is listening only on the HTTPS port but has no TLS connection policies; adding one to enable TLS","server_name":"srv0","https_port":443}
{"level":"info","ts":1649243173.3216436,"logger":"http","msg":"enabling automatic HTTP->HTTPS redirects","server_name":"srv0"}
{"level":"info","ts":1649243173.3216553,"logger":"tls.cache.maintenance","msg":"started background certificate maintenance","cache":"0xc000304d20"}```
