### PR TITLE
[Update] Deploying HashiCorp Vault through the Linode Marketplace

### DIFF
--- a/docs/products/tools/marketplace/guides/hashicorp-vault/index.md
+++ b/docs/products/tools/marketplace/guides/hashicorp-vault/index.md
@@ -26,7 +26,7 @@ title: "Deploying HashiCorp Vault through the Linode Marketplace"
 
 ## Configuration Options
 
-- **Supported distributions:**
+- **Supported distributions:** Debian 11, Ubuntu 22.04 LTS
 - **Recommended plan:** We recommend a 4GB Dedicated CPU or Shared Compute instance for the Vault instance.
 
 {{< content "marketplace-limited-user-fields-shortguide">}}


### PR DESCRIPTION
Added supported distributions to the Vault Marketplace App guide.