### PR TITLE
Re-Home orphaned guides

### DIFF
--- a/docs/guides/development/architectures/_index.md
+++ b/docs/guides/development/architectures/_index.md
@@ -1,0 +1,5 @@
+---
+title: Architectures
+show_in_lists: true
+aliases: ['/development/architectures/']
+---

--- a/docs/guides/development/c/_index.md
+++ b/docs/guides/development/c/_index.md
@@ -1,0 +1,5 @@
+---
+title: C and C++
+show_in_lists: true
+aliases: ['/development/c/']
+---

--- a/docs/guides/development/next-js/_index.md
+++ b/docs/guides/development/next-js/_index.md
@@ -1,0 +1,5 @@
+---
+title: Next.js
+show_in_lists: true
+aliases: ['/development/next-js/']
+---

--- a/docs/guides/development/web-frameworks/_index.md
+++ b/docs/guides/development/web-frameworks/_index.md
@@ -1,0 +1,5 @@
+---
+title: Web Frameworks
+show_in_lists: true
+aliases: ['/development/web-frameworks/']
+---

--- a/docs/guides/development/web-frameworks/web-frameworks/index.md
+++ b/docs/guides/development/web-frameworks/web-frameworks/index.md
@@ -80,69 +80,69 @@ Popularity and quality are two different quantifiers. Each has superior circumst
 
 ### Angular 4
 
-Google maintains Angular as a SPA web framework written in TypeScript. Angular development can be in either TypeScript or JavaScript, or even alternatives such as [Dart](https://dart.dev/). Angular supports PWA and mobile development as well as the traditional web. Angular is structured in terms of components and directives rather than MVC. Angular improves on AngularJS in several aspects that promote project management; it builds in a command-line interface tool, for example. [Gmail is an Angular application](https://github.com/markbrown4/gmail-angular).
+Google maintains [Angular](https://angular.io/) as a SPA web framework written in TypeScript. Angular development can be in either TypeScript or JavaScript, or even alternatives such as [Dart](https://dart.dev/). Angular supports PWA and mobile development as well as the traditional web. Angular is structured in terms of components and directives rather than MVC. Angular improves on AngularJS in several aspects that promote project management; it builds in a command-line interface tool, for example. [Gmail is an Angular application](https://github.com/markbrown4/gmail-angular).
 
 ### AngularJS
 
-AngularJS is an ancestor of Angular 4 based on JavaScript-coded MVC. Google maintained this as well. Although the support for AngularJS has officially ended as of January 2022, it remains in widespread use. JetBlue and Paypal are examples of high-volume, high-profile sites based on AngularJS.
+[AngularJS](https://angularjs.org/) is an ancestor of Angular 4 based on JavaScript-coded MVC. Google maintained this as well. Although the support for AngularJS has officially ended as of January 2022, it remains in widespread use. JetBlue and Paypal are examples of high-volume, high-profile sites based on AngularJS.
 
 ### ASP.NET Core
 
-ASP.NET Core is a prominent open-source and portable web framework. While Microsoft supports ASP.NET, the framework is available for environments beyond Windows including MacOS, Linus, and Docker. Along with Microsoft products, ASP.NET hosts a variety of web servers including NGINX and Apache. Both client-side and server-side logic can be written with .NET; in particular, it's possible to program clients with C# rather than JavaScript.
+[ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/introduction-to-aspnet-core?view=aspnetcore-7.0) is a prominent open-source and portable web framework. While Microsoft supports ASP.NET, the framework is available for environments beyond Windows including MacOS, Linus, and Docker. Along with Microsoft products, ASP.NET hosts a variety of web servers including NGINX and Apache. Both client-side and server-side logic can be written with .NET; in particular, it's possible to program clients with C# rather than JavaScript.
 
 Among ASP.NET's virtues is [high performance](https://www.socalcto.com/2016/07/techempower-benchmarks-and-microsoft.html). ASP.NET frames several of the most well-known websites, including Microsoft's own, GoDaddy, StackOverflow, Dell, and the US Government's Small Business Administration.
 
 ### Backbone.js
 
-Backbone is an MVC framework. While Backbone is often used for SPA, it also permits more conventional multiple-page applications. The [WP-AppKit plugin](https://uncategorized-creations.com/wp-appkit/) gives Backbone progressive web application (PWA) capabilities. Backbone supports JavaScript on the front end and a variety of back-end technologies. Prominent uses of Backbone include the corporate sites for Hulu, US Today, Pandora, and Trello.
+[Backbone](https://backbonejs.org/) is an MVC framework. While Backbone is often used for SPA, it also permits more conventional multiple-page applications. The [WP-AppKit plugin](https://uncategorized-creations.com/wp-appkit/) gives Backbone progressive web application (PWA) capabilities. Backbone supports JavaScript on the front end and a variety of back-end technologies. Prominent uses of Backbone include the corporate sites for Hulu, US Today, Pandora, and Trello.
 
 ### CodeIgniter
 
-CodeIgniter is a backend MVC framework. It exposes PHP as the preferred language for application development and also supports the easy construction of [REST APIs](https://dev.to/vishnuchilamakuru/10-popular-rest-frameworks-for-your-microservice-39ao). As is common with PHP technologies, CodeIgniter builds in good database support, and loads quickly: all of CodeIgniter loads into a fresh process in a small fraction of a second, even with mediocre hardware. CodeIgniter documentation is extensive. The McClatchy newspaper chain is an example of an organization that uses CodeIgniter for its [corporate website](https://www.mcclatchy.com/).
+[CodeIgniter](https://codeigniter.com/) is a backend MVC framework. It exposes PHP as the preferred language for application development and also supports the easy construction of [REST APIs](https://dev.to/vishnuchilamakuru/10-popular-rest-frameworks-for-your-microservice-39ao). As is common with PHP technologies, CodeIgniter builds in good database support, and loads quickly: all of CodeIgniter loads into a fresh process in a small fraction of a second, even with mediocre hardware. CodeIgniter documentation is extensive. The McClatchy newspaper chain is an example of an organization that uses CodeIgniter for its [corporate website](https://www.mcclatchy.com/).
 
 ### Django
 
-Django is a well-known server-side web framework written in Python. Flagship Django-based websites that handle billions of monthly active users include YouTube, Instagram, BitBucket, the New York Times, DropBox, Pinterest, and Mozilla.
+[Django](https://www.djangoproject.com/) is a well-known server-side web framework written in Python. Flagship Django-based websites that handle billions of monthly active users include YouTube, Instagram, BitBucket, the New York Times, DropBox, Pinterest, and Mozilla.
 
 ### Ember.js
 
-Ember.js is a full-stack MVC SPA JavaScript framework. Its profile is similar to those of Backbone.js and AngularJS. Ember.js's reputation is a bit "heavy"; it occupies a lot of computing memory and is large enough conceptually to be a challenge to learn. Ember.js supports code reuse and a relatively rich ecosystem of third-party libraries. LinkedIn is a well-known Ember.js-based website.
+[Ember.js](https://emberjs.com/) is a full-stack MVC SPA JavaScript framework. Its profile is similar to those of Backbone.js and AngularJS. Ember.js's reputation is a bit "heavy"; it occupies a lot of computing memory and is large enough conceptually to be a challenge to learn. Ember.js supports code reuse and a relatively rich ecosystem of third-party libraries. LinkedIn is a well-known Ember.js-based website.
 
 ### Express.js
 
-Express.js is a full-stack MVC web framework based on Node.js: programming is in JavaScript on both the front and back end. Express.js emphasizes flexibility; successful SPA and multi-page projects are based on Express.js. Express.js itself is a component of such frameworks as MERN and MEAN.
+[Express.js](https://expressjs.com/) is a full-stack MVC web framework based on Node.js: programming is in JavaScript on both the front and back end. Express.js emphasizes flexibility; successful SPA and multi-page projects are based on Express.js. Express.js itself is a component of such frameworks as MERN and MEAN.
 
 ### Gatsby
 
-Gatsby is based on React and therefore is an MVC-oriented full-stack JavaScript framework. Gatsby is among the youngest frameworks on this list and is particularly tuned to static site generation. [Most Recommended Books](https://www.mostrecommendedbooks.com/) is an example of a site built with Gatsby.
+[Gatsby](https://www.gatsbyjs.com/) is based on React and therefore is an MVC-oriented full-stack JavaScript framework. Gatsby is among the youngest frameworks on this list and is particularly tuned to static site generation. [Most Recommended Books](https://www.mostrecommendedbooks.com/) is an example of a site built with Gatsby.
 
 ### Laravel
 
-Laravel is a back-end MVC web framework written in PHP. It is known for its rich collection of support documentation. Laravel's performance is believed to lag behind such competitors as Django and Express.js. Among the roughly [million websites worldwide based on Laravel](https://laravel.com/) is the trading market research platform [Barchart](https://www.barchart.com/).
+[Laravel](https://laravel.com/) is a back-end MVC web framework written in PHP. It is known for its rich collection of support documentation. Laravel's performance is believed to lag behind such competitors as Django and Express.js. Among the roughly [million websites worldwide based on Laravel](https://laravel.com/) is the trading market research platform [Barchart](https://www.barchart.com/).
 
 ### MeteorJS
 
-MeteorJS is like most other JavaScript-based full-stack web frameworks in its MVC architecture, ability to program both client and server in the same language, and an active community of helpful fellow users. MeteorJS emphasizes both real-time performance and ease of use in the sense of programmer productivity. Among its built-in capabilities are conveniences to allow users to register with their accounts from Google or Facebook or other popular services. It integrates front-end assets like LESS, Bootstrap, and D3.js.
+[MeteorJS](https://www.meteor.com/) is like most other JavaScript-based full-stack web frameworks in its MVC architecture, ability to program both client and server in the same language, and an active community of helpful fellow users. MeteorJS emphasizes both real-time performance and ease of use in the sense of programmer productivity. Among its built-in capabilities are conveniences to allow users to register with their accounts from Google or Facebook or other popular services. It integrates front-end assets like LESS, Bootstrap, and D3.js.
 
 ### Play
 
-Play provides MVC like nearly all these frameworks, but unlike any other, it is written in Scala, and most often programmed in Scala, or Java. Play answers the questions an enterprise-grade web framework needs to address. It integrates support for the Selenium and JUnit testing facilities, as well as full REST capabilities, including asynchronous I/O. HuffPost and Coursera use the Play Framework.
+[Play](https://www.playframework.com/) provides MVC like nearly all these frameworks, but unlike any other, it is written in Scala, and most often programmed in Scala, or Java. Play answers the questions an enterprise-grade web framework needs to address. It integrates support for the Selenium and JUnit testing facilities, as well as full REST capabilities, including asynchronous I/O. HuffPost and Coursera use the Play Framework.
 
 ### Rails
 
-Ruby on Rails has been influential over the last two decades. Beginning developers early in this millennium often believed that Rails defined the server-side MVC web framework, or that the Ruby programming language existed only to write web pages. While neither of these is true, Rails remains a leader in new development. Celebrated websites running on Rails include GitHub, AirBnb, Hulu, Shopify, and Twitch.
+[Ruby on Rails](https://rubyonrails.org/) has been influential over the last two decades. Beginning developers early in this millennium often believed that Rails defined the server-side MVC web framework, or that the Ruby programming language existed only to write web pages. While neither of these is true, Rails remains a leader in new development. Celebrated websites running on Rails include GitHub, AirBnb, Hulu, Shopify, and Twitch.
 
 ### React.js
 
-Like Angular and AngularJS, React.js is more of an MVC library than a framework. Facebook sponsors React.js. Its use is widespread in the development of web applications, making such sites as Netflix, Zapier, and Asana possible.
+Like Angular and AngularJS, [React.js](https://react.dev/) is more of an MVC library than a framework. Facebook sponsors React.js. Its use is widespread in the development of web applications, making such sites as Netflix, Zapier, and Asana possible.
 
 ### Spring MVC
 
-Spring MVC is the most popular web framework which extends the Spring Java Enterprise Edition platform to the web. Dave Ramsey's EveryDollar combines Spring MVC on the back end with ReactJS for browser-side programming, and thousands of other organizations leverage their enterprise programming with Spring MVC.
+[Spring MVC](https://docs.spring.io/spring-framework/docs/3.2.x/spring-framework-reference/html/mvc.html) is the most popular web framework which extends the Spring Java Enterprise Edition platform to the web. Dave Ramsey's EveryDollar combines Spring MVC on the back end with ReactJS for browser-side programming, and thousands of other organizations leverage their enterprise programming with Spring MVC.
 
 ### Vue.js
 
-Vue.js brands itself as "The Progressive JavaScript Framework", and provides an [MVVM](https://www.techtarget.com/whatis/definition/Model-View-ViewModel), rather than MVC, architecture. Vue.js' use in GitLab, Chess.com, and, rather provocatively, the official Laravel website, attests to Vue.js's ability to handle high volumes.
+[Vue.js](https://vuejs.org/) brands itself as "The Progressive JavaScript Framework", and provides an [MVVM](https://www.techtarget.com/whatis/definition/Model-View-ViewModel), rather than MVC, architecture. Vue.js' use in GitLab, Chess.com, and, rather provocatively, the official Laravel website, attests to Vue.js's ability to handle high volumes.
 
 ## Conclusion
 

--- a/docs/guides/development/webassembly/_index.md
+++ b/docs/guides/development/webassembly/_index.md
@@ -1,0 +1,5 @@
+---
+title: Web Assembly
+show_in_lists: true
+aliases: ['/development/webassembly/']
+---


### PR DESCRIPTION
Added _index.md to directories without them, which should clear up the orphan links in the development section of the nav.

Also, add links to various web frameworks in web frameworks guide.