### PR TITLE
[Security] Update minimatch from 3.0.4 to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2948,9 +2948,9 @@
    "dev": true
   },
   "node_modules/minimatch": {
-   "version": "3.0.4",
-   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+   "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
    "dev": true,
    "dependencies": {
     "brace-expansion": "^1.1.7"
@@ -6201,9 +6201,9 @@
    "dev": true
   },
   "minimatch": {
-   "version": "3.0.4",
-   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+   "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
    "dev": true,
    "requires": {
     "brace-expansion": "^1.1.7"


### PR DESCRIPTION
Fixes this [vulnerability](https://github.com/linode/docs/security/dependabot/11).