### PR TITLE
[update] Setting Up Rook NFS for Persistent Storage on LKE

### DIFF
--- a/docs/guides/kubernetes/how-to-install-rooknfs-on-lke/index.md
+++ b/docs/guides/kubernetes/how-to-install-rooknfs-on-lke/index.md
@@ -15,6 +15,7 @@ title_meta: "How to Set Up Rook NFS for Persistent Storage on LKE"
 contributor:
   name: Todd Becker
 aliases: ['/kubernetes/how-to-install-rooknfs-on-LKE/']
+deprecated: true
 ---
 
 Rook NFS allows remote hosts to mount filesystems over a network and interact with those filesystems as though they are mounted locally. When used with LKE, Rook can mount a Linode Block Storage PVC which uses `ReadWriteOnce` permissions. The volume can then be leveraged as NFS and exported as a storage class that uses `ReadWriteMany` permissions. This allows Linode's Block Storage to store persistent data for LKE clusters.


### PR DESCRIPTION
- Added deprecation notice.

May be we can write a new guide as recommended here: We recommend that users consider Rook-Ceph's CephNFS which is under active development. Alternatively, there is a classical, non-CSI NFS server provisioner if users don't wish to run a CephCluster and CephFilesystem to host NFS storage.

Fixes https://github.com/linode/docs/issues/6019