### PR TITLE
Algolia ranking changes

### DIFF
--- a/ci/yaml_rules.json
+++ b/ci/yaml_rules.json
@@ -305,5 +305,17 @@
     "required": false,
     "type": "number",
     "description": "For guides displayed on the front (landing) page. Setting a higher weight will move the guide to the top of the list of icons."
+  },
+  "weightAge": {
+    "elements": false,
+    "required": false,
+    "type": "number",
+    "description": "When set, this will override the automatically-calculated weightAge, weightAgeMonths, and weightAgeYears values in the Algolia search index. For example, setting this to zero on an older article can help it rank as highly as other newly-published articles."
+  },
+  "weightSearchBoost": {
+    "elements": false,
+    "required": false,
+    "type": "bool",
+    "description": "If set to true, the article will be boosted in Algolia search results for search terms that match the article."
   }
 }

--- a/docs/guides/platform/_index.md
+++ b/docs/guides/platform/_index.md
@@ -6,5 +6,8 @@ description: 'Learn about everything Linode!'
 show_on_frontpage: true
 title_short: "Linode Platform"
 weight: 30
+cascade:
+    weightAge: 0
+    weightSearchBoost: true
 icon: "cube"
 ---

--- a/docs/products/_index.md
+++ b/docs/products/_index.md
@@ -4,6 +4,10 @@ linkTitle = "Products"
 description = "Get started using the Cloud Manager, CLI, and API to deploy Linode services and manage your account."
 
 [[cascade]]
+weightAge = 0
+weightSearchBoost = true
+
+[[cascade]]
 layout = "tabbed-section-layout"
 [cascade._target]
 # The section rendering for individual product pages uses the tabbed layout

--- a/docs/reference-architecture/_index.md
+++ b/docs/reference-architecture/_index.md
@@ -4,6 +4,8 @@ description = "Reference architectures from Linode show how to arrange cloud inf
 
 [[cascade]]
 date = 2022-05-17
+keywordsAlgolia = ["reference architecture"]
+
 [[cascade]]
 layout = "tabbed-section-layout"
 [cascade._target]


### PR DESCRIPTION
- Set weightAge: 0 on product docs and linode platform guides
- Set weightSearchBoost: true on product docs and linode platform guides
- Add weightAge and weightSearchBoost to blueberry yaml rules
- Set "reference architecture" in keywordsAlgolia frontmatter of reference arch docs

Additional changes are being made to the linode-algolia-admin tool to support these frontmatter updates, so there will be no visible ranking changes until that happens (either in testing or in prod)