### PR TITLE
Ignore directory generated by linalgadm tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ hugo_stats.json
 .hugo_build.lock
 redirects.conf
 scripts/duplicates.csv
+algolia_out/


### PR DESCRIPTION
The linode algolia admin tool generates a directory named algolia_out/ with some data it needs to run, but we don’t need to save it in version control, and this PR puts it in our gitignore.