### PR TITLE
[update] Using rdiff-backup with SSHFS

### DIFF
--- a/docs/guides/security/backups/using-rdiff-backup-with-sshfs/index.md
+++ b/docs/guides/security/backups/using-rdiff-backup-with-sshfs/index.md
@@ -1,5 +1,6 @@
 ---
 slug: using-rdiff-backup-with-sshfs
+deprecated: true
 author:
   name: Linode
   email: docs@linode.com


### PR DESCRIPTION
- Added deprecation tag because SSHFS is no longer maintained. More details here:https://github.com/libfuse/sshfs