### PR TITLE
Fixes deprecated links that 404

### DIFF
--- a/docs/guides/databases/mongodb/creating-a-mongodb-replication-set-on-centos-6-4/index.md
+++ b/docs/guides/databases/mongodb/creating-a-mongodb-replication-set-on-centos-6-4/index.md
@@ -1,7 +1,7 @@
 ---
 slug: creating-a-mongodb-replication-set-on-centos-6-4
 deprecated: true
-deprecated_link: '/guides/create-a-mongodb-replica-set/'
+deprecated_link: 'guides/create-a-mongodb-replica-set/'
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/databases/mongodb/creating-a-mongodb-replication-set-on-debian-7-wheezy/index.md
+++ b/docs/guides/databases/mongodb/creating-a-mongodb-replication-set-on-debian-7-wheezy/index.md
@@ -1,7 +1,7 @@
 ---
 slug: creating-a-mongodb-replication-set-on-debian-7-wheezy
 deprecated: true
-deprecated_link: '/guides/create-a-mongodb-replica-set/'
+deprecated_link: 'guides/create-a-mongodb-replica-set/'
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/databases/mongodb/creating-a-mongodb-replication-set-on-ubuntu-12-04-precise/index.md
+++ b/docs/guides/databases/mongodb/creating-a-mongodb-replication-set-on-ubuntu-12-04-precise/index.md
@@ -1,7 +1,7 @@
 ---
 slug: creating-a-mongodb-replication-set-on-ubuntu-12-04-precise
 deprecated: true
-deprecated_link: '/guides/create-a-mongodb-replica-set/'
+deprecated_link: 'guides/create-a-mongodb-replica-set/'
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/development/react/deploy-a-react-app-on-linode/index.md
+++ b/docs/guides/development/react/deploy-a-react-app-on-linode/index.md
@@ -18,7 +18,7 @@ contributor:
   link: https://twitter.com/philzona
 aliases: ['/development/react/deploy-a-react-app-on-linode/','/development/javascript/deploy-a-react-app-on-linode/']
 deprecated: true
-deprecated_link: '/guides/how-to-deploy-a-react-app-on-debian-10/'
+deprecated_link: 'guides/how-to-deploy-a-react-app-on-debian-10/'
 external_resources:
 - '[React - A JavaScript library for building user interfaces](https://reactjs.org/)'
 - '[Deploy a React App with Sass Using NGINX](https://web.archive.org/web/20191130010415/http://zabana.me/notes/build-deploy-react-app-with-nginx.html)'

--- a/docs/guides/development/ror/use-unicorn-and-nginx-on-ubuntu-14-04/index.md
+++ b/docs/guides/development/ror/use-unicorn-and-nginx-on-ubuntu-14-04/index.md
@@ -11,7 +11,7 @@ aliases: ['/websites/ror/use-unicorn-and-nginx-on-ubuntu-14-04/','/development/r
 published: 2016-03-30
 modified: 2016-03-30
 deprecated: true
-deprecated_link: '/guides/use-unicorn-and-nginx-on-ubuntu-18-04/'
+deprecated_link: 'guides/use-unicorn-and-nginx-on-ubuntu-18-04/'
 modified_by:
     name: Alex Fornuto
 title: "Deploy a Rails App with Unicorn and nginx on Ubuntu 14.04"

--- a/docs/guides/security/ssl/how-to-make-a-selfsigned-ssl-certificate/index.md
+++ b/docs/guides/security/ssl/how-to-make-a-selfsigned-ssl-certificate/index.md
@@ -1,7 +1,7 @@
 ---
 slug: how-to-make-a-selfsigned-ssl-certificate
 deprecated: true
-deprecated_link: /guides/create-a-self-signed-tls-certificate/
+deprecated_link: 'guides/create-a-self-signed-tls-certificate/'
 author:
   name: Linode
   email: docs@linode.com

--- a/docs/guides/security/ssl/install-lets-encrypt-to-create-ssl-certificates/index.md
+++ b/docs/guides/security/ssl/install-lets-encrypt-to-create-ssl-certificates/index.md
@@ -15,7 +15,7 @@ contributor:
   name: 'Sean Webber'
   link: 'https://github.com/seanthewebber'
 deprecated: true
-deprecated_link: /guides/how-to-install-certbot-on-ubuntu-18-04/
+deprecated_link: 'guides/enabling-https-using-certbot-with-nginx-on-ubuntu/'
 external_resources:
   - "[Let's Encrypt Homepage](https://letsencrypt.org/)"
 tags: ["security","ssl"]

--- a/docs/guides/security/ssl/secure-http-traffic-certbot/index.md
+++ b/docs/guides/security/ssl/secure-http-traffic-certbot/index.md
@@ -14,7 +14,7 @@ modified_by:
 published: 2018-06-27
 title: Secure HTTP Traffic with Certbot
 deprecated: true
-deprecated_link: /guides/how-to-install-certbot-on-ubuntu-18-04/
+deprecated_link: 'guides/enabling-https-using-certbot-with-nginx-on-ubuntu/'
 aliases: ['/quick-answers/websites/secure-http-traffic-certbot/','/quick-answers/websites/certbot/secure-http-traffic-certbot/']
 external_resources:
   - '[Certbot Official Documentation](https://certbot.eff.org/docs/)'

--- a/docs/guides/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/index.md
+++ b/docs/guides/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/index.md
@@ -14,7 +14,7 @@ modified_by:
 published: 2016-04-28
 title: 'How to Install a LAMP Stack on Ubuntu 16.04'
 deprecated: true
-deprecated_link: '/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/'
+deprecated_link: 'guides/how-to-install-a-lamp-stack-on-ubuntu-20-04/'
 external_resources:
  - '[Ubuntu Server Edition Homepage](http://www.ubuntu.com/server)'
  - '[Apache HTTP Server Documentation](http://httpd.apache.org/docs/2.4/)'

--- a/docs/guides/websites/wikis/install-mediawiki-on-ubuntu-1604/index.md
+++ b/docs/guides/websites/wikis/install-mediawiki-on-ubuntu-1604/index.md
@@ -14,7 +14,7 @@ modified_by:
 published: 2009-09-30
 title: Install MediaWiki on Ubuntu 16.04
 deprecated: true
-deprecated_link: '/websites/wikis/install-mediawiki-on-ubuntu-1804/'
+deprecated_link: 'guides/how-to-install-mediawiki-ubuntu-2004/'
 external_resources:
  - '[MediaWiki Wiki](http://www.mediawiki.org/wiki/MediaWiki)'
  - '[What is Media Wiki](https://www.mediawiki.org/wiki/Manual:What_is_MediaWiki%3F)'


### PR DESCRIPTION
This PR fixes deprecated links that 404. We identified these links by finding all `deprecated_link` parameters that have a value starting with `/` or `'/`.