### PR TITLE
[Update] Install VNC on Ubuntu 20.04

### DIFF
--- a/docs/guides/applications/remote-desktop/install-vnc-on-ubuntu-20-04/index.md
+++ b/docs/guides/applications/remote-desktop/install-vnc-on-ubuntu-20-04/index.md
@@ -20,7 +20,7 @@ relations:
         key: install-vnc
         keywords:
             - distribution: Ubuntu 20.04
-aliases: ['/applications/remote-desktop/install-vnc-on-ubuntu-20-04/']
+aliases: ['/applications/remote-desktop/install-vnc-on-ubuntu-21-04/', '/guides/install-vnc-on-ubuntu-21-04/']
 ---
 
 *Virtual network computing*, or VNC, is a graphical desktop sharing system that allows you to control one computer remotely from another. A VNC server transfers keyboard and mouse events, and displays the remote host's screen via a network connection, which allows you to operate a full desktop environment on your Linode.


### PR DESCRIPTION
* Add missing alias. This should fix [the current 404](https://www.linode.com/docs/guides/install-vnc-on-ubuntu-21-04/).