### PR TITLE
Cache images for GitHub Actions

### DIFF
--- a/.github/workflows/cache-images.yaml
+++ b/.github/workflows/cache-images.yaml
@@ -1,0 +1,93 @@
+name: CI Tests
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  hugo-image-cache-name: hugo-generated-images
+  hugo-image-cache-path: /home/runner/work/docs/docs/resources/_gen/images/
+  repo-name: docs
+  repo-owner: linode
+
+jobs:
+  cache-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: List contents of images dir
+        continue-on-error: true
+        run: ls -al ${{ env.hugo-image-cache-path }}
+
+      - name: Cache images dir
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.hugo-image-cache-path }}
+          key: ${{ env.hugo-image-cache-name }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ env.hugo-image-cache-name }}
+
+      - name: List contents of images dir
+        continue-on-error: true
+        run: ls -al ${{ env.hugo-image-cache-path }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10.x'
+          architecture: 'x64'
+
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('./ci/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./ci/requirements.txt
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install dependencies (Node)
+        run: npm install
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.83.1'
+
+      - name: Build Hugo
+        run: hugo --gc
+
+      - name: List existing Hugo image caches
+        run: |
+          curl \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ env.repo-owner }}/${{ env.repo-name }}/actions/caches?key=${{ env.hugo-image-cache-name }} \
+          -o cache-list.json
+
+          echo "The following caches will be deleted:"
+          cat cache-list.json
+
+      - name: Delete existing Hugo image caches
+        run: |
+          for id in $(jq '.actions_caches[].id' cache-list.json); do
+            echo "Deleting cache with id $id"
+            curl \
+            -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ env.repo-owner }}/${{ env.repo-name }}/actions/caches/$id
+          done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,10 @@ name: CI Tests
 
 on: [pull_request]
 
+env:
+  hugo-image-cache-name: hugo-generated-images
+  hugo-image-cache-path: /home/runner/work/docs/docs/resources/_gen/images/
+
 jobs:
   blueberry:
 
@@ -77,6 +81,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: List contents of images dir
+      continue-on-error: true
+      run: ls -al ${{ env.hugo-image-cache-path }}
+    - name: Restore Hugo generated images cache
+      uses: ylemkimon/cache-restore@v2
+      with:
+        path: ${{ env.hugo-image-cache-path }}
+        key: ${{ env.hugo-image-cache-name }}
+        restore-keys: ${{ env.hugo-image-cache-name }}
+    - name: List contents of images dir
+      continue-on-error: true
+      run: ls -al ${{ env.hugo-image-cache-path }}
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
- New workflow for pushes to develop branch (e.g. triggered after a pull request merge into develop):
  - Attempt to restore an existing image cache, if it exists
  - Build Hugo with garbage collection turned on
  - Delete existing image caches. The resources/_gen/images directory is large, so this helps us avoid hitting the 10GB cap on GHA caches. If we were to hit the cap, other caches start getting evicted, and this could possibly include things we want to keep like our GHAs' node/python package caches.
  - Post-cache step will run after workflow and save the new image cache
- Update existing docs404 test:
  - Before starting Hugo server, attempt to restore an image cache, if it exists. Image caches from the develop branch will be found, according to the cache lookup rules for GHA caches
  - Do not attempt to save/update the image cache after the test

This does not remove the resources/_gen/images dir from version control--a subsequent PR will do that. Merging this while that directory is still in version control should help populate the images cache quickly.

Note that if you look at the docs404 logs for this PR, the **Restore Hugo generated images cache** step won’t have found any caches yet. That’s because the new workflow updates will only create a cache after a PR has been merged into develop (for a number of reasons that all work around limitations in the github actions caching APIs).