### PR TITLE
[Update] Using S3cmd with Object Storage

### DIFF
--- a/docs/products/storage/object-storage/guides/s3cmd/index.md
+++ b/docs/products/storage/object-storage/guides/s3cmd/index.md
@@ -4,10 +4,10 @@ author:
   email: docs@linode.com
 title: "Using S3cmd with Object Storage"
 description: "Learn how to use the S3cmd command-line tool with Linode's Object Storage."
-modified: 2022-08-04
+modified: 2022-09-29
 ---
 
-S3cmd is a command line utility that you can use for any S3-compatible Object Storage.
+[S3cmd](https://s3tools.org/s3cmd) is a command line utility that you can use for any S3-compatible Object Storage.
 
 ## Installing S3cmd
 
@@ -46,7 +46,7 @@ After s3cmd has been installed, it needs to be configured to work with the bucke
     - **Access Key:** Enter the access key you wish to use. See [Managing Access Keys](/docs/products/storage/object-storage/guides/access-keys/).
     - **Secret Key:** Enter the secret key that corresponds with the access key. This was displayed once when generating the access key.
     - **Default Region:** `US` (do not change, even if you use Object Storage in a different region)
-    - **S3 Endpoint** (cluster URL): `https://[cluster-id].linodeobjects.com/`, where [cluster-id] is the id of your data center. See [Access Buckets and Files through URLs > Cluster URL (S3 Endpoint)](/docs/products/storage/object-storage/guides/urls/#cluster-url-s3-endpoint) for more details and a list of cluster IDs.
+    - **S3 Endpoint** (cluster URL): `https://[cluster-id].linodeobjects.com`, where [cluster-id] is the id of your data center. See [Access Buckets and Files through URLs > Cluster URL (S3 Endpoint)](/docs/products/storage/object-storage/guides/urls/#cluster-url-s3-endpoint) for more details and a list of cluster IDs.
     - **DNS-style bucket+hostname:port template for accessing a bucket:** `%(bucket)s.[cluster-id].linodeobjects.com`, replacing [cluster-id] with the same id used previously.
     - **Encryption password:** Enter your GPG key if you intend to store and retrieve encrypted files (optional).
     - **Path to GPG program:** Enter the path to your GPG encryption program (optional).
@@ -67,7 +67,7 @@ ERROR: Test failed: 403 (SignatureDoesNotMatch)
 
 S3cmd offers a number of additional configuration options that are not presented as prompts by the `S3cmd --configure` command. To modify any s3cmd configuration options (including the ones from the previous step), you can edit the configuration file directly. This configuration file is named `.s3cfg` and should be stored with your local home directory. For our purposes, its recommended to adjust the following option:
 
-- **website_endpoint:** `http://%(bucket)s.website-[cluster-url]/`, replacing [cluster-url] with the cluster URL corresponding to the data center your buckets are located within (listed on the [Access Buckets and Files through URLs](/docs/products/storage/object-storage/guides/urls/) page).
+- **website_endpoint:** `http://%(bucket)s.website-[cluster-id].linodeobjects.com/`, replacing *[cluster-id]* with the id corresponding to the data center your buckets are located within (listed on the [Access Buckets and Files through URLs](/docs/products/storage/object-storage/guides/urls/) page).
 
 ## Interacting with Buckets
 


### PR DESCRIPTION
This PR removes the trailing slash from s3 endpoint in S3cmd guide. If present, the trailing slash would cause most s3cmd commands that interact with buckets or objects to fail. It also updates the website-endpoint configuration parameter to use the cluster id instead of the cluster url.