### PR TITLE
[Update] Manage Firewall Rules

### DIFF
--- a/docs/products/networking/cloud-firewall/_index.md
+++ b/docs/products/networking/cloud-firewall/_index.md
@@ -8,7 +8,7 @@ tab_group_main:
     title: Overview
     weight: 10
 cascade:
-    date: 2020-06-02
+    date: 2020-11-10
     product_description: "A free cloud-based firewall service that makes it easy to secure network traffic to and from Compute Instances."
 aliases: ['/guides/platform/cloud-firewall/','/platform/cloud-firewall/']
 ---

--- a/docs/products/networking/cloud-firewall/guides/manage-firewall-rules/index.md
+++ b/docs/products/networking/cloud-firewall/guides/manage-firewall-rules/index.md
@@ -5,6 +5,8 @@ author:
 title: "Manage Firewall Rules"
 description: "How to add rules to a Linode Cloud Firewall."
 aliases: ['/products/networking/cloud-firewall/guides/add-rules/','/products/networking/cloud-firewall/guides/edit-rules/','/products/networking/cloud-firewall/guides/delete-rules/']
+published: 2020-11-10
+modified: 2022-08-11
 ---
 
 A Cloud Firewall can be configured with both *Inbound* and *Outbound* rules.
@@ -56,13 +58,19 @@ Rules are separated into *inbound* and *outbound* sections.
     | **Action** | Choose whether this rule will be to allow or drop traffic. The action defined in specific rules will take precedence over the default inbound and outbound traffic policy. *Required* |
 
     {{< note >}}
-  When applying individual IP addresses or IP ranges to either the `source` or `destination` field, the addresses must always be valid and formatted correctly. An example valid IPv4 and IPv6 range is as follows:
+When applying individual IP addresses or IP ranges to either the `source` or `destination` field, the addresses must always be valid and formatted correctly. IP address ranges are formatted differently than port number ranges. Instead of using a hyphenated range of numbers, [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) is used to designate the network prefix and the number of bits in the prefix. The following are examples of valid IPv4 and IPv6 ranges:
 
-  - `139.144.0.0/16`
-  - `2001:db8:1234::/48`
+- `192.0.2.0/24`
+- `198.51.0.0/16`
+- `2001:db8:1234::/48`
 
-  As of the time of this writing, if an IP address or range is invalid, users will be unable to **Save Changes** after reviewing new firewall rules, and no error message will appear. Users should ensure that all IP addresses and Ranges are valid and formatted correctly should they encounter this issue.
-  {{< /note >}}
+In the first example above, using a range of `192.0.2.0/24` applies the rule to all IP addresses from 192.0.2.1 through 192.0.2.254.
+{{</ note >}}
+
+
+    {{< caution >}}
+As of the time of this writing, if an IP address or range is invalid, users will be unable to **Save Changes** after reviewing new firewall rules, and no error message will appear. Users should ensure that all IP addresses and ranges are valid and formatted correctly should they encounter this issue.
+{{</ caution >}}
 
 1. Click on **Add Rule** to add the new rule to this Firewall. If you would like to add any additional rules, repeat the process outlined in this section.
 


### PR DESCRIPTION
This PR updates some of the content regarding using IP ranges in Cloud Firewalls, including adding an example for /24 IPv4 ranges. It also updates the date the Cloud Firewall docs were published, which was inaccurate a few months.