### PR TITLE
[Fix] Continuous Deployment Using LKE: Prometheus and Grafana

### DIFF
--- a/docs/guides/kubernetes/lke-continuous-deployment-part-11/index.md
+++ b/docs/guides/kubernetes/lke-continuous-deployment-part-11/index.md
@@ -58,7 +58,7 @@ Going beyond metrics-server, this guide goes over collecting more advanced metri
 - Let's install that stack *directly* from its repo (without doing helm repo add first)
 - Otherwise, keep the same naming strategy:
 
-      helm upgrade --install kube-prometheus-stack kube-prometheus-stack \
+      helm upgrade kube-prometheus-stack kube-prometheus-stack --install \
         --namespace kube-prometheus-stack --create-namespace \
         --repo https://prometheus-community.github.io/helm-charts
 


### PR DESCRIPTION
```
➜  ~ helm upgrade --install kube-prometheus-stack kube-prometheus-stack \ --namespace prometheus --create-namespace \ --repo https://prometheus-community.github.io/helm-charts

Error: "helm upgrade" requires 2 arguments

Usage:  helm upgrade [RELEASE] [CHART] [flags]
```
Moving `--install` after `kube-prometheus-stack kube-prometheus-stack` allows the command to run as expected.