### PR TITLE
[update]Deploying Prometheus Operator and Grafana on LKE

### DIFF
--- a/docs/guides/kubernetes/deploy-prometheus-operator-with-grafana-on-linode-kubernetes-engine/index.md
+++ b/docs/guides/kubernetes/deploy-prometheus-operator-with-grafana-on-linode-kubernetes-engine/index.md
@@ -281,7 +281,7 @@ If successful, the output should return the IP address of your NodeBalancer.
 
 1.  Install cert-manager's CRDs.
 
-        kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.crds.yaml
+        kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
 
 1.  Add the Helm repository which contains the cert-manager Helm chart.
 
@@ -318,7 +318,7 @@ Now that cert-manager is installed and running on your cluster, you will need to
 1.  Using the text editor of your choice, create a file named `acme-issuer-prod.yaml` with the example configurations, replacing the value of `email` with your own email address for the ACME challenge:
 
     {{< file "~/lke-monitor/acme-issuer-prod.yaml" yaml>}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
@@ -358,7 +358,7 @@ Replace the value of `spec.dnsNames` with the domain, including subdomains, that
     {{< /note >}}
 
     {{< file "~/lke-monitor/certificate-prod.yaml" yaml >}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: prometheus-operator-prod


### PR DESCRIPTION
- Updated the version number and the apiVersion

Feedback Details:
```The documentation for Cert-Manager is outdated as the api version no longer is in alpha. Deployment failed due to this as the version in the guide is deprecated and don't support the current k8s version.
Should be apiVersion: [cert-manager.io/v1](http://cert-manager.io/v1) instead of apiVersion: [cert-manager.io/v1alpha2](http://cert-manager.io/v1alpha2)
Also the version should be 1.11.0 as of 10.02.2023. :)
Otherwise good docs. Will keep you updated if I find more stuff.```