### PR TITLE
[update] Getting Started with Puppet - Basic Installation and Setup

### DIFF
--- a/docs/guides/applications/configuration-management/puppet/getting-started-with-puppet-6-1-basic-installation-and-setup/index.md
+++ b/docs/guides/applications/configuration-management/puppet/getting-started-with-puppet-6-1-basic-installation-and-setup/index.md
@@ -15,6 +15,7 @@ title: Getting Started with Puppet - Basic Installation and Setup
 external_resources:
     - '[Puppet Labs](https://puppet.com/)'
     - '[Puppet Open Source Documentation](https://docs.puppet.com/puppet/)'
+    - '[Configuring Java Arguments](https://puppet.com/docs/pe/2019.0/config_java_args.html)'
 aliases: ['/applications/configuration-management/puppet/getting-started-with-puppet-6-1-basic-installation-and-setup/','/applications/configuration-management/getting-started-with-puppet-6-1-basic-installation-and-setup/']
 ---
 


### PR DESCRIPTION
added a reference link to configure java_args to the canonical documentation