### PR TITLE
[update] Use CoreOS Container Linux on Linode

### DIFF
--- a/docs/guides/applications/containers/use-coreos-container-linux-on-linode/index.md
+++ b/docs/guides/applications/containers/use-coreos-container-linux-on-linode/index.md
@@ -1,5 +1,7 @@
 ---
 slug: use-coreos-container-linux-on-linode
+deprecated: true
+deprecated_link: 'applications/containers/use-coreos-container-linux-on-linode/'
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/applications/containers/use-coreos-container-linux-on-linode/index.md
+++ b/docs/guides/applications/containers/use-coreos-container-linux-on-linode/index.md
@@ -1,7 +1,6 @@
 ---
 slug: use-coreos-container-linux-on-linode
 deprecated: true
-deprecated_link: 'applications/containers/use-coreos-container-linux-on-linode/'
 author:
   name: Linode
   email: docs@linode.com


### PR DESCRIPTION
added deprecation to this guide because Linode no longer supports CoreOS