### PR TITLE
[Update] Products > Object Storage > Guides - Define Access and Permissions using Bucket Policies

### DIFF
--- a/docs/products/storage/object-storage/guides/bucket-policies/index.md
+++ b/docs/products/storage/object-storage/guides/bucket-policies/index.md
@@ -168,7 +168,7 @@ The example below allows all traffic from only the specified IP address:
           "aws:SourceIp": "192.0.2.1/32"
         }
       }
-    },
+    }
   ]
 }
 {{</ file >}}


### PR DESCRIPTION
Fix an errant comma prevent the policy from executing in the "[Allow or Deny Access from a Specific IP Address](https://www.linode.com/docs/products/storage/object-storage/guides/bucket-policies/#allow-or-deny-access-from-a-specific-ip-address)" section.