### PR TITLE
[Update] Compute Instances > Overview

### DIFF
--- a/docs/products/compute/compute-instances/_index.md
+++ b/docs/products/compute/compute-instances/_index.md
@@ -8,6 +8,7 @@ tab_group_main:
 cascade:
     date: 2023-01-18
     product_description: "Linux virtual machines equipped with a tailored set of resources designed to run any cloud-based workload."
+modified: 2023-03-22
 ---
 
 {{< content "april-price-update-shortguide" >}}
@@ -29,12 +30,15 @@ In addition to the resources allocated to each available plan (outlined above), 
 - Shared or Dedicated vCPU cores (dependent on the chosen plan)
 - 100% SSD (Solid State Disk) storage
 - 40 Gbps inbound network bandwidth
-- Free inbound network transfer
+- Free inbound network transfer (ingress)
+- Metered outbound network transfer (egress) that includes 1 TB - 20 TB of prorated* network transfer allowance
 - Dedicated IPv4 and IPv6 addresses (additional addresses available on request)
 - Deploy using the many available [Linux Distributions](https://www.linode.com/distributions/), [Marketplace Apps](https://www.linode.com/marketplace/), or Community [StackScripts](https://www.linode.com/products/stackscripts/)
 - Direct console access through [Lish](/docs/products/compute/compute-instances/guides/lish/)
 - Provisioning and management through the [Cloud Manager](https://cloud.linode.com/), [Linode CLI](https://www.linode.com/products/cli/), or programmatically through the [Linode API](https://www.linode.com/products/linode-api/)
 - [Multi-queue NIC](/docs/products/compute/compute-instances/guides/multiqueue-nic/) support on plans with 2 or more vCPU cores.
+
+\**If a service is not active for the entire month, the amount of network transfer allowance is prorated based on the number of hours the service is active.*
 
 ## Services Included at No Extra Cost
 

--- a/docs/products/platform/get-started/guides/network-transfer/index.md
+++ b/docs/products/platform/get-started/guides/network-transfer/index.md
@@ -3,7 +3,7 @@ description: "Learn how your Linode account's network transfer pool is calculate
 keywords: ["network","billing","account","transfer", "overage"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2018-08-21
-modified: 2022-06-17
+modified: 2023-03-22
 modified_by:
   name: Linode
 title: "Network Transfer Usage and Costs"
@@ -24,19 +24,15 @@ On April 1st 2023, updated pricing will go into effect for some Compute services
 
 The following Linode services consume network transfer and, in most cases, include a set amount of outbound network transfer allowance per month. The amount of transfer is displayed along with the pricing and plan details for each service. See Linode's [pricing page](https://www.linode.com/pricing) for exact amounts.
 
-- **Compute Instances:** Consume network transfer and include 1-20 TB of transfer allowance per month, depending on plan size
+- **Compute Instances:** Consume network transfer and include 1-20 TB of transfer allowance per month, depending on plan size.
 
 - **NodeBalancers:** Consume network transfer but do not include a monthly transfer allowance.
 
-- **Object Storage:** Consumes network transfer and includes 1TB of transfer allowance per month, regardless of plan size
+- **Object Storage:** Consumes network transfer and includes 1TB of transfer allowance per month, regardless of plan size.
 
 - **Managed Databases:** Does not consume network transfer or include a monthly transfer allowance.
 
 The allowance included with each service on an account is added to an account-wide **monthly network transfer pool**. Whenever a service consumes network transfer, it is counted towards this account-wide pool and not the individual transfer allowance.
-
-{{< note >}}
-If the service is not active for the entire month, the amount of network transfer allowance is prorated based on the number of hours the service was active.
-{{< /note >}}
 
 ## Usage Costs
 
@@ -55,6 +51,10 @@ Costs associated with network transfer can often be unexpected or confusing in a
 - Outbound transfer from Object Storage (over both public IPv6 and public IPv4), even to other Linode services within the same data center.
 
 All metered network transfer consumed by a service is counted toward the account-wide **monthly network transfer pool**. Any additional transfer usage that exceeds this monthly allotment costs $0.01/GB (which comes to $10/TB) and is charged at the end of the billing period.
+
+{{< note >}}
+If a service is not active for the entire month, the amount of network transfer allowance is prorated based on the number of hours the service is active.
+{{< /note >}}
 
 {{< note >}}
 The combined monthly network transfer pool is typically enough to cover *most* common use cases for our services. You are only billed for additional network transfer if your usage exceeds this monthly pool during a billing period. If traffic for an individual service exceeds the network transfer amount specified by its plan, but the total transfer used between all of your services is still less than your monthly network transfer pool, then you are *not* charged additional fees.

--- a/docs/products/platform/get-started/guides/network-transfer/index.md
+++ b/docs/products/platform/get-started/guides/network-transfer/index.md
@@ -28,7 +28,7 @@ The following Linode services consume network transfer and, in most cases, inclu
 
 - **NodeBalancers:** Consume network transfer but do not include a monthly transfer allowance.
 
-- **Object Storage:** Consumes network transfer and includes 1TB of transfer allowance per month, regardless of plan size.
+- **Object Storage:** Consumes network transfer and includes 1 TB of transfer allowance per month, regardless of usage.
 
 - **Managed Databases:** Does not consume network transfer or include a monthly transfer allowance.
 

--- a/docs/products/platform/get-started/guides/network-transfer/index.md
+++ b/docs/products/platform/get-started/guides/network-transfer/index.md
@@ -34,6 +34,10 @@ The following Linode services consume network transfer and, in most cases, inclu
 
 The allowance included with each service on an account is added to an account-wide **monthly network transfer pool**. Whenever a service consumes network transfer, it is counted towards this account-wide pool and not the individual transfer allowance.
 
+{{< note >}}
+If a service is not active for the entire month, the amount of network transfer allowance is prorated based on the number of hours the service is active.
+{{< /note >}}
+
 ## Usage Costs
 
 Costs associated with network transfer can often be unexpected or confusing in a cloud hosting environment. Linode keeps these costs simple and transparent so that you can easily anticipate your monthly charges.
@@ -51,10 +55,6 @@ Costs associated with network transfer can often be unexpected or confusing in a
 - Outbound transfer from Object Storage (over both public IPv6 and public IPv4), even to other Linode services within the same data center.
 
 All metered network transfer consumed by a service is counted toward the account-wide **monthly network transfer pool**. Any additional transfer usage that exceeds this monthly allotment costs $0.01/GB (which comes to $10/TB) and is charged at the end of the billing period.
-
-{{< note >}}
-If a service is not active for the entire month, the amount of network transfer allowance is prorated based on the number of hours the service is active.
-{{< /note >}}
 
 {{< note >}}
 The combined monthly network transfer pool is typically enough to cover *most* common use cases for our services. You are only billed for additional network transfer if your usage exceeds this monthly pool during a billing period. If traffic for an individual service exceeds the network transfer amount specified by its plan, but the total transfer used between all of your services is still less than your monthly network transfer pool, then you are *not* charged additional fees.


### PR DESCRIPTION
This PR adds a technical specification for Compute Instances that outlines the egress / network transfer range with a note regarding prorating the amount based on the number of hours a service is active.