### PR TITLE
Updates to incoming and outgoing DNS zone transfers

### DIFF
--- a/docs/products/networking/dns-manager/guides/incoming-dns-zone-transfers/index.md
+++ b/docs/products/networking/dns-manager/guides/incoming-dns-zone-transfers/index.md
@@ -5,6 +5,7 @@ author:
 description: "Learn how to import DNS records from external DNS providers by using AXFR transfers"
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-10-28
+modified: 2022-11-02
 modified_by:
   name: Linode
 title: "Incoming DNS Zone Transfers"
@@ -19,20 +20,26 @@ Linode supports importing DNS records from external DNS providers in one of two 
 
 ## Before You Begin
 
-Verify that your current DNS provider offers the ability to perform outgoing DNS zone transfers (responds to AXFR queries). If they do, determine which name server you can use and make sure that name server allows AXFR queries from the following IP addresses.
+As part of DNS zone transfers, Linode sends an AXFR query to whichever external name server you specify. That external name server must then send back an AXFR response, which includes a copy of the DNS zone file data.
 
-```
-96.126.114.97
-96.126.114.98
-2600:3c00::5e
-2600:3c00::5f
-```
+**Before continuing, verify that your current external DNS provider offers the ability to perform outgoing DNS zone transfers through AXFR.** If they do, add the IP addresses for Linode's AXFR servers to the ACL or allow-list of that DNS provider. These IP addresses vary depending on if you're importing a zone or operating as a secondary and are listed in their corresponding section below.
 
-This process varies by DNS provider or software you are using and is typically available on enterprise-level plans. If your DNS provider does not support AXFR queries, you may need to create an empty domain zone and manually add each DNS record. See [Create a Domain](/docs/products/networking/dns-manager/guides/create-domain/).
+{{< note >}}
+AXFR functionality is typically available on enterprise-level plans. If your DNS provider does not support AXFR, DNS zone transfers will not work. If you still wish to use Linode's name servers, you can instead manually create the DNS zone and update it as needed. See [Create a Domain](/docs/products/networking/dns-manager/guides/create-domain/).
+{{</ note >}}
 
 ## Import a DNS Zone
 
 This section walks you through the first option, importing a DNS zone. This method gathers all of the DNS records from an external DNS service, creates a new domain zone within the DNS Manager, and imports each record into new zone.
+
+1. Within your external name server, allow AXFR transfers to the following Linode IP addresses:
+
+    ```
+    96.126.114.97
+    96.126.114.98
+    2600:3c00::5e
+    2600:3c00::5f
+    ```
 
 1. Log in to the [Cloud Manager](https://cloud.linode.com/) and select **Domains** from the left navigation menu. Click the **Import a Zone** button.
 
@@ -53,6 +60,21 @@ Using Linode's DNS Manager as a *secondary* DNS service allows you to manage you
 - or does not implement any high availability features.
 
 As part of this, a common reason for using Linode's DNS Manager as a secondary DNS provider is if your primary name server is self-hosted. This is true for users of cPanel, Plesk, and other web-hosting panels. It is also true for power-users that prefer to run their own dedicated DNS software, such as BIND, and manually update their DNS zone files. In these cases, you may value the control or automation from your current solution, but you desire more reliability and availability.
+
+1. Within your primary name server, allow AXFR transfer from the following Linode IP addresses. You should also make sure your name server sends NOTIFY requests to these IP addresses, which serves to notify Linode of any DNS changes so an AXFR zone transfer is triggered.
+
+    ```
+    104.237.137.10
+    65.19.178.10
+    74.207.225.10
+    207.192.70.10
+    109.74.194.10
+    2600:3c00::a
+    2600:3c01::a
+    2600:3c02::a
+    2600:3c03::a
+    2a01:7e00::a
+    ```
 
 1. Log in to the [Cloud Manager](https://cloud.linode.com/) and select **Domains** from the left navigation menu. Click the **Create Domain** button.
 

--- a/docs/products/networking/dns-manager/guides/outgoing-dns-zone-transfers/index.md
+++ b/docs/products/networking/dns-manager/guides/outgoing-dns-zone-transfers/index.md
@@ -26,7 +26,7 @@ To perform AXFR transfers, you must specify the IP address for each external DNS
 
 Before continuing, make sure that you've added your domain to the external DNS provider you wish to use. When creating the domain zone on that provider, you may be given the option to create it as a *secondary* (or *read-only*) zone. Make sure to select that option. If you do not know how to create a secondary domain zone on that DNS provider, you may need to consult their documentation or contact them for assistance.
 
-To facilitate quick updates, Linode immediately sends the external name servers a NOTIFY request when you update DNS records through the DNS Manager. If you wish to have this trigger an AXFR zone transfer, you will likely need to add the following IP addresses to the ACL or allow-list of those name servers. If you do not do this, the external name servers will only update DNS records when the refresh time has elasped.
+To facilitate quick updates, Linode immediately sends the external name servers a NOTIFY request when you update DNS records through the DNS Manager. If you wish to have this trigger an AXFR zone transfer, you will likely need to add the following IP addresses to the ACL or allow-list of those name servers. If you do not do this, the external name servers will only update DNS records when the refresh time has elapsed.
 
 ```
 104.237.137.10

--- a/docs/products/networking/dns-manager/guides/outgoing-dns-zone-transfers/index.md
+++ b/docs/products/networking/dns-manager/guides/outgoing-dns-zone-transfers/index.md
@@ -4,33 +4,58 @@ author:
   email: docs@linode.com
 description: "How to transfer domain zones using the Linode DNS Manager."
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2022-10-28
+published: 2020-07-21
+modified: 2022-11-02
 modified_by:
   name: Linode
-published: 2020-07-21
 title: "Outgoing DNS Zone Transfers"
 keywords: ["dns"]
 tags: ["linode platform","cloud manager"]
 aliases: ['/products/networking/dns-manager/guides/transfer-domain-zones/']
 ---
 
-Linode's DNS servers allow Domain zone transfers to non-Linode DNS servers that you designate and trust. This feature can be used to transfer a Domain zone to another hosting provider's DNS servers. To enable this capability, you will need to alter your Domain's SOA record. This section will cover these steps.
+When a domain zone is created within Linode's DNS Manager, you can select if it will operate as a *primary* or a read-only *secondary* zone (see [Select the Zone Type](/docs/products/networking/dns-manager/guides/create-domain/#select-the-zone-type)). Selecting *primary* allows you to edit the DNS records directly within the DNS Manager and is the most common choice.
+
+If you have configured your domain zone as *primary*, you can designate external DNS name servers as *secondaries*. The DNS Manager will then send a NOTIFY request to those name servers when you make any DNS changes. The external name server should then respond back with an AXFR query, which triggers Linode to send an AXFR response with the updated DNS zone. This guide covers the configuration needed to perform outgoing DNS zone transfers, including updating your SOA record.
 
 {{< caution >}}
-Granting another server access to zone information is potentially dangerous. Do not add any IP addresses that you do not know or trust.
+To perform AXFR transfers, you must specify the IP address for each external DNS name server you wish to use. Granting another server access to zone information is potentially dangerous. Do not add any IP addresses that you do not know or trust.
 {{</ caution >}}
 
-1. From the **Domains** section of the Cloud Manager, find the domain for which you would like to enable Domain zone transfer and click on the entry to access its Domain records.
+## Configure the External DNS Provider
 
-1. Viewing your Domain's records, under the **SOA Record** section, click on the **more options ellipsis** corresponding to your Domain's SOA records and select **Edit**.
+Before continuing, make sure that you've added your domain to the external DNS provider you wish to use. When creating the domain zone on that provider, you may be given the option to create it as a *secondary* (or *read-only*) zone. Make sure to select that option. If you do not know how to create a secondary domain zone on that DNS provider, you may need to consult their documentation or contact them for assistance.
 
-1. In the **Edit SOA Record** pane, find the **Domain Transfer IPs** section and enter the IP addresses corresponding to the DNS servers you'd like to give access to your Domain's zone file. Each field should contain a single IP address and additional fields will appear when the **Add an IP** link is clicked.
+To facilitate quick updates, Linode immediately sends the external name servers a NOTIFY request when you update DNS records through the DNS Manager. If you wish to have this trigger an AXFR zone transfer, you will likely need to add the following IP addresses to the ACL or allow-list of those name servers. If you do not do this, the external name servers will only update DNS records when the refresh time has elasped.
 
-1. When you've completed your update, click on **Save**.
+```
+104.237.137.10
+65.19.178.10
+74.207.225.10
+207.192.70.10
+109.74.194.10
+2600:3c00::a
+2600:3c01::a
+2600:3c02::a
+2600:3c03::a
+2a01:7e00::a
+```
 
-    {{< note >}}
-When the DNS servers no longer need access to your Domain's zone file, remove the IP address from the **Domain Transfers** field.
+## Add Secondary Name Servers
+
+1. Log in to the [Cloud Manager](https://cloud.linode.com), select *Domains* from the left menu, and click on the domain you wish to update.
+
+1. Locate the **SOA Record** section and click **Edit**. This action may appear within the corresponding **ellipsis** menu.
+
+1. In the **Edit SOA Record** pane, find the **Domain Transfer IPs**. Add the IP addresses for each external name server you wish to notify of DNS changes and send the DNS zone. To add each additional IP address, click **Add an IP**.
+
+1. Click on **Save** to keep the changes.
+
+{{< note >}}
+If you ever decide to stop using the secondary name server, be sure to remove its IP address from this list.
 {{</ note >}}
+
+## Test AXFR Transfers
 
 When performing the AXFR DNS query, point your secondary name server to `axfr1.linode.com` (or up to `axfr5.linode.com`) instead of `ns1.linode.com`. To test the AXFR query locally, follow the above instructions to allow your computer's IP address as one of the ****Domain Transfer IPs**** in the SOA Record for your domain. This may take a few minutes before going into effect. Then run the following `dig` command, replacing **example.com** with your domain:
 


### PR DESCRIPTION
This PR updates content related to AXFR transfers.

- **Incoming DNS Zone Transfers**: Removes IP address list from the Before You Begin section. The correct list of Linode AXFR server IP addresses then appears within each of the individual sections, as this list of IPs is different for each task.
- **Outgoing DNS Zone Transfers**: Refresh of the entire page, which was mostly untouched in the previous releases. As part of this, the Linode AXFR server IPs are added to this guide.