### PR TITLE
Update IP Sharing and Network Upgrade content for Sydney

### DIFF
--- a/docs/guides/networking/linode-network/network-infrastructure-upgrades/index.md
+++ b/docs/guides/networking/linode-network/network-infrastructure-upgrades/index.md
@@ -7,7 +7,7 @@ description: "An overview of changes and actions that may be required in advance
 keywords: ['networking']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-07-19
-modified: 2022-10-11
+modified: 2022-12-01
 modified_by:
   name: Linode
 title: "Upcoming Changes Related to Network Infrastructure Upgrades"
@@ -50,7 +50,7 @@ Review the table below to learn which data centers have been upgraded with the l
 | **Mumbai (India)** | **Complete** |
 | **Newark (New Jersey, USA)** | **Complete** |
 | **Singapore** | **Complete** |
-| Sydney (Australia) | *Coming soon* |
+| **Sydney (Australia)** | **Complete** |
 | Tokyo (Japan) | *Coming soon* |
 | Toronto (Canada) | *Coming soon* |
 


### PR DESCRIPTION
- Marked Sydney as having completed the network infrastructure upgrades
- Mark Sydney has supporting IP Sharing through BGP
- Update formatting of Configure Failover on a Compute Instance guide.