### PR TITLE
[Update] Deploying the UniFi Network Application through the Linode Marketplace

### DIFF
--- a/docs/products/tools/marketplace/guides/unifi-network-application/index.md
+++ b/docs/products/tools/marketplace/guides/unifi-network-application/index.md
@@ -7,6 +7,7 @@ keywords: ['UniFi','Network','gateway', 'routing']
 tags: ["marketplace", "linode platform", "cloud manager"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-09-06
+modified: 2022-09-22
 modified_by:
   name: Linode
 title: "Deploying the UniFi Network Application through the Linode Marketplace"
@@ -37,7 +38,7 @@ When self-hosting the UniFi Network Application, you are responsible for the sec
 
 ### Accessing the UniFi Network Application
 
-1. Open your web browser and navigate to `http://[ip-address]`, where *[ip-address]* can be replaced with your Compute Instance's IP address or rDNS domain. See the [Managing IP Addresses](/docs/guides/managing-ip-addresses/) guide for information on viewing IP addresses and rDNS.
+1. Open your web browser and navigate to `https://[domain]`, where *[domain]* can be replaced with your Compute Instance's rDNS domain or, if you entered one, the domain you specified when you deployed the instance. See the [Managing IP Addresses](/docs/guides/managing-ip-addresses/) guide for information on viewing the rDNS value for your public IPv4 address.
 
 2. First, enter a name for the Network Application. This is primarily used for managing multiple networks.
 

--- a/docs/products/tools/marketplace/guides/unifi-network-application/index.md
+++ b/docs/products/tools/marketplace/guides/unifi-network-application/index.md
@@ -38,9 +38,15 @@ When self-hosting the UniFi Network Application, you are responsible for the sec
 
 ### Accessing the UniFi Network Application
 
-1. Open your web browser and navigate to `https://[domain]`, where *[domain]* can be replaced with your Compute Instance's rDNS domain or, if you entered one, the domain you specified when you deployed the instance. See the [Managing IP Addresses](/docs/guides/managing-ip-addresses/) guide for information on viewing the rDNS value for your public IPv4 address.
+1. Open your web browser and navigate to `https://[domain]`, where *[domain]* can be replaced with your Compute Instance's rDNS domain or, if you entered one, the domain you specified when you deployed the instance. See the [Managing IP Addresses](/docs/guides/managing-ip-addresses/) guide for information on viewing the rDNS value for your public IPv4 address. The URL is also visible when logging into the new Compute Instance for the first time, either through [Lish](/docs/guides/using-the-lish-console/) or [SSH](/docs/guides/set-up-and-secure/#connect-to-the-instance).
 
-2. First, enter a name for the Network Application. This is primarily used for managing multiple networks.
+    {{< output >}}
+The installation is now complete, and you can access the
+UniFi Network Controller GUI from https://192-0-2-163.ip.linodeusercontent.com
+We recommend using the GUI to complete your configurations of the service
+{{</ output >}}
+
+2. Within the setup screen that appears, enter a name for the Network Application. This is primarily used for managing multiple networks.
 
     ![Screenshot of the UniFi Network name page](UniFi-network-name.png)
 


### PR DESCRIPTION
This PR updates the URL used for accessing the UniFi application after deployment. It can no longer be accessed by the IPv4 address and instead needs to use the rDNS domain or any custom domain entered during deployment.