### PR TITLE
[update] Installing a Mastodon Server on CentOS 8, Debian 10, Ubuntu 20.04

### DIFF
--- a/docs/guides/applications/messaging/install-mastodon-on-debian-10/index.md
+++ b/docs/guides/applications/messaging/install-mastodon-on-debian-10/index.md
@@ -59,6 +59,9 @@ Mastodon servers range in size from small private instances to massive public in
 1. Prepare an SMTP server for Mastodon to send email notifications to users when they register for the site, get a follower, receive a message, and for other Mastodon activity.
 
     - You can create your own SMTP server — and even host it on the same machine as your Mastodon server — by following the [Email with Postfix, Dovecot, and MySQL](/docs/guides/email-with-postfix-dovecot-and-mysql/) guide.
+    {{< note >}}
+     This guide uses PostgreSQL database as a backend for Mastodon. You can setup the SMTP server with PostgreSQL database instead of MySQL.
+    {{< /note >}}
 
     - Alternatively, you can use a third-party SMTP service. This guide provides instructions for using [Mailgun](https://www.mailgun.com/) as your SMTP provider.
 

--- a/docs/guides/applications/messaging/install-mastodon-on-ubuntu-2004/index.md
+++ b/docs/guides/applications/messaging/install-mastodon-on-ubuntu-2004/index.md
@@ -58,6 +58,10 @@ Mastodon servers range in size from small private instances to massive public in
 
     - You can create your SMTP server — and even host it on the same machine as your Mastodon server — by following the [Email with Postfix, Dovecot, and MySQL](/docs/guides/email-with-postfix-dovecot-and-mysql/) guide.
 
+     {{< note >}}
+     This guide uses PostgreSQL database as a backend for Mastodon. You can setup the SMTP server with PostgreSQL database instead of MySQL.
+    {{< /note >}}
+
     - Alternatively, you can use a third-party SMTP service. This guide provides instructions for using [Mailgun](https://www.mailgun.com/) as your SMTP provider.
 
 1. Replace occurrences of `example.com` in this guide with the domain name you are using for your Mastodon instance.

--- a/docs/guides/applications/messaging/install-mastodon-server-on-centos-stream/index.md
+++ b/docs/guides/applications/messaging/install-mastodon-server-on-centos-stream/index.md
@@ -58,6 +58,10 @@ Mastodon servers range in size from small private instances to massive public in
 
     - You can create your SMTP server — and even host it on the same machine as your Mastodon server — by following the [Email with Postfix, Dovecot, and MySQL](/docs/guides/email-with-postfix-dovecot-and-mysql/) guide.
 
+     {{< note >}}
+     This guide uses PostgreSQL database as a backend for Mastodon. You can setup the SMTP server with PostgreSQL database instead of MySQL.
+    {{< /note >}}
+
     - Alternatively, you can use a third-party SMTP service. This guide provides instructions for using [Mailgun](https://www.mailgun.com/) as your SMTP provider.
 
 1. Replace occurrences of `example.com` in this guide with the domain name you are using for your Mastodon instance.


### PR DESCRIPTION
Added a note about using PostgreSQL server as backend.

I did not add a note for the Mastadon guide for Ubuntu 16.04 because that guide uses MySQL.

Fixes: [5872 ](https://github.com/linode/docs/issues/5872)