### PR TITLE
Notice regarding deposits for GPU Instances

### DIFF
--- a/docs/products/compute/gpu/_index.md
+++ b/docs/products/compute/gpu/_index.md
@@ -56,6 +56,8 @@ Atlanta, GA, United States; Frankfurt, Germany; Newark, NJ, United States; Mumba
 
 Pricing starts at $1,000/mo ($1.50/hr) for a GPU Instance with 1 GPU card, 8 vCPU cores, 32 GB of memory, and 640 GB of SSD storage. Review the [Pricing page](https://www.linode.com/pricing/#row--compute) for additional plans and their associated costs. See the [Comparison of Compute Instances](#comparison-of-compute-instances) section below to learn more about other Instance types.
 
+{{< content "gpu-deposit-shortguide" >}}
+
 ## Additional Technical Specifications
 
 In addition to the resources allocated to each available plan (outlined above), GPU Compute Instances have the following specifications:

--- a/docs/products/compute/gpu/_shortguides/gpu-deposit-shortguide/index.md
+++ b/docs/products/compute/gpu/_shortguides/gpu-deposit-shortguide/index.md
@@ -1,0 +1,10 @@
+---
+# Shortguide: Notice regarding deposits for GPU instances
+
+headless: true
+show_on_rss_feed: false
+---
+
+{{< note >}}
+In some cases, a $100 deposit may be required to deploy GPU Compute Instances. This may include new accounts that have been active for less than 90 days and accounts that have spent less than $100 on Linode services. If you are unable to deploy GPU instances, contact [Support](https://www.linode.com/support/) for assistance.
+{{</ note >}}

--- a/docs/products/compute/gpu/get-started/index.md
+++ b/docs/products/compute/gpu/get-started/index.md
@@ -7,6 +7,8 @@ aliases: ['/platform/linode-gpu/getting-started-with-gpu/', '/guides/getting-sta
 image: getting-started-with-linode-gpu-instances.png
 ---
 
+{{< content "gpu-deposit-shortguide" >}}
+
 ## Deploy a GPU Linode Instance
 
 1. Log in to the [Cloud Manager](https://cloud.linode.com/) with the username and password you created when signing up.


### PR DESCRIPTION
This PR adds a shortguide that explains a deposit may be needed to deploy GPU Compute Instances. The shortguide is referenced on the main Overview page as well on the the Get Started page.