### PR TITLE
docs(lke): metrics server install guide extra args

### DIFF
--- a/docs/guides/kubernetes/lke-continuous-deployment-part-10/index.md
+++ b/docs/guides/kubernetes/lke-continuous-deployment-part-10/index.md
@@ -82,8 +82,7 @@ Now that there is an application running on our Kubernetes cluster, the next ste
       helm upgrade --install metrics-server bitnami/metrics-server \
         --create-namespace --namespace metrics-server \
         --set apiService.create=true \
-        --set extraArgs.kubelet-insecure-tls=true \
-        --set extraArgs.kubelet-preferred-address-types=InternalIP
+        --set extraArgs="{--kubelet-insecure-tls=true,--kubelet-preferred-address-types=InternalIP}"
 
 - What are these options for?
 
@@ -95,17 +94,12 @@ Now that there is an application running on our Kubernetes cluster, the next ste
 
     (create an entry that will show up in `kubectl get apiservices`)
 
-- `extraArgs.kubelet-insecure-tls=true`
+- `extraArgs="{--kubelet-insecure-tls=true,--kubelet-preferred-address-types=InternalIP}"`
 
-    when connecting to nodes to collect their metrics, don't check kubelet TLS certs
-
-    (because most kubelet certs include the node name, but not its IP address)
-
-- `extraArgs.kubelet-preferred-address-types=InternalIP`
-
-    when connecting to nodes, use their internal IP address instead of node name
-
-    (because the latter requires an internal DNS, which is rarely configured)
+    when connecting to nodes to collect their metrics
+    
+    - don't check kubelet TLS certs (because most kubelet certs include the node name, but not its IP address)
+    - use their internal IP address instead of node name (because the latter requires an internal DNS, which is rarely configured)
 
 ### Testing metrics-server
 


### PR DESCRIPTION
`extraArgs` [is a list of strings](https://github.com/bitnami/charts/blob/69cdea18b67af6c821035f998a308d8c0d2fcc34/bitnami/metrics-server/values.yaml#L179-L181) which means it fails to actually install the helm chart.

```
coalesce.go:175: warning: skipped value for metrics-server.extraArgs: Not a table.
coalesce.go:175: warning: skipped value for metrics-server.extraArgs: Not a table.
Error: YAML parse error on metrics-server/templates/deployment.yaml: error converting YAML to JSON: yaml: line 55: did not find expected '-' indicator
```

This change fixes the docs so the metrics server is correctly installed with the desired parameters.