### PR TITLE
Add PEM format specification

### DIFF
--- a/docs/guides/platform/nodebalancer/nodebalancer-ssl-configuration/index.md
+++ b/docs/guides/platform/nodebalancer/nodebalancer-ssl-configuration/index.md
@@ -58,8 +58,8 @@ This guide has been written with the assumption that you are logged in as the ro
     | **Port** | 443 |
     | **Protocol** | HTTPS |
     | **Session Stickiness** | None |
-    | **SSL Certificate** | Paste the contents of your SSL certificate. If you have linked multiple segments of a chained certificate, be sure to copy all of its contents into the text field, appearing one after another. The certificate must be signed using the RSA algorithm, which is the default in most cases. ECDSA certificates are not supported.|
-    | **Private Key** | Paste the contents of your private key. Your private key must not have a passphrase. |
+    | **SSL Certificate** | Paste the PEM-formatted contents of your SSL certificate. If you have linked multiple segments of a chained certificate, be sure to copy all of its contents into the text field, appearing one after another. The certificate must be signed using the RSA algorithm, which is the default in most cases. ECDSA certificates are not supported.|
+    | **Private Key** | Paste the PEM-formatted contents of your private key. Your private key must not have a passphrase. |
     | **Algorithm** | Round Robin |
     | **Health Check Type** | HTTP Status |
     | **Interval** | 5 |


### PR DESCRIPTION
In the API docs, the ssl_cert and ssl_key fields specify that both the certificate and key files need to be PEM-formatted:

https://www.linode.com/docs/api/nodebalancers/#config-create