### PR TITLE
Add *.adobedtm.com to local server config

### DIFF
--- a/config/development/server.toml
+++ b/config/development/server.toml
@@ -6,7 +6,7 @@ X-Frame-Options = "DENY"
 X-XSS-Protection = "1; mode=block"
 X-Content-Type-Options = "nosniff"
 Referrer-Policy = "no-referrer"
-Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.trustarc.com *.weglot.com *.disqus.com 'unsafe-eval' 'unsafe-inline'"
+Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.adobedtm.com *.trustarc.com *.weglot.com *.disqus.com 'unsafe-eval' 'unsafe-inline'"
 
 [[headers]]
 for = "/**.{css,jpg,js}"


### PR DESCRIPTION
Note that this is just for local development (to silence the errors in the Chrome console).