### PR TITLE
[update]Install OpenVAS 8 on Ubuntu 16.04

### DIFF
--- a/docs/guides/security/vulnerabilities/install-openvas-on-ubuntu-16-04/index.md
+++ b/docs/guides/security/vulnerabilities/install-openvas-on-ubuntu-16-04/index.md
@@ -13,6 +13,7 @@ modified_by:
   name: Linode
 published: 2017-02-06
 title: Install OpenVAS 8 on Ubuntu 16.04
+deprecated: true
 ---
 
 OpenVAS, the Open Vulnerability Assessment System, is a framework of tools that allow you to scan your system for thousands of known vulnerabilities. This guide will show you how to install OpenVAS 8 on Ubuntu 16.04.


### PR DESCRIPTION
_ added deprecated notice because openvas is now GVM and install instructions are different.