### PR TITLE
[New] Manual Network Configuration on a Compute Instance

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -833,6 +833,7 @@ identrust
 idlist
 ie
 iface
+ifcfg
 ifconfig
 ifdown
 ifnames
@@ -969,6 +970,7 @@ kerberos
 kerberos5
 Kernighan
 keychain
+keyfile
 keyfiles
 keygen
 keyid

--- a/docs/guides/networking/linode-network/ifupdown/index.md
+++ b/docs/guides/networking/linode-network/ifupdown/index.md
@@ -1,0 +1,171 @@
+---
+slug: ifupdown
+author:
+  name: Linode
+  email: docs@linode.com
+description: "Learn how to configure networking using the ifupdown utility on Debian and older Ubuntu distributions"
+keywords: ["static", "ip address","ifupdown", "ifup", "ifdown"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2022-05-25
+modified_by:
+  name: Linode
+title: "Network Configuration Using ifupdown"
+tags: ["networking","linode platform",]
+external_resources:
+ - '[ifupdown documentation](https://manpages.debian.org/bullseye/ifupdown/interfaces.5.en.html)'
+---
+
+The [ifupdown](https://manpages.debian.org/bullseye/ifupdown/ifup.8.en.html) package is an older network configuration software that's still used by Debian and older Ubuntu distributions (such as 16.04 LTS and earlier).
+
+{{< note >}}
+Newer Ubuntu releases use Netplan in conjunction with systemd-networkd (or NetworkManager). Newer Debian releases also include systemd-networkd, though ifupdown is still the default.
+{{</ note >}}
+
+{{< note >}}
+This guide serves as a supplement to the main [Manual Network Configuration on a Compute Instance](/docs/guides/manual-network-configuration/) guide. Please review that guide before making any configuration changes to your Compute Instance.
+{{</ note >}}
+
+## Configuration Files
+
+Network configuration settings for ifupdown are managed inside of an [interfaces](https://manpages.debian.org/bullseye/ifupdown/interfaces.5.en.html) file or series of files. The main configuration is typically stored in `/etc/network/interfaces` and additional files are typically added within `/etc/network/interfaces.d/*`
+
+- **Default configuration file:** `/etc/network/interfaces`
+
+## Starter Configuration
+
+Here is an example of a typical configuration file for ifupdown. It statically defines the IPv4 address and allows SLAAC to configure the IPv6 address.
+
+{{< file "/etc/network/interfaces" >}}
+auto lo
+iface lo inet loopback
+
+source /etc/network/interfaces.d/*
+
+auto eth0
+
+allow-hotplug eth0
+
+iface eth0 inet6 auto
+iface eth0 inet static
+    address 192.0.2.123/24
+    gateway 192.0.2.1
+{{</ file >}}
+
+## Configuring IP Addresses Manually
+
+1. Log in to the [Cloud Manager](https://cloud.linode.com/) and review your Compute Instance's IP addresses. See [Managing IP Addresses](/docs/guides/managing-ip-addresses/). Make a note of the following pieces of information or keep this page accessible so you can reference it later.
+
+    - Public IPv4 address(es) and the associated IPv4 gateway
+    - Private IPv4 address (if one has been added)
+    - IPv6 SLAAC address and the associated IPv6 gateway
+    - IPv6 /64 or /56 routed range (if one has been added)
+    - DNS resolvers (if you want to use Linode's resolvers)
+
+1. Disable Network Helper on the Compute Instance so that it doesn't overwrite any of your changes on the next system reboot. For instructions, see the [Network Helper](/docs/guides/network-helper/#single-per-linode) guide. This guide covers disabling Network Helper *globally* (for all Compute Instances on your account) or just for a single instance.
+
+1. Log in to the Compute Instance using [SSH](/docs/guides/connect-to-server-over-ssh/) or [Lish](/docs/guides/using-the-lish-console/). You may want to consider using Lish to avoid getting locked out in the case of a configuration error.
+
+1. Perform any necessary configuration steps as outlined in the workflows below. You can edit your network configuration file using a text editor like [nano](/docs/guides/use-nano-to-edit-files-in-linux/) or [vim](/docs/guides/what-is-vi/).
+
+        sudo nano /etc/network/interfaces
+
+1.  Once you've edited the configuration file to fit your needs, you need to apply the changes or reboot the Compute Instance. To apply your changes with ifupdown, run the following commands:
+
+        sudo ifdown eth0 && sudo ip addr flush eth0 && sudo ifup eth0
+
+## Changing the Primary IPv4 Address
+
+To change the main IPv4 address configured on the system, set the `address` and `gateway` parameters under `iface eth0 inet static` to match the new IP address and its corresponding gateway IP address.
+
+{{< file "/etc/network/interfaces" >}}
+...
+iface eth0 inet static
+    address 192.0.2.123/24
+    gateway 192.0.2.1
+{{</ file >}}
+
+## Configuring the Primary IPv4 Address through DHCP
+
+DHCP can be used to automatically configure your primary IPv4 address. The primary IPv4 address is defined as the IPv4 address assigned to your system that is in the first position when sorted numerically. To enable DHCP, modify or add an `iface` for your interface using `dhcp` instead of `static`.
+
+{{< file "/etc/network/interfaces" >}}
+...
+iface eth0 inet dhcp
+# iface eth0 inet static
+#    address 192.0.2.123/24
+#    gateway 192.0.2.1
+{{</ file >}}
+
+{{< caution >}}
+When using DHCP, the IPv4 address configured on your system may change if you add or remove IPv4 addresses on your Compute Instance. If this happens, any tool or system using the original IPv4 address will no longer be able to connect.
+{{</ caution>}}
+
+To disable DHCP, switch `dhcp` back to `static` and manually add the relevant `address` and `gateway` lines.
+
+## Configuring Additional IPv4 Addresses
+
+Additional IP addresses can be configured by adding or modifying the `iface` group for the desired interface. Multiple `address` lines can be provided to configure more than one IP address.
+
+{{< file "/etc/network/interfaces" >}}
+...
+iface eth0 inet static
+    address [ip-address]/[prefix]
+{{</ file >}}
+
+In the example above, make the following replacements:
+
+- **[ip-address]**: The IPv4 address that you wish to statically configure.
+- **[prefix]**: The prefix is based on the type of IP address you are adding. It should be `24` for public IPv4 addresses and `17` for private IPv4 addresses.
+
+## Configuring the Primary IPv6 Address through SLAAC
+
+SLAAC is used to automatically configure your primary IPv6 address. Within ifupdown, you can configure an IPv6 SLAAC address by adding or modifying the `iface` for your interface and the `inet6` protocol, making sure to set it to `auto` instead of `static`.
+
+{{< file "/etc/network/interfaces" >}}
+...
+iface eth0 inet6 auto
+    accept_ra 2
+{{</ file >}}
+
+If you wish to disable IPv6 SLAAC addressing and instead statically configure your primary IPv6 address (not recommended), you can modify the `iface eth0 inet6` group by setting it to `static` and adding your primary IPv6 address within the `address` parameter (using the prefix of `/128`).
+
+{{< file "/etc/network/interfaces" >}}
+...
+iface eth0 inet6 static
+    address [ip-address]/128
+    # accept_ra 2
+{{</ file >}}
+
+## Configuring Additional IPv6 Addresses
+
+If you have an IPv6 range assigned to your Compute Instance, addresses from this range can be configured within the `iface eth0 inet6` group, making sure it's set to `static` instead of `auto`. Multiple `address` lines can be provided to configure more than one IP address.
+
+{{< file "/etc/network/interfaces" >}}
+...
+iface eth0 inet6 static
+    address [ip-address]/[prefix]
+    autoconf 1
+    accept_ra 2
+{{</ file >}}
+
+In the example above, make the following replacements:
+
+- **[ip-address]**: The IPv6 address that you wish to statically configure. You can choose any address within your available range. For example, within the range *2001:db8:e001:1b8c::/64*, the address `2001:db8:e001:1b8c::1` can be used.
+- **[prefix]**: The prefix should either be `64` or `56` (depending on the size of your IPv6 range).
+
+The `autoconf` parameter (when set to `1`), allows the primary IPv6 address to be automatically configured through SLAAC, which is the preferred behavior for most cases.
+
+## Changing the DNS Resolvers
+
+DNS resolvers are the entities that resolve domain names to their corresponding IPv4 address. By default, the Compute Instance should be using the DNS resolvers for the data center in which it resides. You can change these through the `/etc/resolv.conf` file, setting the `nameserver` parameters to your preferred DNS resolvers.
+
+{{< file "/etc/resolv.conf" >}}
+domain ip.linodeusercontent.com
+search ip.linodeusercontent.com
+nameserver 203.0.113.1
+nameserver 203.0.113.2
+nameserver 203.0.113.3
+...
+{{</ file >}}
+
+In the above example, replace the IP addresses provided with the IP addresses of the DNS resolvers you wish to use.

--- a/docs/guides/networking/linode-network/linux-static-ip-configuration/index.md
+++ b/docs/guides/networking/linode-network/linux-static-ip-configuration/index.md
@@ -1,5 +1,7 @@
 ---
 slug: linux-static-ip-configuration
+deprecated: true
+deprecated_link: /guides/manual-network-configuration/
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/networking/linode-network/manual-network-configuration/index.md
+++ b/docs/guides/networking/linode-network/manual-network-configuration/index.md
@@ -1,0 +1,76 @@
+---
+slug: manual-network-configuration
+author:
+  name: Linode
+  email: docs@linode.com
+description: "Learn how to manually edit your distribution-specific network configuration files to set static IPs, routes and DNS resolvers."
+keywords: ["static", "ip address", "addresses"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2022-05-25
+modified_by:
+  name: Linode
+title: "Manual Network Configuration on a Compute Instance"
+tags: ["networking","linode platform"]
+---
+
+Every Compute Instance is assigned several IP addresses, including a pubic IPv4 address and a public IPv6 [SLAAC](https://en.wikipedia.org/wiki/IPv6#Stateless_address_autoconfiguration_.28SLAAC.29) address. By default, a utility called [Network Helper](/docs/guides/network-helper/) automatically configures these IP addresses within the network configuration files on the Compute Instance. While this is preferred in most cases, there are some situations which may require you to manually configure networking yourself. These situations include:
+
+- Installing a custom distribution on a Compute Instance
+- Configuring failover (see [Configuring Failover on a Compute Instance](/docs/guides/ip-failover/))
+- Assigning addresses from an IPv6 routed range
+- Using other DNS resolvers (not Linode’s)
+- Other advanced use cases where custom network configuration is required
+
+The guides in this series walk you through how to manually configure your networking in most common Linux distributions. To learn more about the types of IP addresses available on a Compute Instance, review the [Managing IP Addresses](/docs/guides/managing-ip-addresses/#types-of-ip-addresses) guide. Additional public IPv4 addresses, private IPv4 addresses, and IPv6 routed ranges (/64 or /56) can be added manually or by opening a [support ticket](/docs/guides/support/) and detailing your requirements.
+
+## Network Configuration Software in Linux
+
+All Linux distributions have pre-installed software whose purpose is to manage the internal networking on the system. In most cases, using this default software is preferred. That said, advanced users may wish to install their own preferred tool.
+
+### Default Network Configuration Software by Distribution
+
+The following table contains a list of each Linux distribution offered by Linode. Alongside each distribution is the default network software that it uses and a link to a guide for help with configuring that software.
+
+| Distribution | Network Manager |
+| -- | -- |
+| AlmaLinux 8 | [NetworkManager](/docs/guides/networkmanager/) |
+| Alpine | [ifupdown-ng](/docs/guides/ifupdown/) |
+| Arch | [systemd-networkd](/docs/guides/systemd-networkd/) |
+| CentOS 7 and 8 | [NetworkManager](/docs/guides/networkmanager/) |
+| CentOS Stream 8 and 9 | [NetworkManager](/docs/guides/networkmanager/) |
+| Debian 9-11 | [ifupdown](/docs/guides/ifupdown/) |
+| Fedora 34-36 | [NetworkManager](/docs/guides/networkmanager/) |
+| Gentoo | netifrc |
+| Rocky Linux 8 | [NetworkManager](/docs/guides/networkmanager/) |
+| Slackware | netconfig |
+| OpenSUSE Leap | wicked |
+| Ubuntu 16.04 | [ifupdown](/docs/guides/ifupdown/) |
+| Ubuntu 18.04 - 22.04 | [systemd-networkd](/docs/guides/systemd-networkd/) and Netplan |
+
+To manually configure networking, follow the associated guide and/or the official manual for the networking software and Linux distribution you are using.
+
+## Static vs Dynamic Addressing
+
+IP addresses can be statically configured or dynamically configured through DHCP (for public IPv4 addresses) and SLAAC (for primary IPv6 addresses).
+
+- **Static** configuration means explicitly defining the IP address within your system's network configuration. IPv4 addresses are configured this way through Network Helper and static configuration of IPv4 and IPv6 routed ranges is typically recommended when manually configuring your networking.
+
+- **DHCP** (Dynamic Host Configuration Protocol) can be used to automatically configure a single IPv4 address on a Compute Instance. If multiple IPv4 addresses are on the system, the first IP address (sorted alpha-numerically) is used. DHCP does not configure private IPv4 addresses or any IPv6 addresses. If you intend on adding or removing public IPv4 addresses after you initially configure networking, using DHCP is not recommended as it may configure a different public IPv4 address after you make those changes.
+
+    {{< note >}}
+If you do enable DHCP and are using a firewall (such as Cloud Firewalls), you must configure the firewall to allow communication with our DHCP servers. See the [DHCP IP Address Reference](/docs/guides/dhcp-ip-address-reference/) guide for a list of IP addresses to allow.
+{{</ note >}}
+
+- **SLAAC** (Stateless address autoconfiguration) can *and should* be used to automatically configure the main IPv6 address on a Compute Instance. It does not configure any IPv6 routed ranges (/64 or /56) that may also be assigned to that instance. For SLAAC to function, the Compute Instance needs to accept router advertisements. This is accomplished by enabling router advertisements and disabling IPv6 privacy extensions within your system's networking configuration files. These settings are properly configured by default in our supported distributions.
+
+Static and dynamic addressing can be used together within a single configuration file. As an example, you can use DHCP to configure the public IPv4 address on your system, use SLAAC to configure your IPv6 address, and statically configure any remaining addresses (such as private IPv4 address or addresses from an IPv6 routed range).
+
+## Networking Terms
+
+- **IP address:** A unique and structured combination of numbers (and letters, for IPv6 address) used to identify a device over a network. Every Linode Compute Instance is assigned a public IPv4 address and a public IPv6 address. Additional IP addresses, including private IPv4 addresses and IPv6 routed ranges, are available.
+
+- **Interface:** A real or virtual device that is responsible for facilitating a connection to a network. Each Compute Instance has one public interface for connecting to the internet: *eth0*. If a VLAN is configured, an additional interface for that VLAN is available. In that case, you may assign the public interface to *eth0* or *eth1* if desired.
+
+- **Gateway:** Provides access to a larger network, such as the internet. When configuring a Compute Instance, you only need to specify a gateway for one interface.
+
+- **DNS resolver:** A server responsible for matching domain names to IP addresses. Linode provides DNS resolvers for each data center, though you are free to use others if you choose.

--- a/docs/guides/networking/linode-network/networkmanager/index.md
+++ b/docs/guides/networking/linode-network/networkmanager/index.md
@@ -1,0 +1,185 @@
+---
+slug: networkmanager
+author:
+  name: Linode
+  email: docs@linode.com
+description: "Learn how to configure networking using the NetworkManager utility on CentOS, CentOS Stream, Fedora, and other modern Linux distributions"
+keywords: ["static", "ip address","NetworkManager"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2022-05-25
+modified_by:
+  name: Linode
+title: "Network Configuration Using NetworkManager"
+tags: ["networking","linode platform"]
+external_resources:
+ - '[NetworkManager documentation](https://networkmanager.dev/docs/api/latest/NetworkManager.conf.html)'
+---
+
+[NetworkManager](https://networkmanager.dev/) is a very popular network configuration utility and is used by default on Fedora, CentOS Stream, CentOS, AlmaLinux 8, and Rocky Linux 8. It can also be easily installed on Arch, Ubuntu, and other distributions.
+
+{{< note >}}
+This guide serves as a supplement to the main [Manual Network Configuration on a Compute Instance](/docs/guides/manual-network-configuration/) guide. Please review that guide before making any configuration changes to your Compute Instance.
+{{</ note >}}
+
+## Configuration Files
+
+Most distributions that use NetworkManager enable the ifcfg-rh plugin be default, which allows NetworkManager to use the older *ifcfg* configuration file format. NetworkManager also supports its own native *keyfile* format. By default, [Network Helper](/docs/guides/network-helper/) uses the *ifcfg* format, so that is what this guide covers.
+
+- **File location:** `/etc/sysconfig/network-scripts/`
+- **Naming convention:** `ifcfg-[interface]`, replacing *[interface]* with the name of the interface you wish to configure.
+- **Default configuration file:** `/etc/sysconfig/network-scripts/ifcfg-eth0`
+
+## Starter Configuration
+
+Here is an example of a typical configuration file for NetworkManager. It statically defines the IPv4 address and allows SLAAC to configure the IPv6 address.
+
+{{< file "/etc/sysconfig/network-scripts/ifcfg-eth0" >}}
+DEVICE="eth0"
+NAME="eth0"
+ONBOOT="yes"
+
+BOOTPROTO="none"
+
+IPV6INIT="yes"
+IPV6_ADDR_GEN_MODE="eui64"
+IPV6_PRIVACY="no"
+
+PEERDNS="no"
+
+DOMAIN=ip.linodeusercontent.com
+
+DNS1=203.0.113.1
+DNS2=203.0.113.2
+DNS3=203.0.113.3
+
+GATEWAY0=192.0.2.1
+IPADDR0=192.0.2.123
+PREFIX0=24
+{{</ file >}}
+
+## Configuring IP Addresses Manually
+
+1. Log in to the [Cloud Manager](https://cloud.linode.com/) and review your Compute Instance's IP addresses. See [Managing IP Addresses](/docs/guides/managing-ip-addresses/). Make a note of the following pieces of information or keep this page accessible so you can reference it later.
+
+    - Public IPv4 address(es) and the associated IPv4 gateway
+    - Private IPv4 address (if one has been added)
+    - IPv6 SLAAC address and the associated IPv6 gateway
+    - IPv6 /64 or /56 routed range (if one has been added)
+    - DNS resolvers (if you want to use Linode's resolvers)
+
+1. Disable Network Helper on the Compute Instance so that it doesn't overwrite any of your changes on the next system reboot. For instructions, see the [Network Helper](/docs/guides/network-helper/#single-per-linode) guide. This guide covers disabling Network Helper *globally* (for all Compute Instances on your account) or just for a single instance.
+
+1. Log in to the Compute Instance using [SSH](/docs/guides/connect-to-server-over-ssh/) or [Lish](/docs/guides/using-the-lish-console/). You may want to consider using Lish to avoid getting locked out in the case of a configuration error.
+
+1. Perform any necessary configuration steps as outlined in the workflows below. You can edit your network configuration file using a text editor like [nano](/docs/guides/use-nano-to-edit-files-in-linux/) or [vim](/docs/guides/what-is-vi/).
+
+        sudo nano /etc/sysconfig/network-scripts/ifcfg-eth0
+
+1.  Once you've edited the configuration file to fit your needs, you need to apply the changes or reboot the Compute Instance. To apply your changes with NetworkManager, run the following commands:
+
+        sudo nmcli connection reload
+        sudo nmcli connection down eth0
+        sudo nmcli connection up eth0
+
+## Changing the Primary IPv4 Address
+
+To change the main IPv4 address configured on the system, set the `GATEWAY0`, `ADDRESS0`, and `PREFIX0` parameters to match the new IP address and its corresponding gateway IP address.
+
+{{< file "/etc/sysconfig/network-scripts/ifcfg-eth0" >}}
+...
+GATEWAY0=192.0.2.1
+IPADDR0=192.0.2.123
+PREFIX0=24
+{{</ file >}}
+
+## Configuring the Primary IPv4 Address through DHCP
+
+DHCP can be used to automatically configure your primary IPv4 address. The primary IPv4 address is defined as the IPv4 address assigned to your system that is in the first position when sorted numerically. To enable DHCP, set the `BOOTPROTO` parameter to `"dhcp"` and remove (or comment out) the lines that define the `GATEWAY0`, `ADDRESS0`, and `PREFIX0` parameters.
+
+{{< file "/etc/sysconfig/network-scripts/ifcfg-eth0" >}}
+...
+BOOTPROTO="dhcp"
+...
+# GATEWAY0=192.0.2.1
+# IPADDR0=192.0.2.123
+# PREFIX0=24
+{{</ file >}}
+
+{{< caution >}}
+When using DHCP, the IPv4 address configured on your system may change if you add or remove IPv4 addresses on your Compute Instance. If this happens, any tool or system using the original IPv4 address will no longer be able to connect.
+{{</ caution>}}
+
+To disable DHCP, set the `BOOTPROTO` parameter back to `"none"`.
+
+## Configuring Additional IPv4 Addresses
+
+Additional IPv4 addresses can be configured by adding the `IPADDRn` and `PREFIXn` parameters, where *n* is an incrementing number based on how many other IPv4 address you have configured (starting at `0` for the primary address). For instance, to add a second IPv4 address, use the parameters `IPADDR1` and `PREFIX1`. For a third address, use `IPADDR2` and `PREFIX2`.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+...
+IPADDR1=[ip-address]
+PREFIX1=[prefix]
+{{</ file >}}
+
+In the example above, make the following replacements:
+
+- **[ip-address]**: The IPv4 address that you wish to statically configure.
+- **[prefix]**: The prefix is based on the type of IP address you are adding. It should be `24` for public IPv4 addresses and `17` for private IPv4 addresses.
+
+## Configuring the Primary IPv6 Address through SLAAC
+
+SLAAC is used to automatically configure your primary IPv6 address. For this to work, your system must accept router advertisements. You also may need to disable IPv6 privacy extensions. Within NetworkManager, you can set `IPV6INIT` to `yes`, `IPV6_ADDR_GEN_MODE` to `eui64`, and `IPV6_PRIVACY` to `no`.
+
+{{< file "/etc/sysconfig/network-scripts/ifcfg-eth0" >}}
+...
+IPV6INIT="yes"
+IPV6_ADDR_GEN_MODE="eui64"
+IPV6_PRIVACY="no"
+{{</ file >}}
+
+If you wish to disable IPv6 SLAAC addressing and instead statically configure your IPv6 address (not recommended), you can explicitly set the `net.ipv6.conf.eth0.autoconf` kernel variable to `0` in the `/etc/sysctl.conf` file and then reboot your Compute Instance
+
+{{< file "/etc/sysctl.conf" >}}
+...
+net.ipv6.conf.all.autoconf=0
+{{</ file >}}
+
+Then modify the network configuration file to disable auto-configuration and statically set your IPv6 address.
+
+{{< file "/etc/sysconfig/network-scripts/ifcfg-eth0" >}}
+...
+IPV6INIT="yes"
+IPV6_AUTOCONF="no"
+# IPV6_ADDR_GEN_MODE="eui64"
+# IPV6_PRIVACY="no"
+
+IPV6ADDR=[ip-address]/[prefix]
+IPV6_DEFAULTGW=fe80::1
+{{</ file >}}
+
+## Configuring Additional IPv6 Addresses
+
+If you have an IPv6 range assigned to your Compute Instance, addresses from this range can be configured through the `IPV6ADDR_SECONDARIES` parameter. This accepts a list of space delimited IPv6 addresses.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+...
+IPV6ADDR_SECONDARIES="[ip-address]/[prefix]"
+{{</ file >}}
+
+In the example above, make the following replacements:
+
+- **[ip-address]**: The IPv6 address that you wish to statically configure. You can choose any address within your available range. For example, within the range *2001:db8:e001:1b8c::/64*, the address `2001:db8:e001:1b8c::1` can be used.
+- **[prefix]**: The prefix should either be `64` or `56` (depending on the size of your IPv6 range)
+
+## Changing the DNS Resolvers
+
+DNS resolvers are the entities that resolve domain names to their corresponding IPv4 address. By default, the Compute Instance should be using the DNS resolvers for the data center in which it resides. You can change these by setting the `DNS` parameter to a space delimited list of the IP addresses for your preferred DNS resolvers.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+...
+DNS1=203.0.113.1
+DNS2=203.0.113.2
+DNS3=203.0.113.3
+{{</ file >}}
+
+In the above example, replace the IP addresses provided with the IP addresses of the DNS resolvers you wish to use. Both IPv4 and IPv6 addresses can be used together.

--- a/docs/guides/networking/linode-network/systemd-networkd/index.md
+++ b/docs/guides/networking/linode-network/systemd-networkd/index.md
@@ -1,0 +1,165 @@
+---
+slug: systemd-networkd
+author:
+  name: Linode
+  email: docs@linode.com
+description: "Learn how to configure networking using the systemd-networkd utility on Ubuntu, Arch, and other modern Linux distributions"
+keywords: ["static", "ip address", "systemd-networkd"]
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+published: 2022-05-25
+modified_by:
+  name: Linode
+title: "Network Configuration Using systemd-networkd"
+tags: ["networking","linode platform"]
+---
+
+The [systemd-networkd](https://wiki.archlinux.org/title/systemd-networkd) tool is a newer tool developed as part of systemd. Arch and modern versions of Ubuntu (17.10 and above) currently use systemd-networkd as their default network configuration software.
+
+{{< note >}}
+Ubuntu also has utility called Netplan that serves as a frontend for configuring either systemd-networkd or NetworkManager. By default, NetworkHelper manages networking in Ubuntu using systemd-networkd though you can decide which one works best for your needs.
+{{</ note >}}
+
+{{< note >}}
+This guide serves as a supplement to the main [Manual Network Configuration on a Compute Instance](/docs/guides/manual-network-configuration/) guide. Please review that guide before making any configuration changes to your Compute Instance.
+{{</ note >}}
+
+## Configuration Files
+
+Here are details regarding the network configuration files for systemd-networkd, including information on the default configuration file location.
+
+- **File extension:** `.network`
+- **File location:** `/etc/systemd/network/`
+- **Naming convention:** `[priority]-[interface].network`, with *[priority]* being used to order the files (files are processed alpha-numerically\*) and *[interface]* providing a convenient way for a user to associate a file with a particular interface.
+- **Default configuration file:** `/etc/systemd/network/05-eth0.network`.
+
+\* *When systemd-networkd brings up the network interfaces, the configuration files are processed alpha-numerically. As such, you'll see that files are typically prepended with a 2-digit number to help order them. The default configuration file is prepended with `05`. If we wanted to create a configuration file for a different interface, we could prepend it with a number below `05` (to be processed before) or above (to be processed after).*
+
+## Starter Configuration
+
+Here is an example of a typical configuration file for systemd-networkd. It statically defines the IPv4 address and allows SLAAC to configure the IPv6 address.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+[Match]
+Name=eth0
+
+[Network]
+DHCP=no
+DNS=203.0.113.1 203.0.113.2 203.0.113.3
+Domains=ip.linodeusercontent.com
+IPv6PrivacyExtensions=false
+
+Gateway=192.0.2.1
+Address=192.0.2.123/24
+{{</ file >}}
+
+- [**Name**](https://www.freedesktop.org/software/systemd/man/systemd.network.html#Name=): `eth0`, the default interface configured for the public internet on most Compute Instances. When using a VLAN, the public internet interface may be configured differently.
+
+- [**DHCP**](https://www.freedesktop.org/software/systemd/man/systemd.network.html#DHCP=): `no`, which disables DHCP and allows you to statically define the main IPv4 address in later fields.
+
+- [**DNS**](https://www.freedesktop.org/software/systemd/man/systemd.network.html#DNS=): A list of IP addresses that map to Linode's DNS resolvers. The IP addresses provided in this example are placeholders and do not function.
+
+- [**Domains**](https://www.freedesktop.org/software/systemd/man/systemd.network.html#Domains=): `ip.linodeusercontent.com`, which is defined as a "search domain". This is a quick way of converting single-label hostnames to FQDNs, but isn't often needed.
+
+- [**IPv6PrivacyExtensions**](https://www.freedesktop.org/software/systemd/man/systemd.network.html#IPv6PrivacyExtensions=): `false`, which disables privacy extensions and helps to resolve any issues with automatically configuring your IPv6 SLAAC address.
+
+- [**Gateway**](https://www.freedesktop.org/software/systemd/man/systemd.network.html#Gateway=): Statically configures the IPv4 gateway address.
+
+- [**Address**](https://www.freedesktop.org/software/systemd/man/systemd.network.html#Gateway=): Statically configures the IPv4 address.
+
+## Configuring IP Addresses Manually
+
+1. Log in to the [Cloud Manager](https://cloud.linode.com/) and review your Compute Instance's IP addresses. See [Managing IP Addresses](/docs/guides/managing-ip-addresses/). Make a note of the following pieces of information or keep this page accessible so you can reference it later.
+
+    - Public IPv4 address(es) and the associated IPv4 gateway
+    - Private IPv4 address (if one has been added)
+    - IPv6 SLAAC address and the associated IPv6 gateway
+    - IPv6 /64 or /56 routed range (if one has been added)
+    - DNS resolvers (if you want to use Linode's resolvers)
+
+1. Disable Network Helper on the Compute Instance so that it doesn't overwrite any of your changes on the next system reboot. For instructions, see the [Network Helper](/docs/guides/network-helper/#single-per-linode) guide. This guide covers disabling Network Helper *globally* (for all Compute Instances on your account) or just for a single instance.
+
+1. Log in to the Compute Instance using [SSH](/docs/guides/connect-to-server-over-ssh/) or [Lish](/docs/guides/using-the-lish-console/). You may want to consider using Lish to avoid getting locked out in the case of a configuration error.
+
+1. Perform any necessary configuration steps as outlined in the workflows below. You can edit your network configuration file using a text editor like [nano](/docs/guides/use-nano-to-edit-files-in-linux/) or [vim](/docs/guides/what-is-vi/).
+
+        sudo nano /etc/systemd/network/05-eth0.network
+
+1.  Once you've edited the configuration file to fit your needs, you need to apply the changes or reboot the Compute Instance. To apply your changes with systemd-networkd, restart the service:
+
+        sudo networkctl reload
+
+## Changing the Primary IPv4 Address
+
+To change the IPv4 address configured on the system, set the `Gateway` and `Address` parameters to match the new IP address and its corresponding gateway IP address.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+...
+Gateway=192.0.2.1
+Address=192.0.2.123/24
+{{</ file >}}
+
+## Configuring the Primary IPv4 Address through DHCP
+
+DHCP can be used to automatically configure your primary IPv4 address. The primary IPv4 address is defined as the IPv4 address assigned to your system that is in the first position when sorted numerically. To enable DHCP, set the `DHCP` parameter to `yes` and remove (or comment out) the lines that define the `Gateway` and `Address` of the primary IPv4 address.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+...
+[Network]
+DHCP=yes
+...
+# Gateway=192.0.2.1
+# Address=192.0.2.123/24
+{{</ file >}}
+
+{{< caution >}}
+When using DHCP, the IPv4 address configured on your system may change if you add or remove IPv4 addresses on your Compute Instance. If this happens, any tool or system using the original IPv4 address will no longer be able to connect.
+{{</ caution>}}
+
+## Configuring the Primary IPv6 Address through SLAAC
+
+SLAAC is used to automatically configure your primary IPv6 address. For this to work, your system must accept router advertisements. You also may need to disable IPv6 privacy extensions. Within systemd-networkd, this means setting `IPv6PrivacyExtensions` to `false` and `IPv6AcceptRA` to `true`.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+...
+[Network]
+...
+IPv6PrivacyExtensions=false
+IPv6AcceptRA=true
+{{</ file >}}
+
+If you wish to disable IPv6 SLAAC addressing and instead statically configure your IPv6 address (not recommended), you can explicitly set the `IPv6AcceptRA` parameter to `false` and then add your IPv6 address through the [Configuring Additional IP Addresses](#configuring-additional-ip-addresses) instructions.
+
+{{< note >}}
+The `IPv6AcceptRA` parameter isn't strictly required as long as running the `net.ipv6.conf.eth0.autoconf` kernel variable is set to `1` (not a `0`). You can determine the setting by running the following command.
+
+    sysctl net.ipv6.conf.eth0.autoconf
+{{</ note >}}
+
+## Configuring Additional IP Addresses
+
+Additional IP addresses can be configured by adding another `Address` parameter within the `[Network]` section of the configuration file.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+...
+Address=[ip-address]/[prefix]
+{{</ file >}}
+
+In the example above, make the following replacements:
+
+- **[ip-address]**: The IP address that you wish to statically configure. If configuring an address from an IPv6 range, you can choose any address within that range. For example, within the range *2001:db8:e001:1b8c::/64*, the address `2001:db8:e001:1b8c::1` can be used.
+- **[prefix]**: The prefix is based on the type of IP address you are adding:
+    - Public IPv4 address: `/24`
+    - Private IPv4 address: `/17`
+    - IPv6 SLAAC address: `/128` (though it's recommended to configure this automatically through SLAAC)
+    - IPv6 address from a range: `/64` or `/56` (depending on the size of the range)
+
+## Changing the DNS Resolvers
+
+DNS resolvers are the entities that resolve domain names to their corresponding IPv4 address. By default, the Compute Instance should be using the DNS resolvers for the data center in which it resides. You can change these by setting the `DNS` parameter to a space delimited list of the IP addresses for your preferred DNS resolvers.
+
+{{< file "/etc/systemd/network/05-eth0.network" >}}
+...
+DNS=203.0.113.1 203.0.113.2 203.0.113.3
+{{</ file >}}
+
+In the above example, replace the IP addresses provided with the IP addresses of the DNS resolvers you wish to use. Both IPv4 and IPv6 addresses can be used together.


### PR DESCRIPTION
These guides serve as a replacement for the old Linux Static IP Configuration guide, which is still visible but has been deprecated.