### PR TITLE
Misc formatting and other fixes

### DIFF
--- a/docs/guides/applications/social-networking/how-to-install-and-configure-hubzilla/index.md
+++ b/docs/guides/applications/social-networking/how-to-install-and-configure-hubzilla/index.md
@@ -88,29 +88,29 @@ Hubzilla relies upon a LAMP stack consisting of the Apache web server, the Maria
 
 1.  Ensure the Ubuntu packages are up to date. Reboot the system if advised to do so.
 
-    ```code
+    ```command
     sudo apt-get update -y && sudo apt-get upgrade -y
     ```
 
 2.  Install the Apache web server and the MariaDB RDBMS.
 
-    ```code
+    ```command
     sudo apt install apache2 mariadb-server -y
     ```
 
 3.  Install PHP, including all required PHP libraries, along with some additional utilities.
 
     {{< note >}}
-Hubzilla requires PHP release 8.0 or higher. The following command installs the current PHP release 8.1. To confirm the release of PHP in use, run the command `php -v`.
+    Hubzilla requires PHP release 8.0 or higher. The following command installs the current PHP release 8.1. To confirm the release of PHP in use, run the command `php -v`.
     {{< /note >}}
 
-    ```code
+    ```command
     sudo apt install openssh-server git php php-fpm php-curl php-gd php-mbstring php-xml php-mysql php-zip php-json php-cli imagemagick fail2ban wget libapache2-mod-fcgid -y
     ```
 
 4.  Use the `systemctl` command to ensure Apache and MariaDB are running and configured to start automatically at boot time.
 
-    ```code
+    ```command
     sudo systemctl start apache2
     sudo systemctl enable apache2
     sudo systemctl start mysql
@@ -119,23 +119,23 @@ Hubzilla requires PHP release 8.0 or higher. The following command installs the 
 
 5.  Verify Apache is running using the `systemctl status` command.
 
-    ```code
+    ```command
     sudo systemctl status apache2
     ```
 
-    {{< output >}}
-apache2.service - The Apache HTTP Server
-    Loaded: loaded (/lib/systemd/system/apache2.service; enabled; vendor preset: enabled)
-    Active: active (running) since Wed 2022-11-16 13:38:25 UTC; 10min ago
-    {{< /output >}}
+    ```output
+    apache2.service - The Apache HTTP Server
+        Loaded: loaded (/lib/systemd/system/apache2.service; enabled; vendor preset: enabled)
+        Active: active (running) since Wed 2022-11-16 13:38:25 UTC; 10min ago
+    ```
 
 6.  Configure the firewall to allow Apache connections. Ensure SSH connections are also allowed.
 
     {{< note >}}
-If you intend to use SSL to secure the Hubzilla installation, use the `Apache Full` profile. Otherwise, enable the `Apache` profile. Hubzilla tests the well-known HTTPS port first, so this port must not be open unless HTTPS is used. HTTPS is highly recommended for enhanced security. For conciseness, this guide does not configure HTTPS. However, the basic Hubzilla installation process is the same in both cases.
+    If you intend to use SSL to secure the Hubzilla installation, use the `Apache Full` profile. Otherwise, enable the `Apache` profile. Hubzilla tests the well-known HTTPS port first, so this port must not be open unless HTTPS is used. HTTPS is highly recommended for enhanced security. For conciseness, this guide does not configure HTTPS. However, the basic Hubzilla installation process is the same in both cases.
     {{< /note >}}
 
-    ```code
+    ```command
     sudo ufw allow OpenSSH
     sudo ufw allow in "Apache"
     sudo ufw enable
@@ -143,20 +143,20 @@ If you intend to use SSL to secure the Hubzilla installation, use the `Apache Fu
 
 7.  Ensure the firewall is enabled.
 
-    ```code
+    ```command
     sudo ufw status
     ```
 
-    {{< output >}}
-Status: active
+    ```output
+    Status: active
 
-To                         Action      From
---                         ------      ----
-OpenSSH                    ALLOW       Anywhere
-Apache                     ALLOW       Anywhere
-OpenSSH (v6)               ALLOW       Anywhere (v6)
-Apache (v6)                ALLOW       Anywhere (v6)
-    {{< /output >}}
+    To                         Action      From
+    --                         ------      ----
+    OpenSSH                    ALLOW       Anywhere
+    Apache                     ALLOW       Anywhere
+    OpenSSH (v6)               ALLOW       Anywhere (v6)
+    Apache (v6)                ALLOW       Anywhere (v6)
+    ```
 
 8.  Visit the IP address or domain name of the server. The `Apache2 Default Page` should be displayed.
 
@@ -168,31 +168,31 @@ Apache (v6)                ALLOW       Anywhere (v6)
     -   For `Switch to unix_socket authentication` and `Change the root password?`, enter `n`.
     -   For `Remove anonymous users?`, `Disallow root login remotely?`, `Remove test database and access to it?` and `Reload privilege tables now?`, enter `Y`.
 
-        ```code
+        ```command
         sudo mysql_secure_installation
         ```
 
 2.  Log in to MariaDB. Provide the root password if necessary.
 
-    ```code
+    ```command
     sudo mysql
     ```
 
 3.  Create a `hubzilla` database for the application to use.
 
-    ```code
+    ```command
     CREATE DATABASE hubzilla;
     ```
 
 4.  Create a user for the new database. Supply a unique password in place of `mypassword`.
 
-    ```code
+    ```command
     CREATE USER 'hubzilla'@'localhost' IDENTIFIED BY 'mypassword';
     ```
 
 5.  Grant all privileges for the `hubzilla` database to the new user. Flush the privileges and exit.
 
-    ```code
+    ```command
     GRANT ALL PRIVILEGES ON hubzilla.* TO 'hubzilla'@'localhost';
     FLUSH PRIVILEGES;
     EXIT;
@@ -201,10 +201,10 @@ Apache (v6)                ALLOW       Anywhere (v6)
 6.  Hubzilla requires the `mpm_event` module. To enable this module, first stop Apache and disable `php-8.1` and `mpm_prefork`.
 
     {{< note >}}
-Disable the `php` module associated with the current PHP release. The format of the module name is `php-releasenumber`, where the release number is the major and minor release of PHP. Use the command `php -v` to find this release information.
+    Disable the `php` module associated with the current PHP release. The format of the module name is `php-releasenumber`, where the release number is the major and minor release of PHP. Use the command `php -v` to find this release information.
     {{< /note >}}
 
-    ```code
+    ```command
     sudo systemctl stop apache2
     sudo a2dismod php8.1
     sudo a2dismod mpm_prefork
@@ -212,14 +212,14 @@ Disable the `php` module associated with the current PHP release. The format of 
 
 7.  Enable the PHP `rewrite` and `mpm_event` modules.
 
-    ```code
+    ```command
     sudo a2enmod rewrite
     sudo a2enmod mpm_event
     ```
 
 8.  Connect Apache to the `fpm` mechanism. Enable the following modules and configurations.
 
-    ```code
+    ```command
     sudo a2enconf php8.1-fpm
     sudo a2enmod proxy
     sudo a2enmod proxy_fcgi
@@ -227,7 +227,7 @@ Disable the `php` module associated with the current PHP release. The format of 
 
 9.  Restart Apache and verify it is `active`. If the restart fails, run the `sudo apachectl configtest` command. Review and correct any errors.
 
-    ```code
+    ```command
     sudo systemctl restart apache2
     sudo systemctl status apache2
     ```
@@ -238,7 +238,7 @@ Hubzilla requires its own virtual host to function properly. Create a new `hubzi
 
 1.  Change to the `/etc/apache2/sites-available/` directory and create the new `hubzilla.conf` file.
 
-    ```code
+    ```command
     cd /etc/apache2/sites-available
     sudo nano hubzilla.conf
     ```
@@ -265,19 +265,19 @@ Hubzilla requires its own virtual host to function properly. Create a new `hubzi
 
 3.  Enable the new site.
 
-    ```code
+    ```command
     sudo a2ensite hubzilla
     ```
 
 4.  **Optional** For extra security, disable the default Apache site.
 
-    ```code
+    ```command
     sudo a2dissite 000-default.conf
     ```
 
 5.  Restart Apache and verify its status.
 
-    ```code
+    ```command
     sudo systemctl restart apache2
     sudo systemctl status apache2
     ```
@@ -288,32 +288,32 @@ The LAMP stack is now fully configured and ready for Hubzilla. Use `git` to down
 
 1.  Change directory to `/var/www/html`.
 
-    ```code
+    ```command
     cd /var/www/html
     ````
 
 2.  Use `git` to clone the latest release of Hubzilla from the code base.
 
-    ```code
+    ```command
     sudo git clone https://framagit.org/hubzilla/core.git hubzilla
     ```
 
 3.  Change to the `hubzilla` directory and install the add-ons.
 
-    ```code
+    ```command
     cd hubzilla
     sudo util/add_addon_repo https://framagit.org/hubzilla/addons addons-official
     ```
 
 4.  Create the `store` directory and ensure it is writable.
 
-    ```code
+    ```command
     sudo mkdir -p "store/[data]/smarty3"
     ```
 
 5.  Change ownership and permissions for the `hubzilla` directory.
 
-    ```code
+    ```command
     sudo chown -R www-data:www-data /var/www/html/hubzilla/
     sudo chmod -R 755 /var/www/html/hubzilla/
     ```
@@ -322,13 +322,13 @@ The LAMP stack is now fully configured and ready for Hubzilla. Use `git` to down
 
 6.  Add a `cron` task to update the site every 10 minutes. Run the `crontab -e` command to edit the list of `root` cron jobs.
 
-    ```code
+    ```command
     sudo crontab -e
     ```
 
 7.  Add the following line to the end of the cron file. `usr/bin/php` represents the path to the PHP installation. Before proceeding, confirm the location of PHP using the command `which php`.
 
-    ```code
+    ```command
     */10 * * * *    cd /var/www/html/hubzilla; /usr/bin/php Zotlabs/Daemon/Master.php Cron > /dev/null 2>&1
     ```
 
@@ -349,7 +349,7 @@ To initialize Hubzilla and get it ready for deployment, use the simple web inter
 4.  Hubzilla proceeds to the `Site settings` page. Enter an email address for the site administrator and select the default time zone. The `Website URL` must be set to the domain name for the Hubzilla server. Click **Submit** to continue.
 
     {{< note >}}
-The administration email must contain a valid email address. Hubzilla sends a verification email to the account to confirm the registration.
+    The administration email must contain a valid email address. Hubzilla sends a verification email to the account to confirm the registration.
     {{< /note >}}
 
     ![Hubzilla Site Settings](Hubzilla-Site-Settings.png)
@@ -361,21 +361,21 @@ The administration email must contain a valid email address. Hubzilla sends a ve
 6.  On the `Registration` page, enter an account name, a short nickname to represent the channel on the site, a valid email address, and a password. If registering as an administrator, use the administrator email provided earlier in the Hubzilla site settings. Select the checkbox to agree to the terms of service and click **Register**.
 
     {{< note >}}
-After selecting `Register`, Hubzilla must send an email to the email address of the account. The Linode must have email turned on to complete this process.
+    After selecting `Register`, Hubzilla must send an email to the email address of the account. The Linode must have email turned on to complete this process.
 
-For non-production Hubzilla testing, it is possible to remove the mail server requirements by editing a Hubzilla configuration file. To do so, open the `.htconfig.php` file located at `/var/www/html/hubzilla` and change the `1` in the following line:
+    For non-production Hubzilla testing, it is possible to remove the mail server requirements by editing a Hubzilla configuration file. To do so, open the `.htconfig.php` file located at `/var/www/html/hubzilla` and change the `1` in the following line:
 
-```file {title="/var/www/html/hubzilla/.htconfig.php"}
-App::$config['system']['verify_email'] = 1;
-```
+    ```file {title="/var/www/html/hubzilla/.htconfig.php"}
+    App::$config['system']['verify_email'] = 1;
+    ```
 
-To instead be a `0`:
+    To instead be a `0`:
 
-```file {title="/var/www/html/hubzilla/.htconfig.php"}
-App::$config['system']['verify_email'] = 0;
-```
+    ```file {title="/var/www/html/hubzilla/.htconfig.php"}
+    App::$config['system']['verify_email'] = 0;
+    ```
 
-This configuration change is not recommended on production installations.
+    This configuration change is not recommended on production installations.
     {{< /note >}}
 
     ![Hubzilla Registration](Hubzilla-Registration.png)

--- a/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-22-04/index.md
+++ b/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-22-04/index.md
@@ -4,6 +4,7 @@ description: 'This guide explains how to upgrade inline from Ubuntu 20.04 or 21.
 keywords: ['Upgrade Ubuntu','Upgrade from Ubuntu 20.04','Upgrade to Ubuntu 22.04','Ubuntu inline upgrade']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2022-11-07
+modified: 2023-03-29
 modified_by:
   name: Linode
 title: "Upgrade to Ubuntu 22.04 LTS"
@@ -51,7 +52,7 @@ In an inline upgrade, the primary node is upgraded in place using either the GUI
 -   This method of upgrading tends to retain "digital residue". This includes unnecessary or outdated packages, patches, and data.
 -   This method is recommended if the system is only one release behind and is mainly running a widely used and tested configuration such as a LAMP stack. An inline upgrade might run into more problems when the system configuration is complicated or includes in-house applications.
 
-{{< note type="alert" respectIndent=false >}}
+{{< note type="warning" >}}
 Although this process upgrades the Ubuntu operating system and most common programs, it does not necessarily upgrade every application. It is difficult to predict how the upgrade might affect these programs.
 {{< /note >}}
 
@@ -76,7 +77,7 @@ For an in-depth explanation of the clean install method, see the [Linode guide t
 
 1.  Ensure there is at least 20 GB of disk space available. Verify the amount of disk space availability using the `df -Th` command.
 
-{{< note respectIndent=false >}}
+{{< note >}}
 This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you are not familiar with the `sudo` command, see the [Users and Groups](/docs/guides/linux-users-and-groups/) guide.
 {{< /note >}}
 
@@ -86,7 +87,7 @@ This guide is designed for users who want to upgrade from Ubuntu 20.04 LTS to Ub
 
 If the Linode is running Ubuntu 18.xx or any earlier release, first upgrade it to Ubuntu 20.04 LTS. Then perform the steps in this guide to upgrade from Ubuntu 20.04 LTS to the 22.04 LTS. See the [Linode guide to Upgrade to Ubuntu 20.04](/docs/guides/upgrade-to-ubuntu-20-04/) for more information. Alternatively, if the Ubuntu software and applications are very old, it might make more sense to perform a clean install instead.
 
-{{< note type="alert" respectIndent=false >}}
+{{< note type="alert" >}}
 This operation cannot be canceled after it is started. Ensure there is a stable connection to the Linode and backup power is available.
 {{< /note >}}
 
@@ -98,19 +99,19 @@ To prepare the Ubuntu system for the upgrade, follow these steps.
 
 1.  Upgrade the Linode and ensure it is up to date.
 
-    ```code
+    ```command
     sudo apt update -y && sudo apt upgrade -y && sudo apt dist-upgrade -y
     ```
 
 2.  To simplify the upgrade, remove unused packages and files.
 
-    ```code
+    ```command
     sudo apt autoremove -y && sudo apt autoclean -y
     ```
 
 3.  Reboot the node to ensure any new kernel upgrades are installed. Linode makes new kernels available through the Linode cloud manager. Any updates are automatically applied to the node upon a reboot. For more information, see the [Linode guide to monitoring and maintaining a system](/docs/guides/monitor-and-maintain-compute-instance/#apply-kernel-updates).
 
-    ```code
+    ```command
     sudo reboot
     ```
 
@@ -118,74 +119,74 @@ To prepare the Ubuntu system for the upgrade, follow these steps.
 
 5.  Stop as many non-critical user applications services as possible, including web and database servers. Focus on applications that might be subject to data corruption. To see a list of the active services, use the command `systemctl | grep running`.
 
-    ```code
+    ```command
     sudo systemctl | grep running
     ```
 
-    {{< output >}}
-...
-apache2.service loaded active running The Apache HTTP Server
-...
-mysql.service loaded active running MySQL Community Server
-    {{< /output >}}
+    ```output
+    ...
+    apache2.service loaded active running The Apache HTTP Server
+    ...
+    mysql.service loaded active running MySQL Community Server
+    ```
 
 6.  Use the command `sudo systemctl stop <application_name>` to stop a service. The following example demonstrates how to stop the Apache web server instance.
 
-    {{< note type="alert" respectIndent=false >}}
-Do not stop any essential system services such as `ssh` or any `systemd` entry.
+    {{< note type="alert" >}}
+    Do not stop any essential system services such as `ssh` or any `systemd` entry.
     {{< /note >}}
 
-    ```code
+    ```command
     sudo systemctl stop apache2
     ```
 
 7.  Allow connections on TCP port 1022 through the `ufw` firewall. This permits Ubuntu to use a fallback port if the main connection drops. After adding the rule, reload the firewall.
 
-    ```code
+    ```command
     sudo ufw allow 1022/tcp
     sudo ufw reload
     ```
 
-    {{< output >}}
-Firewall reloaded
-    {{< /output >}}
+    ```output
+    Firewall reloaded
+    ```
 
 8.  Confirm connections on TCP port 1022 are now allowed.
 
-    ```code
+    ```command
     sudo ufw status
     ```
 
-    {{< output >}}
-Status: active
+    ```output
+    Status: active
 
-To                         Action      From
---                         ------      ----
-OpenSSH                    ALLOW       Anywhere
-Apache Full                ALLOW       Anywhere
-1022/tcp                   ALLOW       Anywhere
-OpenSSH (v6)               ALLOW       Anywhere (v6)
-Apache Full (v6)           ALLOW       Anywhere (v6)
-1022/tcp (v6)              ALLOW       Anywhere (v6)
-    {{< /output >}}
+    To                         Action      From
+    --                         ------      ----
+    OpenSSH                    ALLOW       Anywhere
+    Apache Full                ALLOW       Anywhere
+    1022/tcp                   ALLOW       Anywhere
+    OpenSSH (v6)               ALLOW       Anywhere (v6)
+    Apache Full (v6)           ALLOW       Anywhere (v6)
+    1022/tcp (v6)              ALLOW       Anywhere (v6)
+    ```
 
 ### How to Install Ubuntu Release 22.04
 
 The node is now ready for the upgrade. Ensure the update manager is installed, then initiate the upgrade. The upgrade might take some time, depending on the configuration, and must not be interrupted. Ensure there is enough time to complete the entire upgrade before proceeding.
 
-{{< note respectIndent=false >}}
+{{< note >}}
 The upgrade operation can be performed using either a LISH session or an SSH connection. A LISH session is safer, but if SSH is used, the upgrade manager opens a second port for redundancy. This guide uses SSH for the procedure to demonstrate the additional steps required.
 {{< /note >}}
 
 1.  Ensure the `update-manager-core` package is installed. On many systems, this package might already be available.
 
-    ```code
+    ```command
     sudo apt install update-manager-core
     ```
 
 2.  Confirm the release-upgrader is set to the correct release update mode. The file `/etc/update-manager/release-upgrades` must include the line `Prompt=lts`.
 
-    ```code
+    ```command
     sudo cat /etc/update-manager/release-upgrades
     ```
 
@@ -210,87 +211,87 @@ The upgrade operation can be performed using either a LISH session or an SSH con
 
 3.  Run the `do-release-upgrade` command to start the upgrade.
 
-    {{< note respectIndent=false >}}
-To force an upgrade from the latest supported release to a development release, use the command `do-release-upgrade -d`. This guide focuses on upgrading to the latest supported release and does not use this flag.
+    {{< note >}}
+    To force an upgrade from the latest supported release to a development release, use the command `do-release-upgrade -d`. This guide focuses on upgrading to the latest supported release and does not use this flag.
     {{< /note >}}
 
-    ```code
+    ```command
     sudo do-release-upgrade
     ```
 
 4.  If the operation is performed using a SSH connection, Ubuntu verifies the SSH connection details and asks whether to continue. Answer `y` to continue.
 
-    {{< output >}}
-Continue running under SSH?
+    ```output
+    Continue running under SSH?
 
-This session appears to be running under ssh. It is not recommended
-to perform a upgrade over ssh currently because in case of failure it
-is harder to recover.
+    This session appears to be running under ssh. It is not recommended
+    to perform a upgrade over ssh currently because in case of failure it
+    is harder to recover.
 
-If you continue, an additional ssh daemon will be started at port
-'1022'.
-Do you want to continue?
-    {{< /output >}}
+    If you continue, an additional ssh daemon will be started at port
+    '1022'.
+    Do you want to continue?
+    ```
 
 5.  Ubuntu asks the user to confirm the new SSH port is allowed through the firewall. The port should already be open. Press the **Enter** key to continue.
 
-    {{< output >}}
-Starting additional sshd
+    ```output
+    Starting additional sshd
 
-To make recovery in case of failure easier, an additional sshd will
-be started on port '1022'. If anything goes wrong with the running
-ssh you can still connect to the additional one.
-If you run a firewall, you may need to temporarily open this port. As
-this is potentially dangerous it's not done automatically. You can
-open the port with e.g.:
-'iptables -I INPUT -p tcp --dport 1022 -j ACCEPT'
+    To make recovery in case of failure easier, an additional sshd will
+    be started on port '1022'. If anything goes wrong with the running
+    ssh you can still connect to the additional one.
+    If you run a firewall, you may need to temporarily open this port. As
+    this is potentially dangerous it's not done automatically. You can
+    open the port with e.g.:
+    'iptables -I INPUT -p tcp --dport 1022 -j ACCEPT'
 
-To continue please press [ENTER]
-    {{< /output >}}
+    To continue please press [ENTER]
+    ```
 
 6.  Ubuntu reads through the list of packages, builds the dependencies, and searches for internal package mirrors. If no mirrors are available, it prompts for approval to rewrite the `sources.list` file. Enter `y` to continue.
 
-    {{< output >}}
-Fetched 336 kB in 0s (0 B/s)
-Reading package lists... Done
-...
-No valid mirror found
+    ```output
+    Fetched 336 kB in 0s (0 B/s)
+    Reading package lists... Done
+    ...
+    No valid mirror found
 
-While scanning your repository information no mirror entry for the
-upgrade was found. This can happen if you run an internal mirror or
-if the mirror information is out of date.
+    While scanning your repository information no mirror entry for the
+    upgrade was found. This can happen if you run an internal mirror or
+    if the mirror information is out of date.
 
-Do you want to rewrite your 'sources.list' file anyway? If you choose
-'Yes' here it will update all 'focal' to 'jammy' entries.
-If you select 'No' the upgrade will cancel.
+    Do you want to rewrite your 'sources.list' file anyway? If you choose
+    'Yes' here it will update all 'focal' to 'jammy' entries.
+    If you select 'No' the upgrade will cancel.
 
-Continue [yN]
-    {{< /output >}}
+    Continue [yN]
+    ```
 
 7.  Ubuntu downloads the new packages and files. It determines which packages are no longer supported and requests approval to proceed. It also calculates how long the upgrade might take. To continue with the upgrade, answer `y`.
 
-    {{< note respectIndent=false >}}
-To see details about the packages to be removed, installed, and upgraded, enter `d`. Enter `q` to exit the details screen. Then enter `y` to continue with the upgrade.
+    {{< note >}}
+    To see details about the packages to be removed, installed, and upgraded, enter `d`. Enter `q` to exit the details screen. Then enter `y` to continue with the upgrade.
     {{< /note >}}
 
-    {{< output >}}
-Do you want to start the upgrade?
+    ```output
+    Do you want to start the upgrade?
 
 
-14 installed packages are no longer supported by Canonical. You can
-still get support from the community.
+    14 installed packages are no longer supported by Canonical. You can
+    still get support from the community.
 
-5 packages are going to be removed. 91 new packages are going to be
-installed. 571 packages are going to be upgraded.
+    5 packages are going to be removed. 91 new packages are going to be
+    installed. 571 packages are going to be upgraded.
 
-You have to download a total of 552 M. This download will take about
-2 minutes with you connection.
+    You have to download a total of 552 M. This download will take about
+    2 minutes with you connection.
 
-Installing the upgrade can take several hours. Once the download has
-finished, the process cannot be canceled.
+    Installing the upgrade can take several hours. Once the download has
+    finished, the process cannot be canceled.
 
-Continue [yN]  Details [d]
-    {{< /output >}}
+    Continue [yN]  Details [d]
+    ```
 
 8.  Ubuntu displays a pop-up asking whether to restart the services after the upgrade. Select either the `<Yes>` button to automatically restart them or `<No>` to restart them manually.
 
@@ -302,30 +303,30 @@ Continue [yN]  Details [d]
 
 10. Ubuntu locates any obsolete packages and asks the user whether to remove them. Enter `y` to delete the outdated packages.
 
-    {{< output >}}
-Searching for obsolete software
-Reading state information... Done
+    ```output
+    Searching for obsolete software
+    Reading state information... Done
 
-Remove obsolete packages?
+    Remove obsolete packages?
 
 
-41 packages are going to be removed.
+    41 packages are going to be removed.
 
-Continue [yN]  Details [d]
-    {{< /output >}}
+    Continue [yN]  Details [d]
+    ```
 
 11. Ubuntu removes the packages and finalizes the upgrade. This stage might also take some length of time. Ubuntu informs the user that the upgrade is complete and prompts them to reboot the system. Select `y` to reboot and finalize the upgrade.
 
-    {{< output >}}
-System upgrade is complete.
+    ```output
+    System upgrade is complete.
 
-Restart required
+    Restart required
 
-To finish the upgrade, a restart is required.
-If you select 'y' the system will be restarted.
+    To finish the upgrade, a restart is required.
+    If you select 'y' the system will be restarted.
 
-Continue [yN]
-    {{< /output >}}
+    Continue [yN]
+    ```
 
 ## How to Perform Post-Upgrade Clean-Up Activities
 
@@ -333,62 +334,62 @@ Ubuntu has now been upgraded to version 22.04 LTS. After the Linode reboots, it 
 
 1.  Use the `lsb_release -a` command to verify the correct release of Ubuntu is now installed. The `Release` attribute should be `22.04`.
 
-    ```code
+    ```command
     lsb_release -a
     ```
 
-    {{< output >}}
-No LSB modules are available.
-Distributor ID: Ubuntu
-Description:    Ubuntu 22.04.1 LTS
-Release:        22.04
-Codename:       jammy
-    {{< /output >}}
+    ```output
+    No LSB modules are available.
+    Distributor ID: Ubuntu
+    Description:    Ubuntu 22.04.1 LTS
+    Release:        22.04
+    Codename:       jammy
+    ```
 
 2.  **Optional:** To validate the kernel version, use the `uname` command.
 
-    ```code
+    ```command
     uname -mrs
     ```
 
-    {{< output >}}
-Linux 5.15.0-53-generic x86_64
-    {{< /output >}}
+    ```output
+    Linux 5.15.0-53-generic x86_64
+    ```
 
 3.  To increase security, close port `1022` in the `ufw` firewall. Reload the firewall.
 
-    ```code
+    ```command
     sudo ufw delete allow 1022/tcp
     sudo ufw reload
     ```
 
 4.  Confirm the firewall rules are updated.
 
-    ```code
+    ```command
     sudo ufw status
     ```
 
-    {{< output >}}
-Status: active
+    ```output
+    Status: active
 
-To                         Action      From
---                         ------      ----
-OpenSSH                    ALLOW       Anywhere
-Apache Full                ALLOW       Anywhere
-OpenSSH (v6)               ALLOW       Anywhere (v6)
-Apache Full (v6)           ALLOW       Anywhere (v6)
-    {{< /output >}}
+    To                         Action      From
+    --                         ------      ----
+    OpenSSH                    ALLOW       Anywhere
+    Apache Full                ALLOW       Anywhere
+    OpenSSH (v6)               ALLOW       Anywhere (v6)
+    Apache Full (v6)           ALLOW       Anywhere (v6)
+    ```
 
 5.  Ubuntu disables any third-party repositories during the upgrade. To search for disabled repositories, switch to the `sources.list.d` directory and list the entries.
 
-    ```code
+    ```command
     cd /etc/apt/sources.list.d
     ls -l
     ```
 
 6.  Edit each list using a text editor. Remove the `#` symbol at the start of the affected entries, and save the file. In the following example, remove the `#` symbol in front of `deb [arch=amd64]`.
 
-    ```code
+    ```command
     nano archive-application.list
     ```
 
@@ -399,7 +400,7 @@ Apache Full (v6)           ALLOW       Anywhere (v6)
 
 7.  Update any third-party repositories and remove unnecessary packages using `apt` commands.
 
-    ```code
+    ```command
     sudo apt update -y && sudo apt upgrade -y && sudo apt dist-upgrade -y && sudo apt autoremove -y && sudo apt autoclean -y
     ```
 

--- a/docs/guides/tools-reference/basics/how-to-increase-swap-space-in-ubuntu/index.md
+++ b/docs/guides/tools-reference/basics/how-to-increase-swap-space-in-ubuntu/index.md
@@ -3,7 +3,8 @@ slug: how-to-increase-swap-space-in-ubuntu
 description: 'Need to know how to increase swap space in Ubuntu? Guard yourself against out-of-memory errors and add swap space to your server today. ✓ Read more here!'
 keywords: ['how to increase swap space in ubuntu','ubuntu swap file','linux swap space size','create swap partition ubuntu']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-published: 2022-02-07
+published: 2022-12-06
+modified: 2023-03-29
 modified_by:
   name: Linode
 title: "Step-by-Step Guide: How to Increase Swap Space in Ubuntu"
@@ -30,7 +31,7 @@ The system uses RAM preferentially, but switches to using the swap space as nece
 
 As of release 17.04, Ubuntu uses a swap file rather than a partition. However, assuming your Linode is setup with our normal configurations, it has a 512MB swap disk rather than a swap file.
 
-{{< note respectIndent=false >}}
+{{< note >}}
 To increase the size of the swap partition, first power off your Linode from the Cloud Manager. Then simply navigate to the **Storage** tab of your Linode, and click **Resize** next to your swap partition.
 {{< /note >}}
 
@@ -55,7 +56,7 @@ Overall, it is usually better to treat swap space as a safety mechanism to avoid
 
 1.  Follow our [Setting Up and Securing a Compute Instance](/docs/products/compute/compute-instances/guides/set-up-and-secure/) guide to update your system. You may also wish to set the timezone, configure your hostname, create a limited user account, and harden SSH access.
 
-{{< note respectIndent=false >}}
+{{< note >}}
 This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you are not familiar with the `sudo` command, see the [Users and Groups](/docs/guides/linux-users-and-groups/) guide.
 {{< /note >}}
 
@@ -71,120 +72,120 @@ It is possible to create multiple swap files. However, it is better to configure
 
 1.  Some systems automatically configure a swap file during installation. To determine whether the system already has a swap file, use the `swapon --show` command. If any files are displayed, this means one or more swap files already exist. Proceed to the "How to Increase Existing Swap Space" section for information on how to resize a swap file.
 
-    ```code
+    ```command
     sudo swapon --show
     ```
 
     If a swap file has already been created, it is shown as follows. If there is no swap file, there is no output.
 
-    {{< output >}}
-NAME     TYPE      SIZE USED PRIO
-/swapfile file 1024M   0B   -2
-    {{< /output >}}
+    ```output
+    NAME     TYPE      SIZE USED PRIO
+    /swapfile file 1024M   0B   -2
+    ```
 
     If you created a Linode using the standard configuration, you should see a swap partition instead:
 
-    {{< output >}}
-NAME     TYPE      SIZE USED PRIO
-/dev/sdb partition 512M   0B   -2
-{{< /output >}}
+    ```output
+    NAME     TYPE      SIZE USED PRIO
+    /dev/sdb partition 512M   0B   -2
+    ```
 
 2.  Confirm swap space has not already been allocated using the `free` command. This command can be used on most Linux systems to verify the swap space size.
 
-    ```code
+    ```command
     free -h
     ```
     If the total memory for `Swap` is `0B`, a swap file or partition has not been created yet.
 
-    {{< output >}}
-              total       used        free      shared  buff/cache   available
-Mem:          3.8Gi       523Mi       2.7Gi       3.0Mi       643Mi       3.1Gi
-Swap:            0B          0B          0B
-    {{< /output >}}
+    ```output
+                  total       used        free      shared  buff/cache   available
+    Mem:          3.8Gi       523Mi       2.7Gi       3.0Mi       643Mi       3.1Gi
+    Swap:            0B          0B          0B
+    ```
 
     If you created a Linode using the standard configuration, you should see a approximately 512MB dedicated to swap:
 
-    {{< output >}}
-               total        used        free      shared  buff/cache   available
-Mem:           1.9Gi       154Mi       1.4Gi       0.0Ki       410Mi       1.6Gi
-Swap:          511Mi          0B       511Mi
-    {{< /output >}}
+    ```output
+                  total        used        free      shared  buff/cache   available
+    Mem:           1.9Gi       154Mi       1.4Gi       0.0Ki       410Mi       1.6Gi
+    Swap:          511Mi          0B       511Mi
+    ```
 
 3.  Ensure there is enough space on the hard drive to create the swap space. Use the `df -h` command and locate the entry for the root directory, which is listed as `/`. The proposed swap file should fit comfortably within the available disk space with some room to spare. The following example indicates the hard drive has 64G of available space. This is more than adequate.
 
-    ```code
+    ```command
     df -h
     ```
 
-    {{< output >}}
-Filesystem      Size  Used Avail Use% Mounted on
-...
-/dev/sda         49G  3.4G   43G   8% /
-...
-    {{< /output >}}
+    ```output
+    Filesystem      Size  Used Avail Use% Mounted on
+    ...
+    /dev/sda         49G  3.4G   43G   8% /
+    ...
+    ```
 
 4.  Allocate memory for the swap file using the `fallocate` command. This command is used to reserve a certain amount of disc space for a file in advance. The following command creates a 1G file named `swapfile` in the root directory. Always give a swap file a very obvious name to avoid confusion.
 
-    ```code
+    ```command
     sudo fallocate -l 1G /swapfile
     ```
 
 5.  Change the file permissions for `swapfile` so only `root` can write to it. This prevents other users from accidentally deleting or overwriting the file.
 
-    ```code
+    ```command
     sudo chmod 600 /swapfile
     ```
 
 6.  Run the `ls` command to confirm the swap file has been successfully created. Use the `-l` option to see the size of the file.
 
-    ```code
+    ```command
     ls -hl /swapfile
     ```
 
-    {{< output >}}
--rw------- 1 root root 1.0G Nov 28 13:22 /swapfile
-    {{< /output >}}
+    ```output
+    -rw------- 1 root root 1.0G Nov 28 13:22 /swapfile
+    ```
 
 7.  Use the `mkswap` command to designate the new file as a swap file. This means it can be used for volatile memory when RAM space runs low.
 
-    ```code
+    ```command
     sudo mkswap /swapfile
     ```
 
-    {{< output >}}
-Setting up swapspace version 1, size = 1024 MiB (1073737728 bytes)
-no label, UUID=97644d2b-0608-4a32-bfb1-b069af64d86b
-    {{< /output >}}
+    ```output
+    Setting up swapspace version 1, size = 1024 MiB (1073737728 bytes)
+    no label, UUID=97644d2b-0608-4a32-bfb1-b069af64d86b
+    ```
 
 8.  The file swap has now been created, but it is still disabled. Activate it using the `swapon` command.
 
-    ```code
+    ```command
     sudo swapon /swapfile
     ```
 
 9.  The `swapon` command can be used with the `--show` option to confirm the swap space is enabled. If the new swap file is not listed, verify the results of the previous instructions.
 
-    ```code
+    ```command
     sudo swapon --show
     ```
 
-    {{< output >}}
-NAME      TYPE       SIZE USED PRIO
-/dev/sdb  partition  512M   0B   -2
-/swapfile file      1024M   0B   -3
-    {{< /output >}}
+    ```output
+    NAME      TYPE       SIZE USED PRIO
+    /dev/sdb  partition  512M   0B   -2
+    /swapfile file      1024M   0B   -3
+    ```
 
 10. To confirm the amount of swap space available on Ubuntu, use the `free` command. The `total` column for the `Swap` entry should display `1.5Gi` of total memory (1.0GB swap file and 0.5GB swap partition).
 
-    ```code
+    ```command
     free -h
     ```
 
-    {{< output >}}
-               total        used        free      shared  buff/cache   available
-Mem:           1.9Gi       148Mi       1.4Gi       0.0Ki       416Mi       1.6Gi
-Swap:          1.5Gi          0B       1.5Gi
-    {{< /output >}}
+    ```output
+                  total        used        free      shared  buff/cache   available
+    Mem:           1.9Gi       148Mi       1.4Gi       0.0Ki       416Mi       1.6Gi
+    Swap:          1.5Gi          0B       1.5Gi
+    ```
 
 ### Making the Swap File Changes Permanent
 
@@ -203,13 +204,13 @@ To add an entry to the `fstab` file, follow these steps:
 
 1.  As a precaution, make a backup copy of the existing `fstab` file.
 
-    ```code
+    ```command
     sudo cp /etc/fstab /etc/fstab.bak
     ```
 
 2.  Edit the file using a text editor.
 
-    ```code
+    ```command
     sudo nano /etc/fstab
     ```
 
@@ -229,23 +230,23 @@ To adjust the `swappiness` setting, use the following procedure.
 
 1.  Verify the current `swappiness` setting. The default value is `60`.
 
-    ```code
+    ```command
     cat /proc/sys/vm/swappiness
     ```
 
-    {{< output >}}
-60
-    {{< /output >}}
+    ```output
+    60
+    ```
 
 2.  To temporarily adjust the value of `swappiness`, use the `sysctl` utility. The following command lowers the value to `50`.
 
-    ```code
+    ```command
     sudo sysctl vm.swappiness=50
     ```
 
-    {{< output >}}
-vm.swappiness = 50
-    {{< /output >}}
+    ```output
+    vm.swappiness = 50
+    ```
 
 3.  To permanently change this value, edit the `sysctl.conf` file. Add the following line to the bottom of the file.
 
@@ -259,12 +260,12 @@ One advantage of using a swap file over the old partitioning method is the relat
 
 1.  Disable the swap mechanism. Active applications cannot use the swap file while it is disabled.
 
-    ```code
+    ```command
     sudo swapoff -a
     ```
 
-    {{< note respectIndent=false >}}
-This also temporarily disables your swap partition until the next reboot.
+    {{< note >}}
+    This also temporarily disables your swap partition until the next reboot.
     {{< /note >}}
 
 2.  Resize the swap space. `fallocate` can only be used to generate a new file, so the `dd` command must be used instead. Set the individual parameters as follows:
@@ -274,65 +275,65 @@ This also temporarily disables your swap partition until the next reboot.
 -   Set `bs`, or "block size", to `1G`.
 -   The value for `count` indicates how many blocks are allocated. To determine the value of `count`, divide the intended file size by the block size. For example, set the value of `count` to `2` to generate a 2G swap file.
 
-    ```code
+    ```command
     sudo dd if=/dev/zero of=/swapfile bs=1G count=2
     ```
 
-    {{< output >}}
-2+0 records in
-2+0 records out
-2147483648 bytes (2.1 GB, 2.0 GiB) copied, 7.86524 s, 273 MB/s
-    {{< /output >}}
+    ```output
+    2+0 records in
+    2+0 records out
+    2147483648 bytes (2.1 GB, 2.0 GiB) copied, 7.86524 s, 273 MB/s
+    ```
 
 3.  Ensure the permissions are set correctly.
 
-    ```code
+    ```command
     sudo chmod 600 /swapfile
     ```
 
 4.  Convert the file back into swap format.
 
-    ```code
+    ```command
     sudo mkswap /swapfile
     ```
 
-    {{< output >}}
-Setting up swapspace version 1, size = 2 GiB (2147479552 bytes)
-no label, UUID=6e61561d-c03d-4911-9343-8aa4c234576a
-    {{< /output >}}
+    ```output
+    Setting up swapspace version 1, size = 2 GiB (2147479552 bytes)
+    no label, UUID=6e61561d-c03d-4911-9343-8aa4c234576a
+    ```
 
 5.  Enable the swap file.
 
-    ```code
+    ```command
     sudo swapon /swapfile
     ```
 
-    {{< note respectIndent=false >}}
-To also re-enable the swap partition, use `sudo swapon -a` instead.
+    {{< note >}}
+    To also re-enable the swap partition, use `sudo swapon -a` instead.
     {{< /note >}}
 
 6.  Confirm the file has been resized correctly and is ready for use using either the `free` or `swapon --show` command.
 
-    ```code
+    ```command
     free -h
     ```
 
-    {{< output >}}
-               total        used        free      shared  buff/cache   available
-Mem:           1.9Gi       138Mi       1.0Gi       0.0Ki       771Mi       1.6Gi
-Swap:          2.0Gi          0B       2.0Gi
-    {{< /output >}}
+    ```output
+                  total        used        free      shared  buff/cache   available
+    Mem:           1.9Gi       138Mi       1.0Gi       0.0Ki       771Mi       1.6Gi
+    Swap:          2.0Gi          0B       2.0Gi
+    ```
 
-    ```code
+    ```command
     sudo swapon --show
     ```
 
-    {{< output >}}
-NAME      TYPE SIZE USED PRIO
-/swapfile file   2G   0B   -2
-    {{< /output >}}
+    ```output
+    NAME      TYPE SIZE USED PRIO
+    /swapfile file   2G   0B   -2
+    ```
 
-{{< note respectIndent=false >}}
+{{< note >}}
 It is not necessary to edit `cat /etc/fstab` or edit the swappiness value again, because those items are unaffected by the change.
 {{< /note >}}
 

--- a/docs/guides/tools-reference/tools/how-to-use-tcpdump-to-analyze-traffic/index.md
+++ b/docs/guides/tools-reference/tools/how-to-use-tcpdump-to-analyze-traffic/index.md
@@ -3,11 +3,12 @@ slug: how-to-use-tcpdump-to-analyze-traffic
 description: "The tcpdump tool gives you powerful options for capturing and analyzing traffic on your network. Network sniffing tools like tcpdump are helpful for troubleshooting network issues and testing network security. Learn how to start using tcpdump in this tutorial, including everything from capturing and analyzing network packets to advanced options for filtering them."
 keywords: ['tcpdump examples','tcpdump linux','tcpdump network traffic']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-published: 2022-06-11
+published: 2022-10-28
+modified: 2023-03-29
 modified_by:
   name: Nathaniel Stickman
-title: "Use tcdump to Analyze Network Traffic"
-title_meta: "How to Use tcdump to Analyze Network Traffic"
+title: "Use tcpdump to Analyze Network Traffic"
+title_meta: "How to Use tcpdump to Analyze Network Traffic"
 external_resources:
 - '[TCPDUMP & LIBPCAP](https://www.tcpdump.org/)'
 - "[Julia Evans: Let's Learn tcpdump](https://jvns.ca/tcpdump-zine.pdf)"
@@ -60,23 +61,23 @@ sudo tcpdump --version
 
 The command's output may vary, but it should be similar to what you see here:
 
-{{< output >}}
+```output
 tcpdump version 4.9.3
 libpcap version 1.9.1 (with TPACKET_V3)
 OpenSSL 1.1.1k  FIPS 25 Mar 2021
-{{< /output >}}
+```
 
 ## How to Interpret tcpdump Output
 
 Before getting started using *tcpdump*, it can be useful to familiarize yourself with how *tcpdump* displays packets. In *tcpdump*, each line corresponds to a single packet, displayed in distinct sections. Here is an example from later on in this tutorial:
 
-{{< output >}}
+```output
 20:26:16.902555 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 2957537435:2957537583, ack 850702985, win 1432, options [nop,nop,TS val 1668387813 ecr 3505486606], length 148
-{{< /output >}}
+```
 
 Each packet's display breaks down like this, using the example above as a guide:
 
--   `20:26:16.902555` is the Unix timestamp, representing when the packet was sent. Refer to the [How to Use Advanced Display Options with tcpdump](/docs/guides/how-to-use-tcpdump-to-analyze-traffic/#how-to-use-advanced-display-options-with-tcpdump) section further on to see how you can display more human-readable timestamps instead.
+-   `20:26:16.902555` is the Unix timestamp, representing when the packet was sent. Refer to the [How to Use Advanced Display Options with tcpdump](#how-to-use-advanced-display-options-with-tcpdump) section further on to see how you can display more human-readable timestamps instead.
 
 -   `IP` is the network protocol. In this case, the packet is a TCP packet, which show up under the `IP` designation. An ICMP packet, by contrast, would show `ICMP` here.
 
@@ -84,7 +85,7 @@ Each packet's display breaks down like this, using the example above as a guide:
 
     The last entry on each host above, `.ssh` for the source and `.64024` for the destination, is the port.
 
-    Refer to the [How to Use Advanced Display Options with tcpdump](/docs/guides/how-to-use-tcpdump-to-analyze-traffic/#how-to-use-advanced-display-options-with-tcpdump) section below to see how to display host IP addresses instead of hostnames.
+    Refer to the [How to Use Advanced Display Options with tcpdump](#how-to-use-advanced-display-options-with-tcpdump) section below to see how to display host IP addresses instead of hostnames.
 
 -   The rest is query information.
 
@@ -120,7 +121,7 @@ To get a list of available interfaces, use the *tcpdump* command with the `-D` o
 sudo tcpdump -D
 ```
 
-{{< output >}}
+```output
 1.eth0 [Up, Running]
 2.lo [Up, Running, Loopback]
 3.any (Pseudo-device that captures on all interfaces) [Up, Running]
@@ -128,7 +129,7 @@ sudo tcpdump -D
 5.nflog (Linux netfilter log (NFLOG) interface) [none]
 6.nfqueue (Linux netfilter queue (NFQUEUE) interface) [none]
 7.usbmon0 (Raw USB traffic, all USB buses) [none]
-{{< /output >}}
+```
 
 ### Capturing Packets
 
@@ -138,7 +139,7 @@ You can begin capturing packets by simply executing the *tcpdump* command. By de
 sudo tcpdump -i eth0
 ```
 
-{{< output >}}
+```output
 dropped privs to tcpdump
 tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
 listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
@@ -148,7 +149,7 @@ listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
 16:45:52.118992 IP resolver08.atlanta.linode.com.domain > example.hostname-one.com.47687: 65233 2/0/0 PTR example.hostname-two.com., PTR example.hostname-two.com. (134)
 16:45:52.119259 IP example.hostname-one.com.48245 > resolver08.atlanta.linode.com.domain: 43515+ PTR? 148.150.187.170.in-addr.arpa. (46)
 [...]
-{{< /output >}}
+```
 
 You can stop capturing packets using the *Ctrl* + *C* key combination. And, as you may notice, the output from *tcpdump* can accumulate quickly. This is especially the case for broad, unfiltered searches like the one above.
 
@@ -158,7 +159,7 @@ You can make the output more manageable for the purposes of getting to know *tcp
 sudo tcpdump -i eth0 -c 5
 ```
 
-{{< output >}}
+```output
 dropped privs to tcpdump
 tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
 listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
@@ -170,7 +171,7 @@ listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
 5 packets captured
 12 packets received by filter
 0 packets dropped by kernel
-{{< /output >}}
+```
 
 *tcpdump* also gives you the option of capturing packets on all available interfaces, by specifying `any` as the interface. Doing so lets you cast an even wider net when observing network traffic:
 
@@ -190,15 +191,15 @@ Here, you can see the primary filtering options available in *tcpdump*. In the n
     sudo tcpdump -i eth0 -c 1 port 80
     ```
 
-    {{< output >}}
-dropped privs to tcpdump
-tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
-20:12:53.530741 IP example.hostname-two.com.64251 > example.hostname-one.com.http: Flags [S], seq 3536229667, win 65535, options [mss 1460,nop,wscale 6,nop,nop,TS val 2559116808 ecr 0,sackOK,eol], length 0
-1 packet captured
-1 packet received by filter
-0 packets dropped by kernel
-    {{< /output >}}
+    ```output
+    dropped privs to tcpdump
+    tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+    listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
+    20:12:53.530741 IP example.hostname-two.com.64251 > example.hostname-one.com.http: Flags [S], seq 3536229667, win 65535, options [mss 1460,nop,wscale 6,nop,nop,TS val 2559116808 ecr 0,sackOK,eol], length 0
+    1 packet captured
+    1 packet received by filter
+    0 packets dropped by kernel
+    ```
 
 -   Host filtering can be accomplished using the `host` option followed by the IP address for a host you want to observe network traffic for:
 
@@ -206,19 +207,19 @@ listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
     sudo tcpdump -i eth0 -c 5 host 170.187.150.148
     ```
 
-    {{< output >}}
-dropped privs to tcpdump
-tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
-20:20:18.850561 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 2957531627:2957531743, ack 850700453, win 1432, options [nop,nop,TS val 1668029761 ecr 3505128549], length 116
-20:20:18.850695 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 116:232, ack 1, win 1432, options [nop,nop,TS val 1668029761 ecr 3505128549], length 116
-20:20:18.851206 IP example.hostname-one.com.43356 > resolver06.atlanta.linode.com.domain: 55916+ PTR? 173.174.209.73.in-addr.arpa. (45)
-20:20:18.851759 IP resolver06.atlanta.linode.com.domain > example.hostname-one.com.43356: 55916 2/0/0 PTR example.hostname-two.com., PTR example.hostname-two.com. (134)
-20:20:18.852052 IP example.hostname-one.com.54556 > resolver06.atlanta.linode.com.domain: 9603+ PTR? 148.150.187.170.in-addr.arpa. (46)
-5 packets captured
-10 packets received by filter
-0 packets dropped by kernel
-    {{< /output >}}
+    ```output
+    dropped privs to tcpdump
+    tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+    listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
+    20:20:18.850561 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 2957531627:2957531743, ack 850700453, win 1432, options [nop,nop,TS val 1668029761 ecr 3505128549], length 116
+    20:20:18.850695 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 116:232, ack 1, win 1432, options [nop,nop,TS val 1668029761 ecr 3505128549], length 116
+    20:20:18.851206 IP example.hostname-one.com.43356 > resolver06.atlanta.linode.com.domain: 55916+ PTR? 173.174.209.73.in-addr.arpa. (45)
+    20:20:18.851759 IP resolver06.atlanta.linode.com.domain > example.hostname-one.com.43356: 55916 2/0/0 PTR example.hostname-two.com., PTR example.hostname-two.com. (134)
+    20:20:18.852052 IP example.hostname-one.com.54556 > resolver06.atlanta.linode.com.domain: 9603+ PTR? 148.150.187.170.in-addr.arpa. (46)
+    5 packets captured
+    10 packets received by filter
+    0 packets dropped by kernel
+    ```
 
 -   Protocol filtering can be used to narrow results to only a given protocol type. You can accomplish this by simply appending the protocol designation to the *tcpdump* command:
 
@@ -226,19 +227,19 @@ listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
     sudo tcpdump -i eth0 -c 5 icmp
     ```
 
-    {{< output >}}
-dropped privs to tcpdump
-tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
-20:21:13.452381 IP example.hostname-one.com > zg-0421d-148.stretchoid.com: ICMP host example.hostname-one.com unreachable - admin prohibited filter, length 48
-20:21:18.979723 IP example.hostname-one.com > 45.155.204.63: ICMP host example.hostname-one.com unreachable - admin prohibited filter, length 48
-20:21:32.953615 IP example.hostname-one.com > 45.143.203.88: ICMP host example.hostname-one.com unreachable - admin prohibited filter, length 48
-20:21:36.452595 IP ec2-54-197-15-194.compute-1.amazonaws.com > example.hostname-one.com: ICMP echo request, id 6, seq 10080, length 16
-20:21:36.452732 IP example.hostname-one.com > ec2-54-197-15-194.compute-1.amazonaws.com: ICMP echo reply, id 6, seq 10080, length 16
-5 packets captured
-5 packets received by filter
-0 packets dropped by kernel
-    {{< /output >}}
+    ```output
+    dropped privs to tcpdump
+    tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+    listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
+    20:21:13.452381 IP example.hostname-one.com > zg-0421d-148.stretchoid.com: ICMP host example.hostname-one.com unreachable - admin prohibited filter, length 48
+    20:21:18.979723 IP example.hostname-one.com > 45.155.204.63: ICMP host example.hostname-one.com unreachable - admin prohibited filter, length 48
+    20:21:32.953615 IP example.hostname-one.com > 45.143.203.88: ICMP host example.hostname-one.com unreachable - admin prohibited filter, length 48
+    20:21:36.452595 IP ec2-54-197-15-194.compute-1.amazonaws.com > example.hostname-one.com: ICMP echo request, id 6, seq 10080, length 16
+    20:21:36.452732 IP example.hostname-one.com > ec2-54-197-15-194.compute-1.amazonaws.com: ICMP echo reply, id 6, seq 10080, length 16
+    5 packets captured
+    5 packets received by filter
+    0 packets dropped by kernel
+    ```
 
 ### Combining Filters
 
@@ -270,7 +271,7 @@ You can then read the results again right in *tcpdump*, using the `-r` option:
 sudo tcpdump -r example-packet-dump.pcap
 ```
 
-{{< output >}}
+```output
 reading from file example-packet-dump.pcap, link-type EN10MB (Ethernet)
 dropped privs to tcpdump
 20:26:16.902555 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 2957537435:2957537583, ack 850702985, win 1432, options [nop,nop,TS val 1668387813 ecr 3505486606], length 148
@@ -278,7 +279,7 @@ dropped privs to tcpdump
 20:26:16.923532 IP example.hostname-one.com > 107.189.4.117: ICMP host example.hostname-one.com unreachable - admin prohibited filter, length 52
 20:26:16.932689 IP example.hostname-two.com.64024 > example.hostname-one.com.ssh: Flags [.], ack 148, win 65532, options [nop,nop,TS val 3505486685 ecr 1668387813], length 0
 20:26:17.357029 IP6 example.hostname-one.com > ff02::16: HBH ICMP6, multicast listener report v2, 1 group record(s), length 28
-{{< /output >}}
+```
 
 ## How to Use Advanced Display Options with tcpdump
 
@@ -290,23 +291,23 @@ dropped privs to tcpdump
     sudo tcpdump -i eth0 -c 5 -vv
     ```
 
-    {{< output >}}
-dropped privs to tcpdump
-tcpdump: listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
-20:27:34.957840 IP (tos 0x48, ttl 64, id 13252, offset 0, flags [DF], proto TCP (6), length 200)
-    example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], cksum 0x3a89 (incorrect -> 0xebae), seq 2957544691:2957544839, ack 850706093, win 1432, options [nop,nop,TS val 1668465868 ecr 3505564654], length 148
-20:27:34.958582 IP (tos 0x0, ttl 64, id 59922, offset 0, flags [DF], proto UDP (17), length 73)
-    example.hostname-one.com.47790 > resolver06.atlanta.linode.com.domain: [bad udp cksum 0xbf7f -> 0x3f97!] 6992+ PTR? 173.174.209.73.in-addr.arpa. (45)
-20:27:34.958655 IP (tos 0x48, ttl 64, id 13253, offset 0, flags [DF], proto TCP (6), length 184)
-    example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], cksum 0x3a79 (incorrect -> 0xa704), seq 148:280, ack 1, win 1432, options [nop,nop,TS val 1668465869 ecr 3505564654], length 132
-20:27:34.960232 IP (tos 0x0, ttl 59, id 23535, offset 0, flags [none], proto UDP (17), length 162)
-    resolver06.atlanta.linode.com.domain > example.hostname-one.com.47790: [udp sum ok] 6992 q: PTR? 173.174.209.73.in-addr.arpa. 2/0/0 173.174.209.73.in-addr.arpa. PTR example.hostname-two.com., 173.174.209.73.in-addr.arpa. PTR example.hostname-two.com. (134)
-20:27:34.960494 IP (tos 0x0, ttl 64, id 59923, offset 0, flags [DF], proto UDP (17), length 74)
-    example.hostname-one.com.53590 > resolver06.atlanta.linode.com.domain: [bad udp cksum 0xbf80 -> 0x2e92!] 17994+ PTR? 148.150.187.170.in-addr.arpa. (46)
-5 packets captured
-9 packets received by filter
-0 packets dropped by kernel
-    {{< /output >}}
+    ```output
+    dropped privs to tcpdump
+    tcpdump: listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
+    20:27:34.957840 IP (tos 0x48, ttl 64, id 13252, offset 0, flags [DF], proto TCP (6), length 200)
+        example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], cksum 0x3a89 (incorrect -> 0xebae), seq 2957544691:2957544839, ack 850706093, win 1432, options [nop,nop,TS val 1668465868 ecr 3505564654], length 148
+    20:27:34.958582 IP (tos 0x0, ttl 64, id 59922, offset 0, flags [DF], proto UDP (17), length 73)
+        example.hostname-one.com.47790 > resolver06.atlanta.linode.com.domain: [bad udp cksum 0xbf7f -> 0x3f97!] 6992+ PTR? 173.174.209.73.in-addr.arpa. (45)
+    20:27:34.958655 IP (tos 0x48, ttl 64, id 13253, offset 0, flags [DF], proto TCP (6), length 184)
+        example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], cksum 0x3a79 (incorrect -> 0xa704), seq 148:280, ack 1, win 1432, options [nop,nop,TS val 1668465869 ecr 3505564654], length 132
+    20:27:34.960232 IP (tos 0x0, ttl 59, id 23535, offset 0, flags [none], proto UDP (17), length 162)
+        resolver06.atlanta.linode.com.domain > example.hostname-one.com.47790: [udp sum ok] 6992 q: PTR? 173.174.209.73.in-addr.arpa. 2/0/0 173.174.209.73.in-addr.arpa. PTR example.hostname-two.com., 173.174.209.73.in-addr.arpa. PTR example.hostname-two.com. (134)
+    20:27:34.960494 IP (tos 0x0, ttl 64, id 59923, offset 0, flags [DF], proto UDP (17), length 74)
+        example.hostname-one.com.53590 > resolver06.atlanta.linode.com.domain: [bad udp cksum 0xbf80 -> 0x2e92!] 17994+ PTR? 148.150.187.170.in-addr.arpa. (46)
+    5 packets captured
+    9 packets received by filter
+    0 packets dropped by kernel
+    ```
 
 -   Sometimes results are easier to interpret when hostnames are rendered as IP addresses. Alternatively, rendering hostnames as IP addresses may be essential when DNS resolution is unavailable. In these cases, you can use the `-n` option. This option shows hosts by their IP addresses:
 
@@ -314,19 +315,19 @@ tcpdump: listening on eth0, link-type EN10MB (Ethernet), capture size 262144 byt
     sudo tcpdump -i eth0 -n -c 5
     ```
 
-    {{< output >}}
-dropped privs to tcpdump
-tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
-20:15:28.908978 IP6 fe80::f03c:92ff:fe4d:2fb0 > ff02::16: HBH ICMP6, multicast listener report v2, 1 group record(s), length 28
-20:15:28.918797 IP 192.0.2.0.ssh > 198.51.100.0.64024: Flags [P.], seq 2957522283:2957522471, ack 850697205, win 1432, options [nop,nop,TS val 1667739829 ecr 3504838648], length 188
-20:15:28.918915 IP 192.0.2.0.ssh > 198.51.100.0.64024: Flags [P.], seq 188:352, ack 1, win 1432, options [nop,nop,TS val 1667739829 ecr 3504838648], length 164
-20:15:28.919162 IP 192.0.2.0.ssh > 198.51.100.0.64024: Flags [P.], seq 352:748, ack 1, win 1432, options [nop,nop,TS val 1667739830 ecr 3504838648], length 396
-20:15:28.919278 IP 192.0.2.0.ssh > 198.51.100.0.64024: Flags [P.], seq 748:952, ack 1, win 1432, options [nop,nop,TS val 1667739830 ecr 3504838648], length 204
-5 packets captured
-6 packets received by filter
-0 packets dropped by kernel
-    {{< /output >}}
+    ```output
+    dropped privs to tcpdump
+    tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+    listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
+    20:15:28.908978 IP6 fe80::f03c:92ff:fe4d:2fb0 > ff02::16: HBH ICMP6, multicast listener report v2, 1 group record(s), length 28
+    20:15:28.918797 IP 192.0.2.0.ssh > 198.51.100.0.64024: Flags [P.], seq 2957522283:2957522471, ack 850697205, win 1432, options [nop,nop,TS val 1667739829 ecr 3504838648], length 188
+    20:15:28.918915 IP 192.0.2.0.ssh > 198.51.100.0.64024: Flags [P.], seq 188:352, ack 1, win 1432, options [nop,nop,TS val 1667739829 ecr 3504838648], length 164
+    20:15:28.919162 IP 192.0.2.0.ssh > 198.51.100.0.64024: Flags [P.], seq 352:748, ack 1, win 1432, options [nop,nop,TS val 1667739830 ecr 3504838648], length 396
+    20:15:28.919278 IP 192.0.2.0.ssh > 198.51.100.0.64024: Flags [P.], seq 748:952, ack 1, win 1432, options [nop,nop,TS val 1667739830 ecr 3504838648], length 204
+    5 packets captured
+    6 packets received by filter
+    0 packets dropped by kernel
+    ```
 
 -   To get more human-readable timestamps, as opposed to the default Unix-formatted timestamps, you can use the `-tttt` option:
 
@@ -334,19 +335,19 @@ listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
     sudo tcpdump -i eth0 -c 5 -tttt
     ```
 
-    {{< output >}}
-dropped privs to tcpdump
-tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
-2022-06-09 20:28:27.636762 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 2957547039:2957547099, ack 850706389, win 1432, options [nop,nop,TS val 1668518547 ecr 3505617361], length 60
-2022-06-09 20:28:27.636812 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 60:248, ack 1, win 1432, options [nop,nop,TS val 1668518547 ecr 3505617361], length 188
-2022-06-09 20:28:27.637105 IP example.hostname-one.com.35506 > resolver06.atlanta.linode.com.domain: 17406+ PTR? 173.174.209.73.in-addr.arpa. (45)
-2022-06-09 20:28:27.638663 IP resolver06.atlanta.linode.com.domain > example.hostname-one.com.35506: 17406 2/0/0 PTR example.hostname-two.com., PTR example.hostname-two.com. (134)
-2022-06-09 20:28:27.638766 IP example.hostname-one.com.33127 > resolver06.atlanta.linode.com.domain: 13406+ PTR? 148.150.187.170.in-addr.arpa. (46)
-5 packets captured
-11 packets received by filter
-0 packets dropped by kernel
-    {{< /output >}}
+    ```output
+    dropped privs to tcpdump
+    tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+    listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
+    2022-06-09 20:28:27.636762 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 2957547039:2957547099, ack 850706389, win 1432, options [nop,nop,TS val 1668518547 ecr 3505617361], length 60
+    2022-06-09 20:28:27.636812 IP example.hostname-one.com.ssh > example.hostname-two.com.64024: Flags [P.], seq 60:248, ack 1, win 1432, options [nop,nop,TS val 1668518547 ecr 3505617361], length 188
+    2022-06-09 20:28:27.637105 IP example.hostname-one.com.35506 > resolver06.atlanta.linode.com.domain: 17406+ PTR? 173.174.209.73.in-addr.arpa. (45)
+    2022-06-09 20:28:27.638663 IP resolver06.atlanta.linode.com.domain > example.hostname-one.com.35506: 17406 2/0/0 PTR example.hostname-two.com., PTR example.hostname-two.com. (134)
+    2022-06-09 20:28:27.638766 IP example.hostname-one.com.33127 > resolver06.atlanta.linode.com.domain: 13406+ PTR? 148.150.187.170.in-addr.arpa. (46)
+    5 packets captured
+    11 packets received by filter
+    0 packets dropped by kernel
+    ```
 
 ## Conclusion
 


### PR DESCRIPTION
Updated formatting (including changing the deprecated `code` shortcode to the `command` shortcode):
- Install and Configure Hubzilla
- Upgrade to Ubuntu 22.04 LTS
- Step-by-Step Guide: How to Increase Swap Space in Ubuntu
- Use tcpdump to Analyze Network Traffic

Also fixed a spelling issue in the title of that last doc (Use tcpdump to Analyze Network Traffic).