### PR TITLE
Change note to read active Linode(s)

### DIFF
--- a/docs/guides/quick-answers/linode-platform/an-overview-of-common-cloud-manager-errors/index.md
+++ b/docs/guides/quick-answers/linode-platform/an-overview-of-common-cloud-manager-errors/index.md
@@ -16,7 +16,7 @@ authors: ["Linode"]
 
 Have you ever encountered an error message while navigating the cloud Manager and wanted more information as to what may have triggered the error and what your best next steps may be? In this guide we'll go over some common error messages in a higher level of detail than are traditionally provided, and discuss your best path forward.
 
-{{< note respectIndent=false >}}
+{{< note >}}
 For more information on troubleshooting, see the [Troubleshooting Section](/docs/guides/troubleshooting/) of our documentation.
 {{< /note >}}
 
@@ -56,9 +56,8 @@ If you see the following message, then you'll be unable to create a resource due
 
 The reasons behind these limits can vary, though in most cases are related to default resource limits set on your account.
 
-
 ## Your DNS Zones are Not Being Served
 
 **Your DNS zones are not being served. Your domains will not be served by Linode's nameservers unless you have at least one Linode present on your account. You can create one here.**
 
-This message is seen when using Linode's DNS Manager without any billable resources currently present on your account. While the DNS Manager is a free service, it does require that at least one billable resource is available on your account. See our [pricing page](https://www.linode.com/pricing/) for more information on resources you can add to freely access the DNS Manager.
+This message is seen when using the DNS Manager without any active Compute Instances. While the DNS Manager is a free service, it does require that at least one active Compute Instance is present on your account. See [DNS Manager Pricing and Availability](/docs/products/networking/dns-manager/#pricing-and-availability).

--- a/docs/products/networking/dns-manager/_index.md
+++ b/docs/products/networking/dns-manager/_index.md
@@ -8,7 +8,7 @@ tab_group_main:
 cascade:
     date: 2020-06-02
     product_description: "A comprehensive, reliable, and fast DNS service, providing easy domain management to Linode customers at no charge."
-modified: 2022-10-28
+modified: 2023-03-16
 aliases: ['/dns-manager/','/platform/manager/dns-manager/','/networking/dns/dns-manager/','/platform/manager/dns-manager-new-manager/','/networking/dns/dns-manager-overview/','/platform/manager/dns-manager-classic-manager/','/guides/dns-manager/']
 ---
 
@@ -26,8 +26,8 @@ In addition to supporting a wide range of DNS record types, the Linode DNS Manag
 
 The DNS Manager is available at no charge across [all regions](https://www.linode.com/global-infrastructure/).
 
-{{< note >}}
-To use the Linode DNS Manager to serve your domains, you must have at least one active Linode on your account. If a Linode does not exist on your account or if all Linodes are removed, DNS records will no longer be served.
+{{< note type="warning" title="DNS Manager Compute Instance requirement">}}
+To use the Linode DNS Manager to serve your domains, you must have at least one active Compute Instance on your account. If your account does not have any Compute Instances (for instance, if they have all been removed), DNS records will not be served.
 {{< /note >}}
 
 ## Technical Specifications

--- a/docs/products/networking/dns-manager/get-started/index.md
+++ b/docs/products/networking/dns-manager/get-started/index.md
@@ -3,7 +3,7 @@ title: Get Started
 description: "Get started with the Linode DNS Manager. Learn to add a domain and add DNS records."
 tab_group_main:
     weight: 20
-modified: 2023-02-09
+modified: 2023-03-16
 ---
 
 Linode's DNS Manager enables users to manage DNS records for each of their domains directly within the tools they already use: like the Cloud Manager, Linode CLI, or Linode API. It supports most common DNS record types, including A, AAAA (quad A), CNAME, MX, TXT, NS, SOA, SRV, and CAA. Follow this guide to learn how to start using the DNS Manager.
@@ -12,10 +12,6 @@ Linode's DNS Manager enables users to manage DNS records for each of their domai
 1. [Create the Domain Zone](#create-the-domain-zone)
 1. [Add DNS Records](#add-dns-records)
 1. [Use Linode's Name Servers](#use-linodes-name-servers)
-
-{{< note >}}
-To use the Linode DNS Manager to serve your domains, you must have at least one billable service on your account, such as a Compute Instance, NodeBalancer, or an Object Storage Bucket. If no services exist on your account or if all services are removed, DNS records are not served.
-{{< /note >}}
 
 ## Understanding DNS
 
@@ -40,6 +36,10 @@ A *domain zone* (also called a [DNS zone](https://en.wikipedia.org/wiki/DNS_zone
 1. For *secondary* domains, add the IP Address of your external DNS provider's name server. If they have more than one name server, click **Add an IP** to add each additional one if desired. See [Incoming DNS Zone Transfers > Operate as a Secondary Read-Only DNS Service](/docs/products/networking/dns-manager/guides/incoming-dns-zone-transfers/#operate-as-a-secondary-read-only-dns-service).
 
 1. Click the **Create Domain** button to create the domain zone.
+
+{{< note type="warning" title="DNS Manager Compute Instance requirement">}}
+To use the Linode DNS Manager to serve your domains, you must have at least one active Compute Instance on your account. If your account does not have any Compute Instances (for instance, if they have all been removed), DNS records will not be served.
+{{< /note >}}
 
 ## Add DNS Records
 


### PR DESCRIPTION
The note regarding DNS Manager states that in order to serve domains, you must have at least one active service. This is inaccurate. The logic in Cloud Manager requires that you have one active Linode. Updated accordingly.