### PR TITLE
Updates to Managed Database guides (note about resize)

### DIFF
--- a/docs/products/databases/managed-databases/guides/create-database/index.md
+++ b/docs/products/databases/managed-databases/guides/create-database/index.md
@@ -4,7 +4,8 @@ author:
   email: docs@linode.com
 title: "Create a Managed Database"
 description: "A walkthough on creating a Managed Database through the Cloud Manager"
-modified: 2022-06-06
+published: 2022-06-06
+modified: 2022-08-09
 ---
 
 This guide walks you through creating a Linode Managed Database through the Cloud Manager.
@@ -47,6 +48,10 @@ Select the **region** where the database cluster will reside. Regions correspond
 Every node of a database cluster is built on its own Linode Compute Instance. In the **Choose a Plan** section, select the Compute Instance type and plan that the nodes will use. You can choose from either [Dedicated CPU](/docs/products/compute/dedicated-cpu/) or [Shared CPU](/docs/products/compute/shared-cpu/) plans. In general, Dedicated CPU plans are recommended for high-performance production databases.
 
 - [Choosing a Compute Instance Type and Plan](/docs/guides/choosing-a-compute-instance-plan/)
+
+{{< note >}}
+Once a Managed Database cluster is created, it cannot be resized to a different plan. To modify the resources allocated to your database, you will need to create a new Managed Database with the desired plan, migrate your data, and delete the original Managed Database.
+{{</ note >}}
 
 ## Determine the Number of Nodes
 

--- a/docs/products/databases/managed-databases/guides/database-engines/index.md
+++ b/docs/products/databases/managed-databases/guides/database-engines/index.md
@@ -5,6 +5,7 @@ author:
 title: "Database Engines and Plans"
 description: "Learn the differences between the database engines offered by Linode's Managed Database service."
 published: 2022-06-06
+modified: 2022-08-09
 ---
 
 When deploying a Managed Database, you are able to select from a variety of database engines and plans. While each database engine enables you to store data, application compatibility and the way in which they store and access data can vary greatly. This guide aims to provide more information on each database engine, the reasons you might choose one over the other, and advice on selecting an appropriate plan size.
@@ -82,3 +83,7 @@ Each Managed Database can be deployed with a specific set of resources. This col
 [Dedicated CPU Instances](/docs/products/compute/dedicated-cpu/) reserve physical CPU cores that you can utilize at 100% load 24/7 for as long as you need. This provides competition free guaranteed CPU resources and ensures your software can run at peak speed and efficiency. With Dedicated CPU instances, you can run your software for prolonged periods of maximum CPU usage, and you can ensure the lowest latency possible for latency-sensitive operations. These instances offer a perfectly balanced set of resources for most production applications.
 
 *Best for production websites, enterprise applications, high traffic databases, and any application that requires 100% sustained CPU usage or may be impacted by resource contention.*
+
+{{< note >}}
+Once a Managed Database cluster is created, it cannot be resized to a different plan. To modify the resources allocated to your database, you will need to create a new Managed Database with the desired plan, migrate your data, and delete the original Managed Database.
+{{</ note >}}


### PR DESCRIPTION
This PR adds a note to several guides to notify users that Managed Databases can't be resized once created.

- [Update] Managed Databases > Create a Managed Database
- [Update] Managed Databases > Database Engines and Plans 