### PR TITLE
[Update] Capture an Image

### DIFF
--- a/docs/products/tools/images/guides/capture-an-image/index.md
+++ b/docs/products/tools/images/guides/capture-an-image/index.md
@@ -4,6 +4,7 @@ author:
   email: docs@linode.com
 title: Capture an Image
 description: "How to capture an Image from a Linode."
+modified: 2022-11-16
 ---
 
 ## Requirements and Considerations
@@ -12,7 +13,9 @@ When capturing an image file from an existing Linode Compute Instance, keep the 
 
 - Review the overall [Technical Specifications](/docs/products/tools/images/#technical-specifications) of the Custom Images service.
 
-- **Disk must be formatted using ext3/ext4 filesystems.** Images cannot be created if you are using raw disks or disks that have been formatted using custom filesystems. CoreOS disk images are in RAW format. Images made from CoreOS disks can't be used to deploy new Linodes.
+- **The disk's internal storage utilization must be 10% less than the account's image size limit** (6 GB by default). To check the internal disk usage, log in to the Compute Instance and run `df -h`. Within the output, locate the disk and review the value within the **Used** column.
+
+- **The disk must be formatted using ext3/ext4 filesystems.** Images cannot be created if you are using raw disks or disks that have been formatted using custom filesystems. CoreOS disk images are in RAW format. Images made from CoreOS disks can't be used to deploy new Linodes.
 
 - **Power off Linode to avoid database corruption.** If your Linode is running any active databases, it's recommended to power off the Linode down prior to creating the image. Creating an image that includes a running database can cause corruption or data loss in the imaged copy of the database.
 


### PR DESCRIPTION
This PR adds information regarding the internal storage utilization when caturing an image. Specifically, the internal storage utilization must be 10% less than the account's image size limit (6 GB by default). 