### PR TITLE
[Update] LKE networking information and suggested firewall rules

### DIFF
--- a/docs/guides/kubernetes/lke-network-firewall-information-shortguide/index.md
+++ b/docs/guides/kubernetes/lke-network-firewall-information-shortguide/index.md
@@ -7,7 +7,7 @@ description: 'Language that describes the options for creating workloads on Lino
 keywords: []
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2020-04-06
-modified: 2020-04-06
+modified: 2022-11-22
 modified_by:
   name: Linode
 title: "Network and Filewall Information for Linode Kubernetes Engine Clusters"
@@ -17,24 +17,35 @@ tags: ["kubernetes"]
 aliases: ['/kubernetes/lke-network-firewall-information-shortguide/']
 ---
 
-In an LKE cluster, both of the following types of workload endpoints *cannot* be reached from the Internet:
+In an LKE cluster, some entities and services are only accessible from within that cluster while others are publicly accessible (reachable from the internet).
 
--   Pod IPs, which use a per-cluster virtual network in the range 10.2.0.0/16
+**Private (accessible only within the cluster)**
 
--   ClusterIP Services, which use a per-cluster virtual network in the range 10.128.0.0/16
+- Pod IPs, which use a per-cluster virtual network in the range 10.2.0.0/16
+- ClusterIP Services, which use a per-cluster virtual network in the range 10.128.0.0/16
 
-All of the following types of workloads *can* be reached from the Internet:
+**Public (accessible over the internet)**
 
--   NodePort Services, which listen on all Nodes with ports in the range 30000-32768.
+- NodePort Services, which listen on all Nodes with ports in the range 30000-32768.
+- LoadBalancer Services, which automatically deploy and configure a NodeBalancer.
+- Any manifest which uses hostNetwork: true and specifies a port.
+- Most manifests which use hostPort and specify a port.
 
--   LoadBalancer Services, which automatically deploy and configure a NodeBalancer.
+Exposing workloads to the public internet through the above methods can be convenient, but this can also carry a security risk. You may wish to manually install firewall rules on your cluster nodes. The following policies are needed to allow communication between the node pools and the control plane and block unwanted traffic:
 
--   Any manifest which uses hostNetwork: true and specifies a port.
+- **ALlow kubelet health checks:** TCP port 10250 from 192.168.128.0/17 Accept
+- **Allow Wireguard tunneling for kubectl proxy:** UDP port 51820 from 192.168.128.0/17 Accept
+- **Allow Calico BGP traffic:** TCP port 179 from 192.168.128.0/17 Accept
+- **Allow NodePorts for workload services:** TCP/UDP port 30000 - 32767 192.168.128.0/17 Accept
+- **Block all other TCP traffic:** TCP All Ports All IPv4/All IPv6 Drop
+- **Block all other UDP traffic:** UDP All Ports All IPv4/All IPv6 Drop
+- **Block all ICMP traffic:** ICMP All Ports All IPv4/All IPv6 Drop
+- IPENCAP for IP ranges 192.168.128.0/17 for internal communication between node pools and control plane.
 
--   Most manifests which use hostPort and specify a port.
+For additional information, [please see this community post](https://www.linode.com/community/questions/19155/securing-k8s-cluster). Future LKE release may allow greater flexibility for the network endpoints of these types of workloads.
 
-Exposing workloads to the public Internet through the above methods can be convenient, but they can also carry a security risk. You may wish to manually install firewall rules on your cluster nodes; to do so, [please see this community post](https://www.linode.com/community/questions/19155/securing-k8s-cluster). Linode is developing services which will allow for greater flexibility for the network endpoints of these types of workloads in the future.
+Please note, at this time, nodes should be removed from the Cloud Firewall configuration before removing/recycling of node pools within the Kubernetes configuration. Also, when adding node pools to the Kubernetes cluster, Cloud Firewall must be updated with the new node pool(s). Failure to add the new nodes creates a security risk.
 
 {{< note >}}
- All new LKE clusters will create a service named `Kubernetes` in the `default` namespace designed to ease interactions with the control plane. This is a standard service for LKE clusters.
- {{< /note >}}
+All new LKE clusters create a service named `Kubernetes` in the `default` namespace designed to ease interactions with the control plane. This is a standard service for LKE clusters.
+{{< /note >}}


### PR DESCRIPTION
This PR updates the `lke-network-firewall-information-shortguide` shortguide, which appears in 3 LKE guides. The updates include adding suggested firewall rules for LKE.