### PR TITLE
Recategorized a CMS guide and updated title capitalization

### DIFF
--- a/docs/guides/websites/cms/basics/best-open-source-content-management-systems/index.md
+++ b/docs/guides/websites/cms/basics/best-open-source-content-management-systems/index.md
@@ -2,14 +2,14 @@
 slug: best-open-source-content-management-systems
 author:
   name: Steven J. Vaughan-Nichols
-description: 'Searching for the best open source content management systems (CMS)? From what to look for in a CMS to the top options available, this guide covers it all.'
+description: "Searching for the best open source content management systems (CMS)? From what to look for in a CMS to the top options available, this guide covers it all."
 keywords: ['top 10 open source cms','top open source content management systems','top opensource cms']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-03-25
 modified_by:
   name: Linode
 title: "The Top Open Source Content Management Systems"
-h1_title: "What are the Best Open Source Content Management Systems?"
+h1_title: "What Are the Best Open Source Content Management Systems?"
 enable_h1: true
 contributor:
   name: Steven J. Vaughan-Nichols

--- a/docs/guides/websites/cms/basics/cms-overview/index.md
+++ b/docs/guides/websites/cms/basics/cms-overview/index.md
@@ -3,7 +3,7 @@ slug: cms-overview
 author:
   name: Linode
   email: docs@linode.com
-description: 'An overview of the three content management systems that Linode supports'
+description: "An overview of the three content management systems that Linode supports"
 keywords: ["drupal", "WordPress", "joomla", "cms", "content management system", "content management framwork"]
 tags: ["drupal","wordpress","cms","lamp"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
@@ -11,7 +11,7 @@ modified: 2017-02-15
 modified_by:
   name: Linode
 published: 2014-10-17
-title: 'Content Management Systems: an Overview'
+title: "Content Management Systems: An Overview"
 aliases: ['/websites/cms/cms-overview/','/websites/cms/basics/cms-overview/']
 ---
 
@@ -30,7 +30,6 @@ A LAMP stack is a System Admin term for a web server using Linux, Apache, MySQL,
 {{< /note >}}
 
 Using a Linode gives you more control and a greater understanding of website administration. Linux and content management systems play a huge role in the open-source world, and now, you can begin learning both.
-
 
 ## Themes and Templates
 
@@ -59,7 +58,6 @@ Joomla works best for intermediate users, and while it lends itself to social co
 Originally built as a blogger platform, [WordPress](/docs/websites/cms/how-to-install-and-configure-wordpress/) is arguably the easiest to use and the most popular. Initially released in 2003, it has grown rapidly since. The WP platform is used for over 60 million websites, and 100,000 new websites are created daily.
 
 WordPress is best for static content. However, WP sites are often built for complex, dynamic solutions because the community is so large and has added so many capabilities. The structure of the company behind WordPress, Automattic, and its philosophy represent the ability for large growth with such an open-source project.
-
 
 ## Next Steps
 


### PR DESCRIPTION
- Moved "The Top Open Source Content Management Systems" guide from WordPress category to CMS Basics category
- Updated title capitalization for two CMS guides