### PR TITLE
Singapore network upgrades are completed

### DIFF
--- a/docs/guides/networking/linode-network/ip-failover/index.md
+++ b/docs/guides/networking/linode-network/ip-failover/index.md
@@ -7,7 +7,7 @@ description: "This guide discusses how to enable failover on a Linode Compute In
 keywords: ['IP failover','IP sharing','elastic IP']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-03-23
-modified: 2022-09-01
+modified: 2022-10-11
 modified_by:
   name: Linode
 title: "Configuring Failover on a Compute Instance"
@@ -38,7 +38,7 @@ Within Linode's platform, failover is configured by first enabling [IP Sharing](
 | **London (United Kingdom)** | **New method (BGP)** | [lelastic](/docs/guides/ip-failover/#configure-failover) / [FRR](/docs/guides/ip-failover-bgp-frr/) | 7 |
 | **Mumbai (India)** | **New method (BGP)** | [lelastic](/docs/guides/ip-failover/#configure-failover) / [FRR](/docs/guides/ip-failover-bgp-frr/) | 14 |
 | **Newark (New Jersey, USA)** | **New method (BGP)** | [lelastic](/docs/guides/ip-failover/#configure-failover) / [FRR](/docs/guides/ip-failover-bgp-frr/) | 6 |
-| Singapore | *Undergoing network upgrades* | - | 9 |
+| **Singapore** | **New method (BGP)** | [lelastic](/docs/guides/ip-failover/#configure-failover) / [FRR](/docs/guides/ip-failover-bgp-frr/) | 9 |
 | Sydney (Australia) |  *Not supported* | - | 16 |
 | Tokyo (Japan) | Legacy method (ARP) | [keepalived](/docs/guides/ip-failover-keepalived/) | 11 |
 | Toronto (Canada) |  *Not supported* | - | 15 |

--- a/docs/guides/networking/linode-network/network-infrastructure-upgrades/index.md
+++ b/docs/guides/networking/linode-network/network-infrastructure-upgrades/index.md
@@ -7,13 +7,11 @@ description: "An overview of changes and actions that may be required in advance
 keywords: ['networking']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-07-19
-modified: 2022-09-01
+modified: 2022-10-11
 modified_by:
   name: Linode
 title: "Upcoming Changes Related to Network Infrastructure Upgrades"
 noindex: true
-_build:
-  list: false
 ---
 
 Throughout 2022, Linode is rolling out networking infrastructure upgrades to all of our existing data centers. These upgrades increase the stability and resiliency of our already reliable network. It also enables us to bring features, such as VLAN and IP Sharing, to every data center.
@@ -51,7 +49,7 @@ Review the table below to learn which data centers have been upgraded with the l
 | **London (United Kingdom)** | **Complete** |
 | **Mumbai (India)** | **Complete** |
 | **Newark (New Jersey, USA)** | **Complete** |
-| Singapore | *In progress* |
+| **Singapore** | **Complete** |
 | Sydney (Australia) | *Coming soon* |
 | Tokyo (Japan) | *Coming soon* |
 | Toronto (Canada) | *Coming soon* |


### PR DESCRIPTION
This PR updates the relevant guides related to the network infrastructure upgrades to mark Singapore as complete. It also updates the front matter for the network infrastructure guide so that it is searchable on the docs site.