### PR TITLE
Mark /116 pools as deprecated

### DIFF
--- a/docs/guides/networking/linode-network/an-overview-of-ipv6-on-linode/index.md
+++ b/docs/guides/networking/linode-network/an-overview-of-ipv6-on-linode/index.md
@@ -42,11 +42,11 @@ See the [Viewing IP Addresses](/docs/guides/managing-ip-addresses/#viewing-ip-ad
 
 ### Linux Terminal
 
-1. Using your terminal, SSH into the Linode whose IPv6 address you would like to find.
+1.  Using your terminal, SSH into the Linode whose IPv6 address you would like to find.
 
         ssh user@192.0.2.0
 
-1. Use the `ip` tool to find your Linode's IPv6 address:
+1.  Use the `ip` tool to find your Linode's IPv6 address:
 
         root@localhost:~# ip -6 address
         1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 state UNKNOWN qlen 1
@@ -87,8 +87,8 @@ An IPv6 pool is accessible from every Linode on your account within the assigned
 
 - `/116` **pool** *(4,096 addresses)*
 
-{{< note >}}
-The IPv6 `/116` prefix is not available in the Toronto, Atlanta, Sydney, or Mumbai data centers.
+    {{< caution >}}
+The IPv6 /116 prefix has been deprecated and is no longer available for new Compute Instances. If you have an existing Compute Instance with a /116 pool, please review the [Upcoming Changes Related to Network Infrastructure Upgrades](/docs/guides/network-infrastructure-upgrades/) to learn about changes that may affect your services.
 {{</ note >}}
 
 ## IPv6 Forwarding

--- a/docs/guides/networking/linode-network/network-infrastructure-upgrades/index.md
+++ b/docs/guides/networking/linode-network/network-infrastructure-upgrades/index.md
@@ -30,9 +30,9 @@ For most customers, these upgrades are performed seamlessly behind the scenes. F
 
 The following is a list of breaking changes and any action that may be required if you are impacted by that change:
 
-- **Deprecation of IPv6 /116 pools:** /116 pools will no longer be provided to Compute Instances within data center that have received the upgrades. Existing /116 pools will be removed from Compute Instances at that time.
+- **Deprecation of IPv6 /116 pools:** /116 pools will no longer be provided to new Compute Instances. Existing /116 pools will be removed from Compute Instances when data center is undergoing upgrades.
 
-    *Action:* If you were using /116 for IPv6 failover, consider using an IPv6 /64 instead.
+    *Action:* If you are using /116 for IPv6 failover, consider using an IPv6 /64 instead.
 
 - **IP failover through BGP:** IP failover (IP Sharing) for public IPv4 addresses and IPv6 routed ranges will be facilitated through BGP instead of ARP (configured through [keepalived](/docs/guides/ip-failover-keepalived/)).
 

--- a/docs/guides/platform/manager/managing-ip-addresses/index.md
+++ b/docs/guides/platform/manager/managing-ip-addresses/index.md
@@ -57,8 +57,8 @@ All private IPs in the same data center can communicate with each other over the
 - **/116 Pool:** *(4,096 addresses)* An IPv6 pool is accessible from every Linode on your account within the assigned data center. Addresses from that pool can be configured on each Linode within that data center. This can enable features like IPv6 failover. By default, up to one /116 pool can be added per customer per data center.
 
     {{< caution >}}
-The IPv6 /116 prefix has been deprecated and is not available in the Toronto, Atlanta, Sydney, or Mumbai data centers. To add a /116 pool in a supported data center, [contact our Support team](https://www.linode.com/support/) with your request.
-{{</ caution >}}
+The IPv6 /116 prefix has been deprecated and is no longer available for new Compute Instances. If you have an existing Compute Instance with a /116 pool, please review the [Upcoming Changes Related to Network Infrastructure Upgrades](/docs/guides/network-infrastructure-upgrades/) to learn about changes that may affect your services.
+{{</ note >}}
 
 ## Adding an IP Address
 


### PR DESCRIPTION
This PR adds a deprecation notice to pages that reference /116 pools. Users are no longer able to add them within any data centers.