### PR TITLE
[Update] Linode Writer's Formatting Guide

### DIFF
--- a/docs/guides/linode-writers-formatting-guide/index.md
+++ b/docs/guides/linode-writers-formatting-guide/index.md
@@ -8,7 +8,7 @@ keywords: ["style guide", "format", "formatting", "how to write", "write for us"
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/linode-writers-formatting-guide/','/linode-writers-guide/','/style-guide/']
 published: 2014-01-15
-modified: 2022-12-07
+modified: 2023-01-20
 modified_by:
   name: Linode
 title: Linode Writer's Formatting Guide
@@ -542,29 +542,147 @@ Unordered lists are bulleted and should be used for any collection of items that
 - Item 3
 ```
 
-### Notes and Cautions
+### Note Shortcode
 
-Notes should be important text that does not necessarily fit the narrative of the preceding step or paragraph. If a step in your guide can cause any major issues with the user's Linode or computer, a caution note should be included.
+The **note** shortcode is used to display a note to the reader.
 
 ```file
 {{</* note */>}}
-This is a sample note.
+This is an example note.
 {{</* /note */>}}
 ```
 
-{{< note respectIndent=false >}}
-This is a sample note.
+{{< note >}}
+This is an example note.
 {{< /note >}}
 
-```file
-{{</* caution */>}}
-This is a sample caution.
-{{</* /caution */>}}
+#### Parameters
+
+The shortcode accepts the following parameters:
+
+| Parameter | Values | Description |
+| -- | -- | -- |
+| `type` | | Identifies the note as one of 4 types: |
+|  | `"secondary"` | A muted note. |
+|  | `"primary"` | (*DEFAULT*) A note or tip related to the surrounding content. This is the default type if no type is specified. |
+|  | `"warning"` | A note to take certain precautions. |
+|  | `"alert"` | An important note that should not be skipped over. |
+| `title` | String | Sets the title of the note. |
+| `noTitle` | boolean | Does not apply a default title to the note. Defaults to false. |
+| `isCollapsible` | boolean | Sets the note as collapsible. The note must have a title defined. Defaults to false. |
+| `respectIndent` | boolean | This is only used for older note shortcodes (`{{</* note */>}}`) that have been converted to the newer shortcode. By default, content between the shortcode tags is rendered using `.InnerDeindent`, which allows the shortcode to respect the indentation of any parent elements (such as lists). When set to `false`, `.Inner` is used instead, which does not de-indent the content and does not respect the indentation of parent elements. Defaults to true. |
+
+#### Note Types
+
+There are four unique types of notes:
+
+- **Secondary** (`type="secondary"`, title defaults to "Note")
+
+    {{< note type="secondary" >}}
+    This is an example of a secondary note with inline code (`sudo nano`), a link ([Linode Documentation](/docs/)), and a command shortcode:
+
+    ```command
+    sudo apt update
+    ```
+    {{< /note >}}
+
+- **Primary** (type is unset or `type="primary"`, title defaults to "Note")
+
+    {{< note >}}
+    This is an example of a primary note with inline code (`sudo nano`), a link ([Linode Documentation](/docs/)), and a command shortcode:
+
+    ```command
+    sudo apt update
+    ```
+    {{< /note >}}
+
+- **Warning** (`type="warning"`, title defaults to "Warning")
+
+    {{< note type="warning" >}}
+    This is an example of a warning note with inline code (`sudo nano`), a link ([Linode Documentation](/docs/)), and a command shortcode:
+
+    ```command
+    sudo apt update
+    ```
+    {{< /note >}}
+
+- **Alert** (`type="alert"`, title defaults to "Important")
+
+    {{< note type="alert" >}}
+    This is an example of an alert note with inline code (`sudo nano`), a link ([Linode Documentation](/docs/)), and a command shortcode:
+
+    ```command
+    sudo apt update
+    ```
+    {{< /note >}}
+
+#### Custom Title
+
+Each note can also have a custom title, which is set using the `title` parameter.
+
+```file {lang="text"}
+{{</* note title="Custom title" */>}}
+This is an example note with a custom title.
+{{</* /note */>}}
 ```
 
-{{< note type="alert" respectIndent=false >}}
-This is a sample caution.
+{{< note title="Custom title" >}}
+This is an example note with a custom title.
 {{< /note >}}
+
+#### No Title
+
+Additionally, you can specify that the note should have no title by using `noTitle=true`. This causes the default title to not display.
+
+```file {lang="text"}
+{{</* note noTitle=true */>}}
+This is an example note with no title.
+{{</* /note */>}}
+```
+
+{{< note noTitle=true >}}
+This is an example note with no title.
+{{< /note >}}
+
+#### Collapsible
+
+Additionally, a note can also be collapsible by setting `isCollapsible=true` (defaults to false). This hides the body of the note and displays a collapse/expand icon.
+
+```file {lang="text"}
+{{</* note title="This is a collapsible note with a custom title" isCollapsible=true */>}}
+This content is hidden until the user expands the note.
+{{</* /note */>}}
+```
+
+{{< note title="This is a collapsible note with a custom title" isCollapsible=true >}}
+This content is hidden until the user expands the note.
+{{< /note >}}
+
+### Indentation
+
+Content within the opening and closing note shortcode tags must respect the expected indentation of any parent elements, such as list items. Since content within a list is indented (using 4 spaces), the content of a note shortcode must be indented by the same number of spaces.
+
+```file
+- First list item.
+
+    {{</* note */>}}
+    This content appears within the first list item and, as such, respects its indentation.
+    {{</* /note */>}}
+
+- Second list item.
+```
+
+If this indentation is not respected, which should only be the case for older note shortcodes made before this change, the following option is set: `respectIndent=false`. If one of these is encountered when editing an existing guide, remove `respectIndent=false` and properly indent the shortcode.
+
+```file
+- First list item.
+
+    {{</* note respectIndent=false */>}}
+This content appears within the first list item but does not respect its indentation.
+{{</* /note */>}}
+
+- Second list item.
+```
 
 ### Numerical Values
 


### PR DESCRIPTION
This PR adds information about the revised `note` shortcode to the Linode Writer's Formatting Guide.