### PR TITLE
Update marketplace app titles (to use Deploy instead of Deploying)

### DIFF
--- a/archetypes/marketplace.md
+++ b/archetypes/marketplace.md
@@ -1,7 +1,6 @@
 ---
-slug: {{ path.Base .File.Dir }}
 author:
-  name: Linode Community
+  name: Linode
   email: docs@linode.com
 description: "Two to three sentences describing your guide."
 og_description: "Two to three sentences describing your guide when shared on social media. Delete this if not needed."
@@ -11,10 +10,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: {{ now.Format "2006-01-02" }}
 modified_by:
   name: Linode
-title: "Deploying ___App_Name___ through the Linode Marketplace"
-contributor:
-  name: Your Name
-  link: Github/Twitter Link
+title: "Deploy ___App_Name___ through the Linode Marketplace"
 external_resources:
 - '[Link Title 1](http://www.example.com)'
 - '[Link Title 2](http://www.example.net)'
@@ -28,23 +24,20 @@ external_resources:
 
 {{< content "marketplace-verify-standard-shortguide">}}
 
-{{<note>}}
+{{< note >}}
 **Estimated deployment time for ___App_Name___:** The software should be fully installed within 2-5 minutes.
-{{</note>}}
+{{< /note >}}
 
 ## Configuration Options
 
-- **Supported distributions:** Debian 9
+- **Supported distributions:** Debian 11
 - **Recommended plan:** All plan types and sizes can be used.
 
 ### ___App_Name___ Options
 
-<!-- The following table has three parts. The UDF name, in bold and in one column, followed by
-     UDF description in the second column. The description is in normal text, with an optional
-     "Required." tag at the end of the description, in italics, if the field is mandatory. -->
-| **Field** | **Description** |
-|:--------------|:------------|
-| **UDF** | Description of UDF. *Required*. |
+<!-- List each UDF field. Include a description and note if it is required. -->
+
+- **Field name** (*required*): Description of the field.
 
 ## Getting Started after Deployment
 

--- a/docs/products/tools/marketplace/guides/aapanel/index.md
+++ b/docs/products/tools/marketplace/guides/aapanel/index.md
@@ -10,7 +10,7 @@ published: 2021-08-13
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying aaPanel through the Linode Marketplace"
+title: "Deploy aaPanel through the Linode Marketplace"
 aliases: ['/guides/deploying-aapanel-marketplace-app/','/guides/aapanel-marketplace-app/']
 external_resources:
 - '[aaPanel](https://www.aapanel.com/)'

--- a/docs/products/tools/marketplace/guides/akaunting/index.md
+++ b/docs/products/tools/marketplace/guides/akaunting/index.md
@@ -10,7 +10,7 @@ published: 2022-01-25
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Akaunting through the Linode Marketplace"
+title: "Deploy Akaunting through the Linode Marketplace"
 external_resources:
 - '[Akaunting](https://akaunting.com)'
 aliases: ['/guides/deploying-akaunting-marketplace-app/','/guides/akaunting-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/antmediaenterpriseserver/index.md
+++ b/docs/products/tools/marketplace/guides/antmediaenterpriseserver/index.md
@@ -10,7 +10,7 @@ published: 2022-03-29
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying Ant Media Server Enterprise Edition through the Linode Marketplace"
+title: "Deploy Ant Media Server Enterprise Edition through the Linode Marketplace"
 external_resources:
 - '[Ant Media](https://antmedia.io)'
 - '[Document](https://github.com/ant-media/Ant-Media-Server/wiki)'

--- a/docs/products/tools/marketplace/guides/antmediaserver/index.md
+++ b/docs/products/tools/marketplace/guides/antmediaserver/index.md
@@ -10,7 +10,7 @@ published: 2021-03-30
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying Ant Media Server Community Edition through the Linode Marketplace"
+title: "Deploy Ant Media Server Community Edition through the Linode Marketplace"
 external_resources:
 - '[Ant Media](https://antmedia.io)'
 - '[Document](https://github.com/ant-media/Ant-Media-Server/wiki)'

--- a/docs/products/tools/marketplace/guides/ark-survival-evolved/index.md
+++ b/docs/products/tools/marketplace/guides/ark-survival-evolved/index.md
@@ -9,7 +9,7 @@ published: 2019-04-03
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying an ARK Survival Evolved Server through the Linode Marketplace"
+title: "Deploy an ARK Survival Evolved Server through the Linode Marketplace"
 external_resources:
  - '[The Official ARK: Survival Evolved Wiki](https://ark.gamepedia.com/ARK_Survival_Evolved_Wiki)'
 tags: ["linode platform","marketplace","cloud-manager"]

--- a/docs/products/tools/marketplace/guides/azuracast/index.md
+++ b/docs/products/tools/marketplace/guides/azuracast/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: DeployAzuraCast_OneClickApps.png
 modified_by:
   name: Linode
-title: "Deploying AzuraCast through the Linode Marketplace"
+title: "Deploy AzuraCast through the Linode Marketplace"
 external_resources:
 - '[About AzuraCast](https://www.azuracast.com/about/)'
 - '[Troubleshooting AzuraCast](https://www.azuracast.com/help/)'

--- a/docs/products/tools/marketplace/guides/beef/index.md
+++ b/docs/products/tools/marketplace/guides/beef/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying BeEF through the Linode Marketplace"
+title: "Deploy BeEF through the Linode Marketplace"
 external_resources:
 - '[BeEF](https://beefproject.com/)'
 aliases: ['/guides/deploying-beef-marketplace-app/','/guides/beef-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/bitninja/index.md
+++ b/docs/products/tools/marketplace/guides/bitninja/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying BitNinja through the Linode Marketplace"
+title: "Deploy BitNinja through the Linode Marketplace"
 external_resources:
 - '[BitNinja](https://bitninja.com/)'
 aliases: ['/guides/deploying-bitninja-marketplace-app/','/guides/bitninja-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/budibase/index.md
+++ b/docs/products/tools/marketplace/guides/budibase/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-08-09
 modified_by:
   name: Linode
-title: "Deploying Budibase through the Linode Marketplace"
+title: "Deploy Budibase through the Linode Marketplace"
 ---
 
 [Budibase](https://github.com/Budibase/budibase) is an open-source, low-code platform for building modern business applications. Build, design, and automate different types of applications, including admin panels, forms, internal tools, and client portals. Using Budibase helps developers avoid spending weeks building simple CRUD applications and, instead, allows them to complete many projects in significantly less time.

--- a/docs/products/tools/marketplace/guides/chevereto/index.md
+++ b/docs/products/tools/marketplace/guides/chevereto/index.md
@@ -10,7 +10,7 @@ published: 2021-08-13
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying Chevereto through the Linode Marketplace"
+title: "Deploy Chevereto through the Linode Marketplace"
 external_resources:
 - '[Chevereto](https://chevereto.com/)'
 - '[Chevereto Documentation](https://chevereto.com/docs)'

--- a/docs/products/tools/marketplace/guides/cloudron/index.md
+++ b/docs/products/tools/marketplace/guides/cloudron/index.md
@@ -10,7 +10,7 @@ published: 2020-12-15
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying Cloudron through the Linode Marketplace"
+title: "Deploy Cloudron through the Linode Marketplace"
 external_resources:
 - '[Cloudron Documentation](https://docs.cloudron.io)'
 aliases: ['/platform/marketplace/how-to-deploy-cloudron-with-marketplace-apps/', '/platform/one-click/how-to-deploy-cloudron-with-one-click-apps/','/guides/how-to-deploy-cloudron-with-one-click-apps/','/guides/deploy-cloudron-with-marketplace-apps/','/guides/cloudron-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/clustercontrol/index.md
+++ b/docs/products/tools/marketplace/guides/clustercontrol/index.md
@@ -10,7 +10,7 @@ published: 2021-08-13
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying ClusterControl through the Linode Marketplace"
+title: "Deploy ClusterControl through the Linode Marketplace"
 aliases: ['/guides/deploying-clustercontrol-marketplace-app/','/guides/clustercontrol-marketplace-app/']
 external_resources:
 - '[ClusterControl](https://severalnines.com/product/clustercontrol/clustercontrol-community-edition)'

--- a/docs/products/tools/marketplace/guides/counter-strike-go/index.md
+++ b/docs/products/tools/marketplace/guides/counter-strike-go/index.md
@@ -9,7 +9,7 @@ published: 2019-03-28
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying Counter-Strike Global Offensive through the Linode Marketplace"
+title: "Deploy Counter-Strike Global Offensive through the Linode Marketplace"
 external_resources:
 - '[List of CS:GO Cvar Commands to use with RCON](https://developer.valvesoftware.com/wiki/List_of_CS:GO_Cvars)'
 tags: ["linode platform","marketplace","cloud-manager"]

--- a/docs/products/tools/marketplace/guides/cpanel/index.md
+++ b/docs/products/tools/marketplace/guides/cpanel/index.md
@@ -10,7 +10,7 @@ published: 2020-03-13
 modified: 2022-05-31
 modified_by:
   name: Linode
-title: "Deploying cPanel through the Linode Marketplace"
+title: "Deploy cPanel through the Linode Marketplace"
 external_resources:
 - '[WHM Feature Documentation](https://documentation.cpanel.net/display/78Docs/WHM+Features+List)'
 aliases: ['/platform/marketplace/how-to-deploy-cpanel-with-marketplace-apps/', '/platform/one-click/how-to-deploy-cpanel-with-one-click-apps/','/guides/how-to-deploy-cpanel-with-one-click-apps/','/guides/how-to-deploy-cpanel-with-marketplace-apps/','/guides/cpanel-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/cyberpanel/index.md
+++ b/docs/products/tools/marketplace/guides/cyberpanel/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: DeployCyberPanel_marketplaceapps.png
 modified_by:
   name: Linode
-title: "Deploying CyberPanel through the Linode Marketplace"
+title: "Deploy CyberPanel through the Linode Marketplace"
 external_resources:
 - '[CyberPanel](https://docs.litespeedtech.com/cloud/images/cyberpanel/)'
 aliases: ['/guides/deploy-cyberpanel-with-marketplace-apps/','/guides/cyberpanel-marketplace-app']

--- a/docs/products/tools/marketplace/guides/discourse/index.md
+++ b/docs/products/tools/marketplace/guides/discourse/index.md
@@ -10,7 +10,7 @@ published: 2020-11-19
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Discourse through the Linode Marketplace"
+title: "Deploy Discourse through the Linode Marketplace"
 external_resources:
 - '[About Discourse](https://discourse.org/about/)'
 - '[Discourse on Github](https://github.com/discourse/discourse)'

--- a/docs/products/tools/marketplace/guides/django/index.md
+++ b/docs/products/tools/marketplace/guides/django/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: Django_oneclickapps.png
 modified_by:
   name: Linode
-title: "Deploying Django through the Linode Marketplace"
+title: "Deploy Django through the Linode Marketplace"
 aliases: ['/platform/marketplace/how-to-deploy-django-with-marketplace-apps/','/platform/marketplace/deploying-django-with-marketplace-apps/', '/platform/one-click/how-to-deploy-django-with-one-click-apps/', '/platform/one-click/deploying-django-with-one-click-apps/','/guides/how-to-deploy-django-with-one-click-apps/','/guides/how-to-deploy-django-with-marketplace-apps/','/guides/django-marketplace-app/']
 external_resources:
  - '[The Django Project](https://www.djangoproject.com/)'

--- a/docs/products/tools/marketplace/guides/docker/index.md
+++ b/docs/products/tools/marketplace/guides/docker/index.md
@@ -6,7 +6,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2020-03-11
 modified: 2022-04-01
 image: Docker_oneclickapps.png
-title: "Deploying Docker through the Linode Marketplace"
+title: "Deploy Docker through the Linode Marketplace"
 external_resources:
  - '[Docker Commands Cheat Sheet](/docs/guides/docker-commands-quick-reference-cheat-sheet/)'
  - '[Docker Documentation](https://docs.docker.com/)'

--- a/docs/products/tools/marketplace/guides/drupal/index.md
+++ b/docs/products/tools/marketplace/guides/drupal/index.md
@@ -10,7 +10,7 @@ published: 2019-03-25
 modified: 2022-07-11
 modified_by:
   name: Linode
-title: "Deploying Drupal through the Linode Marketplace"
+title: "Deploy Drupal through the Linode Marketplace"
 aliases: ['/platform/marketplace/deploying-drupal-with-marketplace-apps/','/platform/marketplace/how-to-deploy-drupal-with-marketplace-apps/', '/platform/one-click/deploying-drupal-with-one-click-apps/','/guides/deploying-drupal-with-one-click-apps/','/platform/one-click/how-to-deploy-drupal-with-one-click-apps/','/guides/how-to-deploy-drupal-with-one-click-apps/','/guides/how-to-deploy-drupal-with-marketplace-apps/','/guides/drupal-marketplace-app/']
 contributor:
   name: Linode

--- a/docs/products/tools/marketplace/guides/easypanel/index.md
+++ b/docs/products/tools/marketplace/guides/easypanel/index.md
@@ -7,7 +7,7 @@ keywords: ['easypanel','control panel','cpanel']
 tags: ["marketplace", "linode platform", "cloud manager"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-05-31
-title: "Deploying Easypanel through the Linode Marketplace"
+title: "Deploy Easypanel through the Linode Marketplace"
 contributor:
   name: Holden Morris
   link: https://github.com/hmorris3293

--- a/docs/products/tools/marketplace/guides/filecloud/index.md
+++ b/docs/products/tools/marketplace/guides/filecloud/index.md
@@ -10,7 +10,7 @@ published: 2020-03-18
 modified: 2022-06-03
 modified_by:
   name: Linode
-title: "Deploying FileCloud through the Linode Marketplace"
+title: "Deploy FileCloud through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/flask/index.md
+++ b/docs/products/tools/marketplace/guides/flask/index.md
@@ -10,7 +10,7 @@ published: 2020-03-11
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Flask through the Linode Marketplace"
+title: "Deploy Flask through the Linode Marketplace"
 image: Flask_oneclickapps.png
 contributor:
   name: Linode

--- a/docs/products/tools/marketplace/guides/focalboard/index.md
+++ b/docs/products/tools/marketplace/guides/focalboard/index.md
@@ -10,7 +10,7 @@ published: 2022-02-22
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Focalboard through the Linode Marketplace"
+title: "Deploy Focalboard through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/gitea/index.md
+++ b/docs/products/tools/marketplace/guides/gitea/index.md
@@ -10,7 +10,7 @@ published: 2021-01-04
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Gitea through the Linode Marketplace"
+title: "Deploy Gitea through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/gitlab/index.md
+++ b/docs/products/tools/marketplace/guides/gitlab/index.md
@@ -10,7 +10,7 @@ published: 2019-03-27
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Gitlab through the Linode Marketplace"
+title: "Deploy Gitlab through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/grafana/index.md
+++ b/docs/products/tools/marketplace/guides/grafana/index.md
@@ -10,7 +10,7 @@ published: 2020-03-11
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Grafana through the Linode Marketplace"
+title: "Deploy Grafana through the Linode Marketplace"
 image: feature.png
 contributor:
   name: Linode

--- a/docs/products/tools/marketplace/guides/grav/index.md
+++ b/docs/products/tools/marketplace/guides/grav/index.md
@@ -10,7 +10,7 @@ published: 2022-02-22
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Grav through the Linode Marketplace"
+title: "Deploy Grav through the Linode Marketplace"
 contributor:
   name: Holden Morris
   link: https://github.com/hmorris3293

--- a/docs/products/tools/marketplace/guides/guacamole/index.md
+++ b/docs/products/tools/marketplace/guides/guacamole/index.md
@@ -1,6 +1,6 @@
 ---
 author:
-  name: Linode Community
+  name: Linode
   email: docs@linode.com
 description: "Use the Guacamole Marketplace App to easily install the popular open source remote desktop and access your Linode from any device."
 keywords: ['guacamole', 'marketplace', 'remote desktop']
@@ -10,7 +10,7 @@ published: 2020-12-11
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Apache Guacamole through the Linode Marketplace"
+title: "Deploy Apache Guacamole through the Linode Marketplace"
 aliases: ['/platform/marketplace/guacamole/','/guides/deploy-guacamole-with-marketplace-apps/','/guides/guacamole-marketplace-app/']
 contributor:
   name: Linode

--- a/docs/products/tools/marketplace/guides/harbor/index.md
+++ b/docs/products/tools/marketplace/guides/harbor/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Harbor through the Linode Marketplace"
+title: "Deploy Harbor through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/hashicorp-nomad/index.md
+++ b/docs/products/tools/marketplace/guides/hashicorp-nomad/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-08-09
 modified_by:
   name: Linode
-title: "Deploying HashiCorp Nomad through the Linode Marketplace"
+title: "Deploy HashiCorp Nomad through the Linode Marketplace"
 ---
 
 [HashiCorp Nomad](https://www.nomadproject.io/) is a simple and flexible scheduler and orchestrator to deploy and manage containers and non-containerized applications across cloud platforms (and on-premises servers) at scale.

--- a/docs/products/tools/marketplace/guides/hashicorp-vault/index.md
+++ b/docs/products/tools/marketplace/guides/hashicorp-vault/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-08-09
 modified_by:
   name: Linode
-title: "Deploying HashiCorp Vault through the Linode Marketplace"
+title: "Deploy HashiCorp Vault through the Linode Marketplace"
 ---
 
 [HashiCorp Vault](https://www.vaultproject.io/) is an open source, centralized secrets management system. It provides a secure and reliable way of storing and distributing secrets like API keys, access tokens, and passwords.

--- a/docs/products/tools/marketplace/guides/jenkins/index.md
+++ b/docs/products/tools/marketplace/guides/jenkins/index.md
@@ -10,7 +10,7 @@ published: 2020-03-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Jenkins through the Linode Marketplace"
+title: "Deploy Jenkins through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/jetbackup/index.md
+++ b/docs/products/tools/marketplace/guides/jetbackup/index.md
@@ -10,7 +10,7 @@ published: 2021-08-13
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying JetBackup through the Linode Marketplace"
+title: "Deploy JetBackup through the Linode Marketplace"
 aliases: ['/guides/deploying-jetbackup-marketplace-app/','/guides/jetbackup-marketplace-app/']
 external_resources:
 - '[JetBackup](https://www.jetbackup.com/)'

--- a/docs/products/tools/marketplace/guides/jitsi/index.md
+++ b/docs/products/tools/marketplace/guides/jitsi/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: Deploy_Jitsi_oneclickapps.png
 modified_by:
   name: Linode
-title: "Deploying Jitsi through the Linode Marketplace"
+title: "Deploy Jitsi through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/joomla/index.md
+++ b/docs/products/tools/marketplace/guides/joomla/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-03-29
 modified_by:
   name: Linode
-title: "Deploying Joomla through the Linode Marketplace"
+title: "Deploy Joomla through the Linode Marketplace"
 external_resources:
 - '[Joomla](https://www.joomla.org/)'
 ---

--- a/docs/products/tools/marketplace/guides/joplin/index.md
+++ b/docs/products/tools/marketplace/guides/joplin/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-03-29
 modified_by:
   name: Linode
-title: "Deploying Joplin through the Linode Marketplace"
+title: "Deploy Joplin through the Linode Marketplace"
 external_resources:
 - '[Joplin](https://joplinapp.org/)'
 ---

--- a/docs/products/tools/marketplace/guides/kali-linux/index.md
+++ b/docs/products/tools/marketplace/guides/kali-linux/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-07-05
 modified_by:
   name: Linode
-title: "Deploying Kali Linux through the Linode Marketplace"
+title: "Deploy Kali Linux through the Linode Marketplace"
 aliases: ['/products/tools/marketplace/guides/kalilinux/']
 ---
 

--- a/docs/products/tools/marketplace/guides/kepler/index.md
+++ b/docs/products/tools/marketplace/guides/kepler/index.md
@@ -10,7 +10,7 @@ published: 2021-01-09
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying Kepler through the Linode Marketplace"
+title: "Deploy Kepler through the Linode Marketplace"
 aliases: ['/guides/deploy-kepler-with-marketplace-apps/','/guides/kepler-marketplace-app/']
 contributor:
   name: Linode

--- a/docs/products/tools/marketplace/guides/lamp-stack/index.md
+++ b/docs/products/tools/marketplace/guides/lamp-stack/index.md
@@ -10,7 +10,7 @@ published: 2019-03-26
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying a LAMP Stack through the Linode Marketplace"
+title: "Deploy a LAMP Stack through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/lemp-stack/index.md
+++ b/docs/products/tools/marketplace/guides/lemp-stack/index.md
@@ -10,7 +10,7 @@ published: 2020-03-11
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying a LEMP Stack through the Linode Marketplace"
+title: "Deploy a LEMP Stack through the Linode Marketplace"
 image: feature.png
 contributor:
   name: Linode

--- a/docs/products/tools/marketplace/guides/litespeed-cpanel/index.md
+++ b/docs/products/tools/marketplace/guides/litespeed-cpanel/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-05-17
 modified_by:
   name: Linode
-title: "Deploying LiteSpeed cPanel through the Linode Marketplace"
+title: "Deploy LiteSpeed cPanel through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/liveswitch/index.md
+++ b/docs/products/tools/marketplace/guides/liveswitch/index.md
@@ -7,7 +7,7 @@ keywords: ['liveswitch','streaming','video']
 tags: ["marketplace", "linode platform", "cloud manager"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-05-31
-title: "Deploying LiveSwitch through the Linode Marketplace"
+title: "Deploy LiveSwitch through the Linode Marketplace"
 contributor:
   name: Holden Morris
   link: https://github.com/hmorris3293

--- a/docs/products/tools/marketplace/guides/magicspam/index.md
+++ b/docs/products/tools/marketplace/guides/magicspam/index.md
@@ -10,7 +10,7 @@ published: 2021-08-13
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying MagicSpam through the Linode Marketplace"
+title: "Deploy MagicSpam through the Linode Marketplace"
 aliases: ['/guides/deploying-magicspam-marketplace-app/','/guides/magicspam-marketplace-app/']
 external_resources:
 - '[MagicSpam](https://magicspam.com/)'

--- a/docs/products/tools/marketplace/guides/mastodon/index.md
+++ b/docs/products/tools/marketplace/guides/mastodon/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-12-12
 modified_by:
   name: Linode
-title: "Deploying Mastodon through the Linode Marketplace"
+title: "Deploy Mastodon through the Linode Marketplace"
 external_resources:
   - '[Mastodon Deployment Github Repository](https://github.com/linode-solutions/mastodon-oca)'
 aliases: ['/guides/mastodon-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/mean-stack/index.md
+++ b/docs/products/tools/marketplace/guides/mean-stack/index.md
@@ -10,7 +10,7 @@ published: 2020-03-17
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying a MEAN Stack through the Linode Marketplace"
+title: "Deploy a MEAN Stack through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/mern-stack/index.md
+++ b/docs/products/tools/marketplace/guides/mern-stack/index.md
@@ -10,7 +10,7 @@ published: 2019-04-02
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying a MERN Stack through the Linode Marketplace"
+title: "Deploy a MERN Stack through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/microweber/index.md
+++ b/docs/products/tools/marketplace/guides/microweber/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-09-06
 modified_by:
   name: Linode
-title: "Deploying Microweber through the Linode Marketplace"
+title: "Deploy Microweber through the Linode Marketplace"
 ---
 
 [Microweber](https://microweber.org/) is an open-source, drag and drop website builder and CMS based on the Laravel PHP Framework. It includes features for e-commerce, live editing, file management, design customization, and has plugins for both cPanel and Plesk.

--- a/docs/products/tools/marketplace/guides/minecraft/index.md
+++ b/docs/products/tools/marketplace/guides/minecraft/index.md
@@ -4,7 +4,7 @@ keywords: ['minecraft','marketplace', 'server']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2019-04-01
 modified: 2022-04-01
-title: "Deploying a Minecraft Server through the Linode Marketplace"
+title: "Deploy a Minecraft Server through the Linode Marketplace"
 external_resources:
 - '[Minecraft Wiki](https://minecraft.fandom.com/wiki/Server)'
 tags: ["linode platform","marketplace","cloud-manager"]

--- a/docs/products/tools/marketplace/guides/mistio/index.md
+++ b/docs/products/tools/marketplace/guides/mistio/index.md
@@ -10,7 +10,7 @@ published: 2020-03-18
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Mist.io through the Linode Marketplace"
+title: "Deploy Mist.io through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/mongodb/index.md
+++ b/docs/products/tools/marketplace/guides/mongodb/index.md
@@ -10,7 +10,7 @@ published: 2020-03-11
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying MongoDB through the Linode Marketplace"
+title: "Deploy MongoDB through the Linode Marketplace"
 image: MongoDB_oneclickapps.png
 contributor:
   name: Linode

--- a/docs/products/tools/marketplace/guides/moodle/index.md
+++ b/docs/products/tools/marketplace/guides/moodle/index.md
@@ -10,7 +10,7 @@ published: 2021-08-13
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Moodle through the Linode Marketplace"
+title: "Deploy Moodle through the Linode Marketplace"
 aliases: ['/guides/deploying-moodle-marketplace-app/','/guides/moodle-marketplace-app/']
 external_resources:
 - '[Moodle](https://moodle.org/)'

--- a/docs/products/tools/marketplace/guides/mysql/index.md
+++ b/docs/products/tools/marketplace/guides/mysql/index.md
@@ -10,7 +10,7 @@ published: 2020-03-13
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying MySQL/MariaDB through the Linode Marketplace"
+title: "Deploy MySQL/MariaDB through the Linode Marketplace"
 external_resources:
 - '[MySQL 5.6 Reference Manual](https://dev.mysql.com/doc/refman/5.6/en/index.html)'
 - '[PHP MySQL Manual](http://us2.php.net/manual/en/book.mysql.php)'

--- a/docs/products/tools/marketplace/guides/nextcloud/index.md
+++ b/docs/products/tools/marketplace/guides/nextcloud/index.md
@@ -9,7 +9,7 @@ published: 2020-06-11
 modified: 2022-05-27
 modified_by:
   name: Linode
-title: "Deploying Nextcloud through the Linode Marketplace"
+title: "Deploy Nextcloud through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/nirvashare/index.md
+++ b/docs/products/tools/marketplace/guides/nirvashare/index.md
@@ -10,7 +10,7 @@ published: 2021-08-13
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying NirvaShare through the Linode Marketplace"
+title: "Deploy NirvaShare through the Linode Marketplace"
 aliases: ['/guides/deploying-nirvashare-marketplace-app/','/guides/nirvashare-marketplace-app/']
 external_resources:
 - '[NirvaShare](https://nirvashare.com/)'

--- a/docs/products/tools/marketplace/guides/nodejs/index.md
+++ b/docs/products/tools/marketplace/guides/nodejs/index.md
@@ -10,7 +10,7 @@ published: 2022-02-22
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Node.js through the Linode Marketplace"
+title: "Deploy Node.js through the Linode Marketplace"
 contributor:
   name: Linode
 aliases: ['/guides/nodejs-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/odoo/index.md
+++ b/docs/products/tools/marketplace/guides/odoo/index.md
@@ -10,7 +10,7 @@ published: 2022-02-22
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Odoo through the Linode Marketplace"
+title: "Deploy Odoo through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/openlitespeed-django/index.md
+++ b/docs/products/tools/marketplace/guides/openlitespeed-django/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying OpenLiteSpeed Django through the Linode Marketplace"
+title: "Deploy OpenLiteSpeed Django through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/openlitespeed-nodejs/index.md
+++ b/docs/products/tools/marketplace/guides/openlitespeed-nodejs/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying OpenLiteSpeed Node.js through the Linode Marketplace"
+title: "Deploy OpenLiteSpeed Node.js through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/openlitespeed-rails/index.md
+++ b/docs/products/tools/marketplace/guides/openlitespeed-rails/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying OpenLiteSpeed Rails through the Linode Marketplace"
+title: "Deploy OpenLiteSpeed Rails through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/openlitespeed-wordpress/index.md
+++ b/docs/products/tools/marketplace/guides/openlitespeed-wordpress/index.md
@@ -10,7 +10,7 @@ published: 2021-01-15
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying OpenLiteSpeed WordPress through the Linode Marketplace"
+title: "Deploy OpenLiteSpeed WordPress through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/openvpn/index.md
+++ b/docs/products/tools/marketplace/guides/openvpn/index.md
@@ -11,7 +11,7 @@ published: 2019-04-05
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying OpenVPN through the Linode Marketplace"
+title: "Deploy OpenVPN through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/owncast/index.md
+++ b/docs/products/tools/marketplace/guides/owncast/index.md
@@ -10,7 +10,7 @@ published: 2021-03-31
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Owncast through the Linode Marketplace"
+title: "Deploy Owncast through the Linode Marketplace"
 external_resources:
 - '[Owncast](https://owncast.online/)'
 - '[Owncast Github](https://github.com/owncast/owncast)'

--- a/docs/products/tools/marketplace/guides/peppermint/index.md
+++ b/docs/products/tools/marketplace/guides/peppermint/index.md
@@ -10,7 +10,7 @@ published: 2021-03-31
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Peppermint through the Linode Marketplace"
+title: "Deploy Peppermint through the Linode Marketplace"
 external_resources:
 - "[Peppermint Github](https://github.com/Peppermint-Lab/Peppermint/blob/master/README.md)"
 - "[Peppermint Documentation](https://docs.peppermint.sh/)"

--- a/docs/products/tools/marketplace/guides/percona-monitoring-management/index.md
+++ b/docs/products/tools/marketplace/guides/percona-monitoring-management/index.md
@@ -10,7 +10,7 @@ published: 2020-06-11
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Percona Monitoring and Management (PMM) through the Linode Marketplace"
+title: "Deploy Percona Monitoring and Management (PMM) through the Linode Marketplace"
 contributor:
   name: Linode
 image: 'deploy-percona-marketplace.png'

--- a/docs/products/tools/marketplace/guides/phpmyadmin/index.md
+++ b/docs/products/tools/marketplace/guides/phpmyadmin/index.md
@@ -10,7 +10,7 @@ published: 2020-09-28
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying phpMyAdmin through the Linode Marketplace"
+title: "Deploy phpMyAdmin through the Linode Marketplace"
 external_resources:
 - '[phpMyAdmin Documentation](https://docs.phpmyadmin.net/en/latest/)'
 - '[MariaDB Documentation](https://mariadb.org/documentation/)'

--- a/docs/products/tools/marketplace/guides/pihole/index.md
+++ b/docs/products/tools/marketplace/guides/pihole/index.md
@@ -10,7 +10,7 @@ published: 2022-02-22
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Pi-hole through the Linode Marketplace"
+title: "Deploy Pi-hole through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/plesk/index.md
+++ b/docs/products/tools/marketplace/guides/plesk/index.md
@@ -10,7 +10,7 @@ published: 2019-03-25
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Plesk through the Linode Marketplace"
+title: "Deploy Plesk through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/plex/index.md
+++ b/docs/products/tools/marketplace/guides/plex/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: Deploy_Plex_oneclickapps.png
 modified_by:
   name: Linode
-title: "Deploying Plex Media Server through the Linode Marketplace"
+title: "Deploy Plex Media Server through the Linode Marketplace"
 external_resources:
 - '[Plex Support Articles](https://support.plex.tv/articles/)'
 aliases: ['/platform/marketplace/deploy-plex-with-marketplace-apps/', '/platform/marketplace/deploy-plex-with-one-click-apps/', '/guides/deploy-plex-with-one-click-apps/', '/guides/deploy-plex-with-marketplace-apps/','/platform/one-click/deploy-plex-with-one-click-apps/','/guides/plex-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/postgresql/index.md
+++ b/docs/products/tools/marketplace/guides/postgresql/index.md
@@ -10,7 +10,7 @@ published: 2020-03-17
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying PostgreSQL through the Linode Marketplace"
+title: "Deploy PostgreSQL through the Linode Marketplace"
 external_resources:
  - '[pgAdmin Documentation](http://www.pgadmin.org/docs/)'
  - '[PostgreSQL Documentation](http://www.postgresql.org/docs/)'

--- a/docs/products/tools/marketplace/guides/pritunl/index.md
+++ b/docs/products/tools/marketplace/guides/pritunl/index.md
@@ -11,7 +11,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Pritunl through the Linode Marketplace"
+title: "Deploy Pritunl through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/prometheus-grafana/index.md
+++ b/docs/products/tools/marketplace/guides/prometheus-grafana/index.md
@@ -9,7 +9,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-03-29
 modified_by:
   name: Linode
-title: "Deploying Prometheus and Grafana through the Linode Marketplace"
+title: "Deploy Prometheus and Grafana through the Linode Marketplace"
 external_resources:
 - '[Prometheus](https://prometheus.io/)'
 - '[Grafana](https://grafana.com/)'

--- a/docs/products/tools/marketplace/guides/prometheus/index.md
+++ b/docs/products/tools/marketplace/guides/prometheus/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: Prometheus_oneclickapps.png
 modified_by:
   name: Linode
-title: "Deploying Prometheus through the Linode Marketplace"
+title: "Deploy Prometheus through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/rabbitmq/index.md
+++ b/docs/products/tools/marketplace/guides/rabbitmq/index.md
@@ -10,7 +10,7 @@ published: 2020-09-28
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying RabbitMQ through the Linode Marketplace"
+title: "Deploy RabbitMQ through the Linode Marketplace"
 external_resources:
 - '[RabbitMQ](https://www.rabbitmq.com/)'
 aliases: ['/platform/marketplace/deploy-rabbitmq-with-marketplace-apps/', '/platform/marketplace/deploy-rabbitmq-with-one-click-apps/','/guides/deploy-rabbitmq-with-one-click-apps/','/guides/deploy-rabbitmq-server-with-marketplace-apps/','/guides/deploy-rabbitmq-with-marketplace-apps/','/guides/rabbitmq-marketplace-app/']

--- a/docs/products/tools/marketplace/guides/redis/index.md
+++ b/docs/products/tools/marketplace/guides/redis/index.md
@@ -10,7 +10,7 @@ published: 2020-03-13
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Redis through the Linode Marketplace"
+title: "Deploy Redis through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/restyaboard/index.md
+++ b/docs/products/tools/marketplace/guides/restyaboard/index.md
@@ -10,7 +10,7 @@ published: 2022-01-25
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Restyaboard through the Linode Marketplace"
+title: "Deploy Restyaboard through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/rocketchat/index.md
+++ b/docs/products/tools/marketplace/guides/rocketchat/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Rocket.Chat through the Linode Marketplace"
+title: "Deploy Rocket.Chat through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/ruby-on-rails/index.md
+++ b/docs/products/tools/marketplace/guides/ruby-on-rails/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: RubyonRails_oneclickapps.png
 modified_by:
   name: Linode
-title: "Deploying Ruby on Rails through the Linode Marketplace"
+title: "Deploy Ruby on Rails through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/rust/index.md
+++ b/docs/products/tools/marketplace/guides/rust/index.md
@@ -9,7 +9,7 @@ published: 2019-03-25
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Rust through the Linode Marketplace"
+title: "Deploy Rust through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/saltcorn/index.md
+++ b/docs/products/tools/marketplace/guides/saltcorn/index.md
@@ -10,7 +10,7 @@ published: 2022-02-22
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Saltcorn through the Linode Marketplace"
+title: "Deploy Saltcorn through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/serverwand/index.md
+++ b/docs/products/tools/marketplace/guides/serverwand/index.md
@@ -10,7 +10,7 @@ published: 2021-02-23
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying ServerWand through the Linode Marketplace"
+title: "Deploy ServerWand through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/shadowsocks/index.md
+++ b/docs/products/tools/marketplace/guides/shadowsocks/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: DeployShadowsocksServer_oneclickapps.png
 modified_by:
   name: Linode
-title: "Deploying Shadowsocks through the Linode Marketplace"
+title: "Deploy Shadowsocks through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/splunk/index.md
+++ b/docs/products/tools/marketplace/guides/splunk/index.md
@@ -10,7 +10,7 @@ published: 2021-09-03
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Splunk through the Linode Marketplace"
+title: "Deploy Splunk through the Linode Marketplace"
 aliases: ['/guides/deploying-splunk-marketplace-app/','/guides/splunk-marketplace-app/']
 external_resources:
 - '[Splunk](http://splunk.com/)'

--- a/docs/products/tools/marketplace/guides/team-fortress-2/index.md
+++ b/docs/products/tools/marketplace/guides/team-fortress-2/index.md
@@ -9,7 +9,7 @@ published: 2019-04-04
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying a Team Fortress 2 Server through the Linode Marketplace"
+title: "Deploy a Team Fortress 2 Server through the Linode Marketplace"
 contributor:
   name: Linode
 tags: ["linode platform","marketplace","cloud-manager"]

--- a/docs/products/tools/marketplace/guides/terraria/index.md
+++ b/docs/products/tools/marketplace/guides/terraria/index.md
@@ -9,7 +9,7 @@ published: 2019-04-05
 modified: 2022-05-10
 modified_by:
   name: Linode
-title: "Deploying Terraria through the Linode Marketplace"
+title: "Deploy Terraria through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/unifi-network-application/index.md
+++ b/docs/products/tools/marketplace/guides/unifi-network-application/index.md
@@ -10,7 +10,7 @@ published: 2022-09-06
 modified: 2022-09-22
 modified_by:
   name: Linode
-title: "Deploying the UniFi Network Application through the Linode Marketplace"
+title: "Deploy the UniFi Network Application through the Linode Marketplace"
 ---
 
 The [UniFi Network Application](https://help.ui.com/hc/en-us/articles/1500012237441-UniFi-Network-Use-the-UniFi-Network-Application) is a versatile control panel developed by [Ubiquiti](https://www.ui.com/). It simplifies network management across regions, customizes access to Wi-Fi networks, and more. Manage and apply updates to UniFi networking devices to ensure your networks are performant and secure.

--- a/docs/products/tools/marketplace/guides/uptime-kuma/index.md
+++ b/docs/products/tools/marketplace/guides/uptime-kuma/index.md
@@ -10,7 +10,7 @@ published: 2022-02-22
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Uptime Kuma through the Linode Marketplace"
+title: "Deploy Uptime Kuma through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/utunnel/index.md
+++ b/docs/products/tools/marketplace/guides/utunnel/index.md
@@ -11,7 +11,7 @@ published: 2021-12-10
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying UTunnel VPN through the Linode Marketplace"
+title: "Deploy UTunnel VPN through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/valheim/index.md
+++ b/docs/products/tools/marketplace/guides/valheim/index.md
@@ -10,7 +10,7 @@ published: 2021-03-09
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Valheim through the Linode Marketplace"
+title: "Deploy Valheim through the Linode Marketplace"
 external_resources:
 - '[LinuxGSM Valheim Documentation](https://linuxgsm.com/lgsm/vhserver/)'
 - '[Valheim official website](https://www.valheimgame.com/)'

--- a/docs/products/tools/marketplace/guides/victoriametrics-single/index.md
+++ b/docs/products/tools/marketplace/guides/victoriametrics-single/index.md
@@ -10,7 +10,7 @@ published: 2022-01-25
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying VictoriaMetrics Single through the Linode Marketplace"
+title: "Deploy VictoriaMetrics Single through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/virtualmin/index.md
+++ b/docs/products/tools/marketplace/guides/virtualmin/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: Deploy_Virtualmin_oneclickapps.png
 modified_by:
   name: Linode
-title: "Deploying Virtualmin through the Linode Marketplace"
+title: "Deploy Virtualmin through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/vscode/index.md
+++ b/docs/products/tools/marketplace/guides/vscode/index.md
@@ -10,7 +10,7 @@ published: 2020-12-02
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying VS Code through the Linode Marketplace"
+title: "Deploy VS Code through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/warpspeed/index.md
+++ b/docs/products/tools/marketplace/guides/warpspeed/index.md
@@ -11,7 +11,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying WarpSpeed VPN through the Linode Marketplace"
+title: "Deploy WarpSpeed VPN through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/wazuh/index.md
+++ b/docs/products/tools/marketplace/guides/wazuh/index.md
@@ -10,7 +10,7 @@ published: 2021-11-12
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying Wazuh through the Linode Marketplace"
+title: "Deploy Wazuh through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/webmin/index.md
+++ b/docs/products/tools/marketplace/guides/webmin/index.md
@@ -11,7 +11,7 @@ modified: 2022-03-08
 image: Deploy_Webmin_oneclickapps.png
 modified_by:
   name: Linode
-title: "Deploying Webmin through the Linode Marketplace"
+title: "Deploy Webmin through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/webuzo/index.md
+++ b/docs/products/tools/marketplace/guides/webuzo/index.md
@@ -10,7 +10,7 @@ published: 2020-12-02
 modified: 2022-08-08
 modified_by:
   name: Linode
-title: "Deploying Webuzo through the Linode Marketplace"
+title: "Deploy Webuzo through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/wireguard/index.md
+++ b/docs/products/tools/marketplace/guides/wireguard/index.md
@@ -11,7 +11,7 @@ published: 2019-03-28
 modified: 2022-03-08
 modified_by:
   name: Linode
-title: "Deploying WireGuard through the Linode Marketplace"
+title: "Deploy WireGuard through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/woocommerce/index.md
+++ b/docs/products/tools/marketplace/guides/woocommerce/index.md
@@ -5,7 +5,7 @@ tags: ["cloud-manager","linode platform","cms","wordpress","marketplace"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2019-04-02
 modified: 2022-04-01
-title: "Deploying WooCommerce through the Linode Marketplace"
+title: "Deploy WooCommerce through the Linode Marketplace"
 aliases: ['/platform/marketplace/marketplace-woocommerce/','/platform/marketplace/how-to-deploy-woocommerce-with-marketplace-apps/', '/platform/one-click/how-to-deploy-woocommerce-with-one-click-apps/','/platform/one-click/one-click-woocommerce/','/guides/how-to-deploy-woocommerce-with-one-click-apps/','/guides/how-to-deploy-woocommerce-with-marketplace-apps/','/guides/woocommerce-marketplace-app/']
 external_resources:
 - '[WooCommerce Docs](https://docs.woocommerce.com/)'

--- a/docs/products/tools/marketplace/guides/wordpress/index.md
+++ b/docs/products/tools/marketplace/guides/wordpress/index.md
@@ -10,7 +10,7 @@ published: 2020-09-28
 modified: 2022-07-28
 modified_by:
   name: Linode
-title: "Deploying WordPress through the Linode Marketplace"
+title: "Deploy WordPress through the Linode Marketplace"
 contributor:
   name: Linode
 external_resources:

--- a/docs/products/tools/marketplace/guides/yacht/index.md
+++ b/docs/products/tools/marketplace/guides/yacht/index.md
@@ -13,7 +13,7 @@ modified_by:
   name: Linode
 contributor:
   name: Linode
-title: "Deploying Yacht through the Linode Marketplace"
+title: "Deploy Yacht through the Linode Marketplace"
 aliases: ['/guides/deploy-yacht-with-marketplace-apps/','/guides/yacht-marketplace-app/']
 external_resources:
 - '[Getting Started](https://yacht.sh/docs/Installation/Getting_Started)'

--- a/docs/products/tools/marketplace/guides/zabbix/index.md
+++ b/docs/products/tools/marketplace/guides/zabbix/index.md
@@ -11,7 +11,7 @@ modified: 2022-08-23
 image: DeployZabbix_marketplaceapps.png
 modified_by:
   name: Linode
-title: "Deploying Zabbix through the Linode Marketplace"
+title: "Deploy Zabbix through the Linode Marketplace"
 external_resources:
 - '[Learn from documentation](https://www.zabbix.com/documentation/5.0/manual)'
 - '[Purchase Technical Support contract](https://www.zabbix.com/support)'


### PR DESCRIPTION
This PR updates the marketplace app titles so that they use the word "Deploy" instead of "Deploying". It also updates the archetype template for Marketplace Apps.