### PR TITLE
[Update] Deploying Pi-hole through the Linode Marketplace

### DIFF
--- a/docs/products/tools/marketplace/guides/pihole/index.md
+++ b/docs/products/tools/marketplace/guides/pihole/index.md
@@ -32,7 +32,7 @@ aliases: ['/guides/deploying-pihole-marketplace-app/','/guides/pihole-marketplac
 
 ## Configuration Options
 
-- **Supported distributions:** Ubuntu 20.04 LTS, Debian 11
+- **Supported distributions:** Ubuntu 20.04 LTS
 - **Recommended plan:** All plan types and sizes can be used.
 
 ### Pi-hole Options


### PR DESCRIPTION
This PR removes Debian 11 from list of available distros in the Pi-hole guide.