### PR TITLE
[Update] Manage Block Storage Volumes with the Linode API

### DIFF
--- a/docs/guides/platform/api/create-block-storage-volumes-with-the-linode-api/index.md
+++ b/docs/guides/platform/api/create-block-storage-volumes-with-the-linode-api/index.md
@@ -6,12 +6,12 @@ author:
 description: "This guide demonstrate how to create, attach, clone, and resize Volumes using the Linode API."
 keywords: ["linode api", "block storage", "volume"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2018-05-14
+modified: 2022-11-16
 modified_by:
   name: Linode
 published: 2018-05-14
 title: "How to Manage Block Storage Volumes with the Linode API"
-h1_title: "Managing Block Storage Volumes with the Linode API"
+h1_title: "Manage Block Storage Volumes with the Linode API"
 enable_h1: true
 external_resources:
   - '[API Documentation](https://developers.linode.com/api/v4)'
@@ -155,3 +155,7 @@ Pass the desired size (in gigabytes) using the `size` parameter:
         "size": 200
     }' \
     https://api.linode.com/v4/volumes/$volume_id/resize
+
+{{< note >}}
+After resizing the Volume, you also need to resize the file system to accommodate the additional space. For instructions, see the last few steps on the [Resize a Volume](/docs/products/storage/block-storage/guides/resize-volume/) guide.
+{{</ note >}}


### PR DESCRIPTION
This PR adds a note to the resize section of the guide on managing Block Storage volumes in the API. The note informs readers they will need to resize the file system on the volume after resizing the volume itself.

> After resizing the Volume, you also need to resize the file system to accommodate the additional space. For instructions, see the last few steps on the [Resize a Volume](/docs/products/storage/block-storage/guides/resize-volume/) guide.