### PR TITLE
[update] How to Use Paramiko and Python to SSH into a Server

### DIFF
--- a/docs/guides/development/python/use-paramiko-python-to-ssh-server/index.md
+++ b/docs/guides/development/python/use-paramiko-python-to-ssh-server/index.md
@@ -63,7 +63,7 @@ client = paramiko.client.SSHClient()
 client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 client.connect(host, username=username, password=password)
 _stdin, _stdout,_stderr = client.exec_command("df")
-print(stdout.read().decode())
+print(_stdout.read().decode())
 client.close()
 {{< /file >}}
 


### PR DESCRIPTION
- fixed the typo in the variable
Based on the feed back:
"I think on line 16 there is a small issue
print(stdout.read().decode())
should we not have _stdout ? as stdout will not be recognized as a variable. That's a minor thing and I want to thank you for this nice tutorial, nicely made"