### PR TITLE
Adjustments to Vale's minimum alert level

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,7 @@ jobs:
       with:
         files: '${{ steps.select_docs_dir_files.outputs.added_modified }}'
         version: 2.19.0
+        vale_flags: "--minAlertLevel=error"
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,7 +3,7 @@ StylesPath = ci/vale/styles
 # The minimum alert level to display (suggestion, warning, or error).
 #
 # CI builds will only fail on error-level alerts.
-MinAlertLevel = error
+MinAlertLevel = warning
 
 # HTML tags to be ignored by Vale. `code` and `tt` are the default, but Linode
 # seems to use `strong` in a similar ways -- e.g., `**docker build -t ubuntu**`,


### PR DESCRIPTION
In a recent change, the minimum alert level in Vale was set to only show errors (`MinAlertLevel = error`). This change was done in the .vale.ini file and affected the GitHub Action, running Vale locally in Docker, and using the VS Code extension. The intended purpose was to only show errors in the GitHub Action, though it was acceptable that the other methods of running Vale were also impacted (considering that you can explicitly set the preferred level in VS Code settings).

A better way to implement this without impacting any other Vale usage or needing to change any local settings is to use the `--minAlertLevel` flag within the GitHub Action itself. This PR makes that change and then reverts the main Vale configuration file back to showing both warning and errors.