### PR TITLE
Use scroll-padding-top to offset sticky header when clicking anchor links

### DIFF
--- a/_vendor/github.com/linode/linode-docs-theme/assets/css/styles.css
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/css/styles.css
@@ -35,6 +35,7 @@ html {
   margin: 0;
   padding: 0;
   color: var(--color-body-text);
+  scroll-padding-top: var(--height-navbar-row);
 }
 
 body {


### PR DESCRIPTION
Adding the scroll-padding-top property will accommodate for the height of the sticky header when clicking anchor links. I haven't tested this code, but adding the property to the html element in chrome devtools produces a desirable result

![CleanShot 2022-06-06 at 11 58 17](https://user-images.githubusercontent.com/785186/172198761-ce50b284-9be0-4c3c-a954-17365f85983a.gif)

The calculation would need to pull the `--height-navbar-row` and add an additional padding, like a line-height variable, if that exists. See this guide for more options: https://getpublii.com/blog/one-line-css-solution-to-prevent-anchor-links-from-scrolling-behind-a-sticky-header.html