### PR TITLE
[update] remove information about you can skip setting root password

### DIFF
--- a/ci/vale/dictionary.txt
+++ b/ci/vale/dictionary.txt
@@ -490,6 +490,7 @@ dokku
 domain1
 domain2
 domain3
+domain_id
 domainkey
 domainname
 donenfeld
@@ -1319,6 +1320,7 @@ mysqld
 mysqldefault
 mysqldump
 mysql_config_editor
+mysql_secure_installation
 mytestdb
 myuser
 mzet

--- a/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-centos-stream-8/index.md
+++ b/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-centos-stream-8/index.md
@@ -96,7 +96,7 @@ ownCloud requires a full LAMP (Linux, Apache, MySQL, PHP) stack. In this section
 
         sudo mysql_secure_installation
 
-    During this process, the system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user. You are then prompted to answer four questions, to all of which you should respond `y` (as in "yes").
+    You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
 #### Install PHP
 

--- a/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-ubuntu-20-04/index.md
+++ b/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-ubuntu-20-04/index.md
@@ -81,7 +81,7 @@ ownCloud requires a full LAMP (Linux, Apache, MySQL, PHP) stack. In this section
 
         sudo mysql_secure_installation
 
-    During this process, the system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user. You are then prompted to answer four questions, to all of which you should respond `y` (as in "yes").
+    You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
 1. Install PHP and all the required PHP packages
 

--- a/docs/guides/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7/index.md
+++ b/docs/guides/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7/index.md
@@ -99,7 +99,7 @@ Follow the steps below to create the database tables for virtual users, domains 
         sudo systemctl start mariadb
         sudo systemctl enable mariadb
 
-1.  Use the [*mysql_secure_installation*](https://mariadb.com/kb/en/library/mysql_secure_installation/) tool to configure additional security options. This tool will ask if you want to set a new password for the MySQL root user, but you can skip that step:
+1.  Use the [*mysql_secure_installation*](https://mariadb.com/kb/en/library/mysql_secure_installation/) tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
 
         sudo mysql_secure_installation
 

--- a/docs/guides/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7/index.md
+++ b/docs/guides/email/postfix/email-with-postfix-dovecot-and-mariadb-on-centos-7/index.md
@@ -99,16 +99,9 @@ Follow the steps below to create the database tables for virtual users, domains 
         sudo systemctl start mariadb
         sudo systemctl enable mariadb
 
-1.  Use the [*mysql_secure_installation*](https://mariadb.com/kb/en/library/mysql_secure_installation/) tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
+1.  Use the [*mysql_secure_installation*](https://mariadb.com/kb/en/library/mysql_secure_installation/) tool to configure additional security options. You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
         sudo mysql_secure_installation
-
-    Answer **Y** at the following prompts:
-
-    -   Remove anonymous users?
-    -   Disallow root login remotely?
-    -   Remove test database and access to it?
-    -   Reload privilege tables now?
 
 1.  Create a new database:
 

--- a/docs/guides/email/postfix/email-with-postfix-dovecot-and-mysql/index.md
+++ b/docs/guides/email/postfix/email-with-postfix-dovecot-and-mysql/index.md
@@ -141,16 +141,9 @@ Data for the mail server's users (email addresses), domains, and aliases are sto
 
 Follow the steps below to create the database and add tables for virtual users, domains and aliases:
 
-1.  Use the [*mysql_secure_installation*](https://mariadb.com/kb/en/library/mysql_secure_installation/) tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
+1.  Use the [*mysql_secure_installation*](https://mariadb.com/kb/en/library/mysql_secure_installation/) tool to configure additional security options. You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
         sudo mysql_secure_installation
-
-    Answer **Y** at the following prompts:
-
-    -   Remove anonymous users?
-    -   Disallow root login remotely?
-    -   Remove test database and access to it?
-    -   Reload privilege tables now?
 
 1.  Log in to MySQL as a root user:
 

--- a/docs/guides/email/postfix/email-with-postfix-dovecot-and-mysql/index.md
+++ b/docs/guides/email/postfix/email-with-postfix-dovecot-and-mysql/index.md
@@ -141,7 +141,7 @@ Data for the mail server's users (email addresses), domains, and aliases are sto
 
 Follow the steps below to create the database and add tables for virtual users, domains and aliases:
 
-1.  Use the [*mysql_secure_installation*](https://mariadb.com/kb/en/library/mysql_secure_installation/) tool to configure additional security options. This tool will ask if you want to set a new password for the MySQL root user, but you can skip that step:
+1.  Use the [*mysql_secure_installation*](https://mariadb.com/kb/en/library/mysql_secure_installation/) tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
 
         sudo mysql_secure_installation
 

--- a/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/index.md
@@ -222,7 +222,7 @@ GRANT ALL ON webdata.* TO 'webuser' IDENTIFIED BY 'password';
 quit
 {{< /highlight >}}
 
-1.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. This tool will ask if you want to set a new password for the MySQL root user, but you can skip that step:
+1.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
 
         sudo mysql_secure_installation
 

--- a/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/index.md
@@ -222,16 +222,9 @@ GRANT ALL ON webdata.* TO 'webuser' IDENTIFIED BY 'password';
 quit
 {{< /highlight >}}
 
-1.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
+1.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
         sudo mysql_secure_installation
-
-    Answer **Y** at the following prompts:
-
-    -  Remove anonymous users?
-    -  Disallow root login remotely?
-    -  Remove test database and access to it?
-    -  Reload privilege tables now?
 
 ### PHP
 

--- a/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-20-04/index.md
+++ b/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-20-04/index.md
@@ -225,16 +225,9 @@ GRANT ALL ON webdata.* TO 'webuser';
 quit
 {{< /highlight >}}
 
-1.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
+1.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
         sudo mysql_secure_installation
-
-    Answer **Y** at the following prompts:
-
-    -  Remove anonymous users?
-    -  Disallow root login remotely?
-    -  Remove test database and access to it?
-    -  Reload privilege tables now?
 
 ### PHP
 

--- a/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-20-04/index.md
+++ b/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-20-04/index.md
@@ -225,7 +225,7 @@ GRANT ALL ON webdata.* TO 'webuser';
 quit
 {{< /highlight >}}
 
-1.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. This tool will ask if you want to set a new password for the MySQL root user, but you can skip that step:
+1.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
 
         sudo mysql_secure_installation
 

--- a/docs/guides/web-servers/lemp/how-to-install-the-lemp-stack-on-centos-8/index.md
+++ b/docs/guides/web-servers/lemp/how-to-install-the-lemp-stack-on-centos-8/index.md
@@ -81,7 +81,7 @@ GRANT ALL PRIVILEGES ON testdb.* TO 'testuser';
 quit
 {{< /highlight >}}
 
-5.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. This tool will ask if you want to set a new password for the MySQL root user, but you can skip that step:
+5.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
 
         sudo mysql_secure_installation
 

--- a/docs/guides/web-servers/lemp/how-to-install-the-lemp-stack-on-centos-8/index.md
+++ b/docs/guides/web-servers/lemp/how-to-install-the-lemp-stack-on-centos-8/index.md
@@ -81,16 +81,9 @@ GRANT ALL PRIVILEGES ON testdb.* TO 'testuser';
 quit
 {{< /highlight >}}
 
-5.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. The system asks if you want to enable the `VALIDATE PASSWORD COMPONENT`. This feature ensures that all created passwords are strong and unique. Answer `n` (as in "no"). When prompted, type and verify a new secure password for the MySQL admin user.
+5.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
         sudo mysql_secure_installation
-
-    Answer **Y** at the following prompts:
-
-    -  Remove anonymous users?
-    -  Disallow root login remotely?
-    -  Remove test database and access to it?
-    -  Reload privilege tables now?
 
 ### PHP
 

--- a/docs/guides/web-servers/lemp/how-to-install-the-lemp-stack-on-debian-10/index.md
+++ b/docs/guides/web-servers/lemp/how-to-install-the-lemp-stack-on-debian-10/index.md
@@ -88,16 +88,9 @@ GRANT ALL PRIVILEGES ON testdb.* TO 'testuser';
 quit
 {{< /highlight >}}
 
-5.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. This tool will ask if you want to set a new password for the MariaDB root user, but you can skip that step:
+5.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
         sudo mysql_secure_installation
-
-    Answer **Y** at the following prompts:
-
-    -  Remove anonymous users?
-    -  Disallow root login remotely?
-    -  Remove test database and access to it?
-    -  Reload privilege tables now?
 
 ### PHP
 

--- a/docs/guides/web-servers/lemp/how-to-install-the-lemp-stack-on-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/lemp/how-to-install-the-lemp-stack-on-ubuntu-18-04/index.md
@@ -86,16 +86,9 @@ GRANT ALL PRIVILEGES ON testdb.* TO 'testuser';
 quit
 {{< /highlight >}}
 
-5.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. This tool will ask if you want to set a new password for the MariaDB root user, but you can skip that step:
+5.  Use the *[mysql_secure_installation](https://mariadb.com/kb/en/library/mysql_secure_installation/)* tool to configure additional security options. You will be given the choice to change the MariaDB root password, remove anonymous user accounts, disable root logins outside of localhost, and remove test databases. It is recommended that you answer `yes` to these options. You can read more about the script in the [MariaDB Knowledge Base](https://mariadb.com/kb/en/mariadb/mysql_secure_installation/).
 
         sudo mysql_secure_installation
-
-    Answer **Y** at the following prompts:
-
-    -  Remove anonymous users?
-    -  Disallow root login remotely?
-    -  Remove test database and access to it?
-    -  Reload privilege tables now?
 
 ### PHP
 


### PR DESCRIPTION
When you run mysql_secure_installation tool the system prompts you to change the root password. Added information to create a root password.

Fixes: https://github.com/linode/docs/issues/5528