### PR TITLE
[Update] Object Storage > Using S3cmd with Object Storage

### DIFF
--- a/docs/products/storage/object-storage/guides/s3cmd/index.md
+++ b/docs/products/storage/object-storage/guides/s3cmd/index.md
@@ -4,7 +4,7 @@ author:
   email: docs@linode.com
 title: "Using S3cmd with Object Storage"
 description: "Learn how to use the S3cmd command-line tool with Linode's Object Storage."
-modified: 2022-09-29
+modified: 2023-02-10
 ---
 
 [S3cmd](https://s3tools.org/s3cmd) is a command line utility that you can use for any S3-compatible Object Storage.
@@ -17,19 +17,25 @@ The following commands will install s3cmd on various common operating systems. A
 
 To install s3cmd on a Mac, [Homebrew](https://brew.sh/) can be used:
 
-    brew install s3cmd
+```command
+brew install s3cmd
+```
 
 {{< note >}}
 On macOS, s3cmd might fail to install if you do not have XCode command line tools installed. If that is the case, run the following command:
 
-    xcode-select --install
+```command
+xcode-select --install
+```
 {{< /note >}}
 
 ### Linux
 
 To install s3cmd on a Linux system (such as CentOS, Ubuntu, or Debian), Python’s package manager [pip](/docs/guides/how-to-manage-packages-and-virtual-environments-on-linux/) can be used.
 
-    sudo pip install s3cmd
+```command
+sudo pip install s3cmd
+```
 
 Some Linux distributions are also able to install s3cmd from their own package managers, but those versions may not be as up to date. See [Download S3cmd](https://s3tools.org/download) for more information.
 
@@ -39,14 +45,16 @@ After s3cmd has been installed, it needs to be configured to work with the bucke
 
 1.  Run the following command to start the configuration process.
 
-        s3cmd --configure
+    ```command
+    s3cmd --configure
+    ```
 
 1.  This command will prompt you with a series of questions. Answer them based on the recommendations below:
 
     - **Access Key:** Enter the access key you wish to use. See [Managing Access Keys](/docs/products/storage/object-storage/guides/access-keys/).
     - **Secret Key:** Enter the secret key that corresponds with the access key. This was displayed once when generating the access key.
     - **Default Region:** `US` (do not change, even if you use Object Storage in a different region)
-    - **S3 Endpoint** (cluster URL): `https://[cluster-id].linodeobjects.com`, where [cluster-id] is the id of your data center. See [Access Buckets and Files through URLs > Cluster URL (S3 Endpoint)](/docs/products/storage/object-storage/guides/urls/#cluster-url-s3-endpoint) for more details and a list of cluster IDs.
+    - **S3 Endpoint** (cluster URL): `[cluster-id].linodeobjects.com`, where [cluster-id] is the id of your data center. See [Access Buckets and Files through URLs > Cluster URL (S3 Endpoint)](/docs/products/storage/object-storage/guides/urls/#cluster-url-s3-endpoint) for more details and a list of cluster IDs.
     - **DNS-style bucket+hostname:port template for accessing a bucket:** `%(bucket)s.[cluster-id].linodeobjects.com`, replacing [cluster-id] with the same id used previously.
     - **Encryption password:** Enter your GPG key if you intend to store and retrieve encrypted files (optional).
     - **Path to GPG program:** Enter the path to your GPG encryption program (optional).
@@ -56,10 +64,10 @@ After s3cmd has been installed, it needs to be configured to work with the bucke
 
 1.  When the prompt appears to test access with the supplied credentials, enter `n` to skip. Currently, this process results in the following error - even when the settings are correct.
 
-    {{<output>}}
-Please wait, attempting to list all buckets...
-ERROR: Test failed: 403 (SignatureDoesNotMatch)
-{{</output>}}
+    ```output
+    Please wait, attempting to list all buckets...
+    ERROR: Test failed: 403 (SignatureDoesNotMatch)
+    ```
 
 1.  When the prompt appears to save your settings, enter `Y`. A configuration file named `.s3cfg` is created within your home directory.
 
@@ -81,7 +89,9 @@ To list the buckets within a different data center, use the `--host` parameter a
 
 **Example**: List all buckets on the account within the Newark data center when s3cmd has been configured for a different data center:
 
-    s3cmd ls --host=https://us-east-1.linodeobjects.com
+```command
+s3cmd ls --host=https://us-east-1.linodeobjects.com
+```
 
 ### Create a Bucket
 
@@ -91,7 +101,9 @@ Creates a bucket with the specified bucket label. See the [Create and Manage Buc
 
 **Example:** Create a bucket with the label of "example-bucket":
 
-    s3cmd mb s3://example-bucket
+```command
+s3cmd mb s3://example-bucket
+```
 
 ### Delete a Bucket
 
@@ -101,11 +113,15 @@ Deletes the bucket with the specified label.
 
 **Example:** Delete the bucket with the label of "example-bucket":
 
-    s3cmd rb s3://example-bucket
+```command
+s3cmd rb s3://example-bucket
+```
 
 To delete a bucket that has files in it, include the `--recursive` (or `-r`) option *and* the `--force` (or `-f`) option. Use caution when running this command:
 
-    s3cmd rb -r -f s3://example-bucket/
+```command
+s3cmd rb -r -f s3://example-bucket/
+```
 
 ## Interacting with Objects
 
@@ -115,7 +131,9 @@ To delete a bucket that has files in it, include the `--recursive` (or `-r`) opt
 
 **Example:** List all objects within the bucket called "example-bucket":
 
-    s3cmd ls s3://example-bucket/
+```command
+s3cmd ls s3://example-bucket/
+```
 
 ### Upload an Object
 
@@ -123,7 +141,9 @@ To delete a bucket that has files in it, include the `--recursive` (or `-r`) opt
 
 **Example:** Upload the file "file.txt" to the bucket called "example-bucket":
 
-    s3cmd put file.txt s3://example-bucket/
+```command
+s3cmd put file.txt s3://example-bucket/
+```
 
 **Additional command options:**
 - `-P`: Makes the object publicly accessible. This will allow the object to be accessed by anyone with the URL. Once successfully uploaded, s3cmd will output the public URL.
@@ -137,7 +157,9 @@ To delete a bucket that has files in it, include the `--recursive` (or `-r`) opt
 
 **Example:** Download the file "file.txt" from the bucket called "example-bucket":
 
-    s3cmd get s3://example-bucket/file.txt
+```command
+s3cmd get s3://example-bucket/file.txt
+```
 
 **Additional command options:**
 - `-e`: Decrypts an encrypted object.
@@ -148,11 +170,15 @@ To delete a bucket that has files in it, include the `--recursive` (or `-r`) opt
 
 **Example:** Delete the "file.txt" file on the bucket called "example-bucket":
 
-    s3cmd rm s3://example-bucket/file.txt
+```command
+s3cmd rm s3://example-bucket/file.txt
+```
 
 To delete all files in a bucket, include the `--recursive` (or `-r`) option *and* the `--force` (or `-f`) option. Use caution when running this command:
 
-    s3cmd rm -r -f s3://example-bucket/
+```command
+s3cmd rm -r -f s3://example-bucket/
+```
 
 ## Permissions and Access Controls
 
@@ -162,11 +188,15 @@ To delete all files in a bucket, include the `--recursive` (or `-r`) option *and
 
 **Example:** Apply the bucket policies defined within the file "policy.json" to the bucket called "example-bucket":
 
-    s3cmd setpolicy policy.json s3://example-bucket
+```command
+s3cmd setpolicy policy.json s3://example-bucket
+```
 
 To ensure that it has been applied correctly, you can use the `info` command:
 
-    s3cmd info s3://bucket-policy-example
+```command
+s3cmd info s3://bucket-policy-example
+```
 
 You should see output like the following:
 
@@ -184,7 +214,9 @@ s3://example-bucket/ (bucket):
 
 Creating a **signed URL** allows you to create a link to objects with limited permissions and a time limit to access them. To create a signed URL on a preexisting object with s3cmd, use the following syntax:
 
-    s3cmd signurl s3://my-example-bucket/example.txt +300
+```command
+s3cmd signurl s3://my-example-bucket/example.txt +300
+```
 
 The output of the command is a URL that can be used for a set period of time to access the object, even if the ACL is set to private. In this case, `+300` represents the amount of time in seconds that the link remains active, or five minutes total. After this time has passed, the link expires and can no longer be used.
 
@@ -194,15 +226,19 @@ You can also create a static website using Object Storage and s3cmd:
 
 1.  To create a website from a bucket, use the `ws-create` command:
 
-        s3cmd ws-create --ws-index=index.html --ws-error=404.html s3://my-example-bucket
+    ```command
+    s3cmd ws-create --ws-index=index.html --ws-error=404.html s3://my-example-bucket
+    ```
 
     The `--ws-index` and `--ws-error` flags specify which objects the bucket should use to serve the static site's index page and error page, respectively.
 
 1.  You need to separately upload the `index.html` and `404.html` files (or however you have named the index and error pages) to the bucket:
 
-        echo 'Index page' > index.html
-        echo 'Error page' > 404.html
-        s3cmd put index.html 404.html s3://my-example-bucket
+    ```command
+    echo 'Index page' > index.html
+    echo 'Error page' > 404.html
+    s3cmd put index.html 404.html s3://my-example-bucket
+    ```
 
 1.  The static site is accessed from a different URL than the generic URL for the Object Storage bucket. Static sites are available at the `website-us-east-1` subdomain for the Newark data center, the `website-eu-central-1` subdomain for the Frankfurt data center, and the `website-ap-south-1` subdomain for the Singapore data center. Using `my-example-bucket` as an example, you would navigate to either:
 
@@ -223,4 +259,6 @@ To upload the current directory, replace *[local-path]* with `./`.
 
 **Example:** Upload the current directory to the bucket labeled *example-bucket* and make all files public.
 
-    s3cmd sync ./ s3://example-bucket -P
+```command
+s3cmd sync ./ s3://example-bucket -P
+```


### PR DESCRIPTION
- Removes `https://` from the endpoint value in s3cmd. The protocol (https/http) is set in another configuration parameter so including it here is redundant.
- Updates the formatting