### PR TITLE
[Update] Deploy Mastodon through the Linode Marketplace

### DIFF
--- a/docs/products/tools/marketplace/guides/cpanel/index.md
+++ b/docs/products/tools/marketplace/guides/cpanel/index.md
@@ -35,7 +35,7 @@ cPanel requires a valid license to use the software beyond the initial 15 day [f
 ## Configuration Options
 
 - **Supported distributions:** CentOS 7, Ubuntu 20.04 LTS
-- **Recommended minimum plan:** 2GB Dedicated Compute Instance or higher, depending on the number of sites and size of the sites you plan on hosting.
+- **Recommended minimum plan:** 2GB Shared CPU Compute Instance or higher, depending on the number of sites and size of the sites you plan on hosting.
 
 ## Getting Started after Deployment
 

--- a/docs/products/tools/marketplace/guides/mastodon/index.md
+++ b/docs/products/tools/marketplace/guides/mastodon/index.md
@@ -1,12 +1,13 @@
 ---
 author:
-  name: Linode Staff
+  name: Linode
   email: docs@linode.com
-description: "Self-hosted Mastodon server."
+description: "Learn how to deploy Mastodon, a decentralized social network and micro-blogging platform, on the Linode Marketplace."
 keywords: ['social', 'messaging', 'mastodon']
 tags: ["linode platform","mastodon","marketplace","cloud-manager",]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-12-12
+modified: 2023-02-09
 modified_by:
   name: Linode
 title: "Deploy Mastodon through the Linode Marketplace"
@@ -38,7 +39,7 @@ The Mastodon Marketplace App *requires* a custom domain. After deploying Mastodo
 {{< /note >}}
 
 - **Supported distributions:** Debian 11
-- **Recommended minimum plan:** All plan types and sizes can be used.
+- **Recommended minimum plan:** 2GB Shared CPU Compute Instance or higher
 
 ### Configuration Options
 


### PR DESCRIPTION
This PR updates the recommended plan for Mastodon Marketplace App from any Compute Instance to a minimum recommendation of a 2 GB instance. It also updates the meta description and fixes an issue with the cPanel plan guidance.