### PR TITLE
[Release Notes] LKE v1.46.0

### DIFF
--- a/docs/release-notes/lke/v1.11.0.md
+++ b/docs/release-notes/lke/v1.11.0.md
@@ -8,7 +8,11 @@ version: 1.11.0
 
 - Update CCM to version 0.3.8 to include support for NodeBalancer Proxy Protocol
 - Update CSI to version 0.1.7 to include support for Linode Block Storage Volume expansion.
-- Upgrade cluster control plane components to latest available patch version: v1.17.14 and 1.18.12
+
+### Changed
+
+- Upgraded clusters using Kubernetes 1.18 to patch version 1.18.12.
+- Upgraded clusters using Kubernetes 1.17 to patch version 1.17.14.
 
 ### Fixed
 

--- a/docs/release-notes/lke/v1.12.1.md
+++ b/docs/release-notes/lke/v1.12.1.md
@@ -6,6 +6,10 @@ version: 1.12.1
 
 ### Added
 
-- Upgrade cluster control plane components to latest available patch version: v1.17.16 and v1.18.14
 - Add support for cluster upgrades to the next available Kubernetes minor version
 - Add support for full-cluster and individual node recycle
+
+### Changed
+
+- Upgraded clusters using Kubernetes 1.18 to patch version 1.18.14.
+- Upgraded clusters using Kubernetes 1.17 to patch version 1.17.16.

--- a/docs/release-notes/lke/v1.14.0.md
+++ b/docs/release-notes/lke/v1.14.0.md
@@ -6,8 +6,9 @@ version: 1.14.0
 
 ### Added
 
-- Add support for deploying Kubernetes v1.19.7
+- Kubernetes 1.19 (1.19.7) is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md) and [blog post](https://kubernetes.io/blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/).
 
 ### Changed
 
-- Upgrade cluster control plane components to latest available patch version: v1.17.17 and v1.18.15
+- Upgraded clusters using Kubernetes 1.18 to patch version 1.18.15.
+- Upgraded clusters using Kubernetes 1.17 to patch version 1.17.17.

--- a/docs/release-notes/lke/v1.15.1.md
+++ b/docs/release-notes/lke/v1.15.1.md
@@ -6,7 +6,8 @@ version: 1.15.1
 
 ### Changed
 
-- Upgrade cluster control plane components to latest available patch version: v1.18.16 and v1.19.8
+- Upgraded clusters using Kubernetes 1.19 to patch version 1.19.8.
+- Upgraded clusters using Kubernetes 1.18 to patch version 1.18.16.
 - Upgrade CoreDNS on all LKE clusters to v1.8.0
 - Upgrade CCM for LKE clusters to v0.3.12, which allows for inter-service communication from within cluster via external LB and removes support for deprecated `tls` and `protocol` annotations
 - Update all Kubernetes worker node disk images to their latest patch versions: v1.19.8 and v1.18.16. Please recycle your nodes to receive the latest updates

--- a/docs/release-notes/lke/v1.16.0.md
+++ b/docs/release-notes/lke/v1.16.0.md
@@ -6,7 +6,7 @@ version: 1.16.0
 
 ### Added
 
-- Add support for deploying Kubernetes v1.20.4
+- Kubernetes 1.20 (1.20.4) is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md) and [blog post](https://kubernetes.io/blog/2020/12/08/kubernetes-1-20-release-announcement/).
 
 ### Changed
 

--- a/docs/release-notes/lke/v1.17.0.md
+++ b/docs/release-notes/lke/v1.17.0.md
@@ -10,7 +10,9 @@ version: 1.17.0
 
 ### Changed
 
-- Upgrade cluster control plane components to latest available patch version: v1.18.17, v1.19.9, and v1.20.5
+- Upgraded clusters using Kubernetes 1.20 to patch version 1.20.5.
+- Upgraded clusters using Kubernetes 1.19 to patch version 1.19.9.
+- Upgraded clusters using Kubernetes 1.18 to patch version 1.18.17.
 - Remove support for v1.16 clusters in LKE
 - Upgrade Calico CNI to v3.10.4 for all LKE clusters
 - Upgrade etcd to v3.4.14 for all LKE clusters

--- a/docs/release-notes/lke/v1.20.0.md
+++ b/docs/release-notes/lke/v1.20.0.md
@@ -6,7 +6,7 @@ version: 1.20.0
 
 ### Added
 
-- Add support for Kubernetes v1.21.1.
+- Kubernetes 1.21 (1.21.1) is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md) and [blog post](https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/).
 
 ### Changed
 

--- a/docs/release-notes/lke/v1.21.0.md
+++ b/docs/release-notes/lke/v1.21.0.md
@@ -11,9 +11,11 @@ version: 1.21.0
 
 ### Changed
 
+- Upgraded clusters using Kubernetes 1.20 to patch version 1.20.7.
+- Upgraded clusters using Kubernetes 1.19 to patch version 1.19.11.
+- Upgraded clusters using Kubernetes 1.18 to patch version 1.18.19.
 - Upgraded coreDNS image from v1.8.0 to v1.8.4
 - Upgraded Calico CNI from v3.10.4 to v3.19.0
-- Upgraded cluster control plane components to latest available patch version: v1.18.19, v1.19.11, and v1.20.7.
 
 ### Fixed
 

--- a/docs/release-notes/lke/v1.22.0.md
+++ b/docs/release-notes/lke/v1.22.0.md
@@ -10,4 +10,6 @@ version: 1.22.0
 
 ### Changed
 
-- Upgrade cluster control plane components to latest available Kubernetes patch versions: v1.19.12, v1.20.8, and v1.21.2.
+- Upgraded clusters using Kubernetes 1.21 to patch version 1.21.2.
+- Upgraded clusters using Kubernetes 1.20 to patch version 1.20.8.
+- Upgraded clusters using Kubernetes 1.19 to patch version 1.19.12.

--- a/docs/release-notes/lke/v1.23.0.md
+++ b/docs/release-notes/lke/v1.23.0.md
@@ -6,5 +6,7 @@ version: 1.23.0
 
 ### Changed
 
+- Upgraded clusters using Kubernetes 1.21 to patch version 1.21.3.
+- Upgraded clusters using Kubernetes 1.20 to patch version 1.20.9.
+- Upgraded clusters using Kubernetes 1.19 to patch version 1.19.13.
 - Upgraded Calico CNI from v3.19.0 to v3.19.1
-- Upgraded cluster control plane components to latest available patch version: v1.19.13, v1.20.9, and v1.21.3.

--- a/docs/release-notes/lke/v1.27.0.md
+++ b/docs/release-notes/lke/v1.27.0.md
@@ -6,5 +6,7 @@ version: 1.27.0
 
 ### Changed
 
-- Upgraded cluster control plane components to latest available patch versions: v1.19.15, v1.20.11, and v1.21.5
+- Upgraded clusters using Kubernetes 1.21 to patch version 1.21.5.
+- Upgraded clusters using Kubernetes 1.20 to patch version 1.20.11.
+- Upgraded clusters using Kubernetes 1.19 to patch version 1.19.15.
 - Upgraded Linode CCM to v0.3.15 on all LKE clusters

--- a/docs/release-notes/lke/v1.29.0.md
+++ b/docs/release-notes/lke/v1.29.0.md
@@ -6,7 +6,7 @@ version: 1.29.0
 
 ### Added
 
-- Add support for Kubernetes v1.22.3.
+- Kubernetes 1.22 (1.22.3) is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) and [blog post](https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/).
 
 ### Changed
 

--- a/docs/release-notes/lke/v1.3.0.md
+++ b/docs/release-notes/lke/v1.3.0.md
@@ -6,11 +6,13 @@ version: 1.3.0
 
 ### Added
 
-- Added support for Kubernetes control plane versions 1.15.12, 1.16.11, 1.17.7. All clusters were upgraded to these versions
 - Kubelet versions 1.15.10, 1.16.7, and 1.17.3 were made available for new and recycled Nodes
 
 ### Changed
 
+- Upgraded clusters using Kubernetes 1.17 to patch version 1.17.7.
+- Upgraded clusters using Kubernetes 1.16 to patch version 1.16.11.
+- Upgraded clusters using Kubernetes 1.15 to patch version 1.15.12.
 - Allow patch version skew between control plane and kubelet, so that we can push kubelet upgrades asynchronously
 
 ### Fixed

--- a/docs/release-notes/lke/v1.30.0.md
+++ b/docs/release-notes/lke/v1.30.0.md
@@ -6,5 +6,10 @@ version: 1.30.0
 
 ### Added
 
-- Upgraded cluster control plane components to latest available patch versions: v1.20.13, v1.21.7, and v1.22.4.
 - Added support for multi-replica cluster-autoscaler on clusters with an HA control plane.
+
+### Changed
+
+- Upgraded clusters using Kubernetes 1.22 to patch version 1.22.4.
+- Upgraded clusters using Kubernetes 1.21 to patch version 1.21.7.
+- Upgraded clusters using Kubernetes 1.20 to patch version 1.20.13.

--- a/docs/release-notes/lke/v1.32.0.md
+++ b/docs/release-notes/lke/v1.32.0.md
@@ -4,6 +4,8 @@ date: 2022-01-19
 version: 1.32.0
 ---
 
-### Added
+### Changed
 
-- Upgraded cluster control plane components to latest available patch versions: v1.20.14, v1.20.8, and v1.22.5.
+- Upgraded clusters using Kubernetes 1.22 to patch version 1.22.5.
+- Upgraded clusters using Kubernetes 1.21 to patch version 1.21.8.
+- Upgraded clusters using Kubernetes 1.20 to patch version 1.20.14.

--- a/docs/release-notes/lke/v1.34.0.md
+++ b/docs/release-notes/lke/v1.34.0.md
@@ -6,4 +6,5 @@ version: 1.34.0
 
 ### Changed
 
-- Upgrade cluster control plane components to latest available patch version: v1.21.10 and v1.22.7.
+- Upgraded clusters using Kubernetes 1.22 to patch version 1.22.7.
+- Upgraded clusters using Kubernetes 1.21 to patch version 1.21.10.

--- a/docs/release-notes/lke/v1.36.0.md
+++ b/docs/release-notes/lke/v1.36.0.md
@@ -6,9 +6,10 @@ version: 1.36.0
 
 ### Added
 
-- Add support for Kubernetes v1.23
+- Kubernetes 1.23 (1.23.5) is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md) and [blog post](https://kubernetes.io/blog/2021/12/07/kubernetes-1-23-release-announcement/).
 
 ### Changed
 
+- Upgraded clusters using Kubernetes 1.22 to patch version 1.22.8.
+- Upgraded clusters using Kubernetes 1.21 to patch version 1.21.11.
 - Upgrade Calico CNI from v3.19.1 to v3.22.1
-- Upgrade cluster control plane components to latest available patch version: v1.21.11, v1.22.8 and v1.23.5.

--- a/docs/release-notes/lke/v1.42.0.md
+++ b/docs/release-notes/lke/v1.42.0.md
@@ -4,12 +4,10 @@ date: 2022-06-27
 version: 1.42.0
 ---
 
-### Added
-
-- Add support for Kubernetes patch versions v1.23.8 and v1.22.11
-
 ### Changed
 
+- Upgraded clusters using Kubernetes 1.23 to patch version 1.23.8.
+- Upgraded clusters using Kubernetes 1.22 to patch version 1.22.11.
 - Made stability improvements to Kubernetes dashboard
 - Made stability improvements to etcd
 - Removed support for Kubernetes v1.21

--- a/docs/release-notes/lke/v1.44.0.md
+++ b/docs/release-notes/lke/v1.44.0.md
@@ -6,7 +6,7 @@ version: 1.44.0
 
 ### Added
 
-- Adds support for [Kubernetes 1.24](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/).
+- Kubernetes v1.24 is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md) and [blog post](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/).
 
     {{< note >}}
     The dockershim component was removed in upstream Kubernetes starting at version 1.24 (see [Dockershim Removal FAQ](https://kubernetes.io/blog/2022/02/17/dockershim-faq/)). The Linode Kubernetes Engine has kept this component installed on 1.24 LKE nodes in case any customer is reliant on that feature. When deploying a new LKE cluster using Kubernetes v1.24 (and later versions), the default container runtime has been changed to containerd.

--- a/docs/release-notes/lke/v1.44.0.md
+++ b/docs/release-notes/lke/v1.44.0.md
@@ -6,7 +6,7 @@ version: 1.44.0
 
 ### Added
 
-- Kubernetes v1.24 is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md) and [blog post](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/).
+- Kubernetes 1.24 is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md) and [blog post](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/).
 
     {{< note >}}
     The dockershim component was removed in upstream Kubernetes starting at version 1.24 (see [Dockershim Removal FAQ](https://kubernetes.io/blog/2022/02/17/dockershim-faq/)). The Linode Kubernetes Engine has kept this component installed on 1.24 LKE nodes in case any customer is reliant on that feature. When deploying a new LKE cluster using Kubernetes v1.24 (and later versions), the default container runtime has been changed to containerd.

--- a/docs/release-notes/lke/v1.45.0.md
+++ b/docs/release-notes/lke/v1.45.0.md
@@ -6,7 +6,7 @@ version: 1.45.0
 
 ### Added
 
-- Added support for customers to create Kubernetes v1.25 clusters
+- Kubernetes 1.25 is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) and [blog post](https://kubernetes.io/blog/2022/08/04/upcoming-changes-in-kubernetes-1-25/).
 
 ### Changed
 

--- a/docs/release-notes/lke/v1.46.0.md
+++ b/docs/release-notes/lke/v1.46.0.md
@@ -1,0 +1,14 @@
+---
+title: Linode Kubernetes Engine v1.46.0
+date: 2023-02-16
+version: 1.46.0
+---
+
+### Added
+
+- Kubeconfig files and service account tokens can be regenerated through the Linode API. See the **Kubernetes Cluster Regenerate** ([POST /lke/clusters/{clusterId}/regenerate](/docs/api/linode-kubernetes-engine-lke/#kubernetes-cluster-regenerate)) and **Service Token Delete** ([DELETE /lke/clusters/{clusterId}/servicetoken](/docs/api/linode-kubernetes-engine-lke/#service-token-delete)) endpoints.
+
+### Changed
+
+- Upgraded clusters using Kubernetes 1.25 to patch version 1.25.6.
+- Upgraded clusters using Kubernetes 1.24 to patch version 1.24.10.

--- a/docs/release-notes/lke/v1.5.1.md
+++ b/docs/release-notes/lke/v1.5.1.md
@@ -6,7 +6,8 @@ version: 1.5.1
 
 ### Changed
 
-- Add support for Kubernetes control plane version 1.16.13 and 1.17.9 with upstream bug fixes. All clusters were upgraded to these versions
+- Upgraded clusters using Kubernetes 1.17 to patch version 1.17.9.
+- Upgraded clusters using Kubernetes 1.16 to patch version 1.16.13.
 
 ### Fixed
 

--- a/docs/release-notes/lke/v1.7.2.md
+++ b/docs/release-notes/lke/v1.7.2.md
@@ -7,4 +7,9 @@ version: 1.7.2
 ### Added
 
 - Add mitigation for CVE-2020-8558 on node initialization. Users should recycle their nodes for these changes to apply.
-- Upgrade the control planes to the latest patch version available: v1.15.12, v1.16.14, and v1.17.11.
+
+### Changed
+
+- Upgraded clusters using Kubernetes 1.17 to patch version 1.17.11.
+- Upgraded clusters using Kubernetes 1.16 to patch version 1.16.14.
+- Upgraded clusters using Kubernetes 1.15 to patch version 1.15.12.

--- a/docs/release-notes/lke/v1.8.0.md
+++ b/docs/release-notes/lke/v1.8.0.md
@@ -6,4 +6,4 @@ version: 1.8.0
 
 ### Added
 
-- Add support for deploying Kubernetes v1.18.8
+- Kubernetes 1.18 (1.18.8) is now available on LKE. Review the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md) and [blog post](https://kubernetes.io/blog/2020/03/25/kubernetes-1-18-release-announcement/).


### PR DESCRIPTION
This PR adds release notes for LKE v1.46.0. It also updates language for Kubernetes upgrades in previous release notes.