### PR TITLE
Fixes theme 404 issue (including for ref arch content)

### DIFF
--- a/_vendor/github.com/hotwired/turbo/src/core/drive/visit.ts
+++ b/_vendor/github.com/hotwired/turbo/src/core/drive/visit.ts
@@ -407,5 +407,10 @@ export class Visit implements FetchRequestDelegate {
 }
 
 function isSuccessful(statusCode: number) {
+  if (statusCode == 404) {
+    // Temporary patch (bep).
+    // In most cases, a 404 response is, from a rendering perspective, a successful response.
+    return true
+  }
   return statusCode >= 200 && statusCode < 300
 }


### PR DESCRIPTION
This is a hacky way to introduce this change to the turbo module. The right way to do it is to vendor the fix bep gave us in this PR: https://github.com/linode/linode-docs-theme/pull/372

But, we ran into a problem when vendoring the theme after that PR was merged:
https://github.com/linode/linode-docs-theme/issues/375

So, I'm trying out editing the existing file in the docs vendored turbo module in the meantime till we get issue #375 figured out.