### PR TITLE
[Update] Getting Started With Cloud Firewall

### DIFF
--- a/docs/guides/platform/cloud-firewall/getting-started-with-cloud-firewall/index.md
+++ b/docs/guides/platform/cloud-firewall/getting-started-with-cloud-firewall/index.md
@@ -62,9 +62,21 @@ Upon initial creation of a Cloud Firewall, you are required to select Firewall r
 
 {{< content "delete-cloud-firewall-rules-shortguide" >}}
 
-## Limiting User Access to Cloud Firewalls
+## Update a Cloud Firewall's Status
 
-Currently, Cloud firewall user access controls cannot be set directly using the [Cloud Manager](/docs/guides/accounts-and-passwords/#users-and-permissions) and are instead set using [Personal Access Tokens with the Linode API](/docs/api/profile/#personal-access-tokens-list). Below is an example API request that will create an API token with this permission that can be adjusted and edited as needed:
+{{< content "cloud-firewall-status-shortguide" >}}
+
+## Delete a Cloud Firewall
+
+{{< content "delete-cloud-firewall-shortguide" >}}
+
+## Limits and Considerations
+
+{{< content "cloud-firewall-limits-shortguide" >}}
+
+### Limiting User Access to Cloud Firewalls with the Linode API
+
+Currently, Cloud firewall user access controls for API tokens cannot be set directly using the [Cloud Manager](https://www.linode.com/docs/guides/an-overview-of-the-linode-cloud-manager/#api-keys--api-tokens) and are instead set using [Personal Access Tokens with the Linode API](/docs/api/profile/#personal-access-tokens-list) itself. Below is an example API request that will create an API token with Cloud Firewall permissions that can be adjusted and edited as needed:
 
 
 {{< file >}}
@@ -81,15 +93,3 @@ https://api.linode.com/v4/profile/tokens
 In this example, the `scope` field defines an OAUTH scope of `read_write` for all Cloud Firewalls on the account, while `expiry` defines the expiration date of the Personal Access Token, and `label` is an identifier used for display purposes to identify the token.
 
 When completing this request an API token will be returned in the `Token` field to be used and distributed as needed. This token should be saved in a secure manner immediately as it will not be retrievable again. For more information on creating Personal Access Tokens to use with Cloud Firewall, see our API documentation for creating [Personal Access Tokens with the Linode API](/docs/api/profile/#personal-access-tokens-list).
-
-## Update a Cloud Firewall's Status
-
-{{< content "cloud-firewall-status-shortguide" >}}
-
-## Delete a Cloud Firewall
-
-{{< content "delete-cloud-firewall-shortguide" >}}
-
-## Limits and Considerations
-
-{{< content "cloud-firewall-limits-shortguide" >}}

--- a/docs/guides/platform/cloud-firewall/getting-started-with-cloud-firewall/index.md
+++ b/docs/guides/platform/cloud-firewall/getting-started-with-cloud-firewall/index.md
@@ -62,6 +62,26 @@ Upon initial creation of a Cloud Firewall, you are required to select Firewall r
 
 {{< content "delete-cloud-firewall-rules-shortguide" >}}
 
+## Limiting User Access to Cloud Firewalls
+
+Currently, Cloud firewall user access controls cannot be set directly using the [Cloud Manager](/docs/guides/accounts-and-passwords/#users-and-permissions) and are instead set using [Personal Access Tokens with the Linode API](/docs/api/profile/#personal-access-tokens-list). Below is an example API request that will create an API token with this permission that can be adjusted and edited as needed:
+
+
+{{< file >}}
+curl -H "Content-Type: application/json" \
+-H "Authorization: Bearer $TOKEN" \
+-X POST -d '{
+  "scopes": "firewall:read_write",
+  "expiry": "2022-8-01T00:00:01",
+  "label": "cloud-firewall-access"
+}' \
+https://api.linode.com/v4/profile/tokens
+{{< /file >}}
+
+In this example, the `scope` field defines an OAUTH scope of `read_write` for all Cloud Firewalls on the account, while `expiry` defines the expiration date of the Personal Access Token, and `label` is an identifier used for display purposes to identify the token.
+
+When completing this request an API token will be returned in the `Token` field to be used and distributed as needed. This token should be saved in a secure manner immediately as it will not be retrievable again. For more information on creating Personal Access Tokens to use with Cloud Firewall, see our API documentation for creating [Personal Access Tokens with the Linode API](/docs/api/profile/#personal-access-tokens-list).
+
 ## Update a Cloud Firewall's Status
 
 {{< content "cloud-firewall-status-shortguide" >}}

--- a/docs/guides/platform/manager/an-overview-of-the-linode-cloud-manager/index.md
+++ b/docs/guides/platform/manager/an-overview-of-the-linode-cloud-manager/index.md
@@ -143,6 +143,10 @@ The **My Profile** section of Cloud Manager provides access to various settings 
 
 {{< content "cloud-api-keys-shortguide" >}}
 
+{{< note >}}
+Currently, Cloud Firewall permissions can not be set for Personal Access Tokens using the Linode Cloud Manager and the Linode API should be used directly for this purpose. For more information, see our [API documentation](/docs/api/profile/#personal-access-tokens-list) and our guide on [Getting Started With Cloud Firewall](http://localhost:1313/docs/guides/getting-started-with-cloud-firewall/#limiting-user-access-to-cloud-firewalls-with-the-linode-api)
+{{< /note >}}
+
 ### OAuth Apps
 
 {{< content "cloud-oauth-apps-shortguide" >}}


### PR DESCRIPTION
Addresses the current inability to create Personal Access tokens with limited cloud firewall permissions in the Linode Manager, and guides users towards completing this with the API