### PR TITLE
[Update] Cloud Firewall Limits

### DIFF
--- a/docs/products/networking/cloud-firewall/_shortguides/cloud-firewall-limits-shortguide/index.md
+++ b/docs/products/networking/cloud-firewall/_shortguides/cloud-firewall-limits-shortguide/index.md
@@ -5,8 +5,9 @@ headless: true
 show_on_rss_feed: false
 ---
 
-- Cloud Firewalls are **compatible with all Linode Compute Instances**. They are not currently supported on other Linode services, such as NodeBalancers or Object Storage.
-- A Cloud Firewall can be attached to multiple Linode Compute Instances but a Linode Compute Instance can only be attached to one *active* (enabled) Cloud Firewall at a time.
+- Cloud Firewalls are **compatible with all Linode Compute Instances**. They are not currently directly supported on other Linode services, such as NodeBalancers or Object Storage.
+- A Cloud Firewall can be attached to multiple Compute Instances but a Compute Instance can only be attached to one *active* (enabled) Cloud Firewall at a time.
+- Cloud Firewall rules are applied to traffic over the public and private network but are not applied to traffic over a private [VLAN](/docs/products/networking/vlans/).
 - A maximum of **25 rules** can be added to each Cloud Firewall (both Inbound and Outbound rules combined).
 - A maximum of **255 IP addresses (and ranges)** can be added to each Cloud Firewall rule.
 - All **IP addresses** and **IP Ranges** must be formatted correctly, or changes will be unable to be saved.


### PR DESCRIPTION
Added information about the type of traffic to which Cloud Firewall rules are applied. Specifically, they are applied to traffic over both the public and private networks, but not over VLANs.