### PR TITLE
Fix link to updated guide

### DIFF
--- a/docs/guides/networking/linode-network/linux-static-ip-configuration/index.md
+++ b/docs/guides/networking/linode-network/linux-static-ip-configuration/index.md
@@ -1,7 +1,7 @@
 ---
 slug: linux-static-ip-configuration
 deprecated: true
-deprecated_link: /guides/manual-network-configuration/
+deprecated_link: /docs/guides/manual-network-configuration/
 author:
   name: Linode
   email: docs@linode.com


### PR DESCRIPTION
The link to the "Manual Network Configuration on a Compute Instance" guide doesn't work. It looks like the link is missing the /docs/ directory in the URL.