### PR TITLE
Fix some quote issues with code block attributes

### DIFF
--- a/docs/guides/applications/configuration-management/ansible/deploy-linodes-using-ansible/index.md
+++ b/docs/guides/applications/configuration-management/ansible/deploy-linodes-using-ansible/index.md
@@ -341,7 +341,7 @@ A [pull request](https://github.com/ansible/ansible/pull/51196) currently exists
 
     -   Open the `/etc/hosts` file and add your Linode's IPv4 address and label:
 
-        ```file {title=""/etc/hosts"}
+        ```file {title="/etc/hosts"}
         127.0.0.1       localhost
         192.0.2.0 simple-linode-29
         ```

--- a/docs/guides/websites/cms/wordpress/how-to-use-nginx-fastcgi-page-cache-with-wordpress/index.md
+++ b/docs/guides/websites/cms/wordpress/how-to-use-nginx-fastcgi-page-cache-with-wordpress/index.md
@@ -128,7 +128,7 @@ Adding this rule means it is not possible to test caching from these addresses.
     -   The `fastcgi_cache_bypass` and `fastcgi_no_cache` are assigned based on the value of `skip_cache` from the previous section. This tells NGINX not to search the cache and not to store any new content.
     -   The `add_header` instruction is used to add a header field indicating whether the resource is taken from the cache or not. This field is handy for debug purposes, but is not strictly required in production code.
 
-    ```file {title="/etc/nginx/sites-available/example.com.conf" lang=aconf"}
+    ```file {title="/etc/nginx/sites-available/example.com.conf" lang="aconf"}
     fastcgi_cache wpcache;
     fastcgi_cache_valid 200 301 302 2h;
     fastcgi_cache_use_stale error timeout updating invalid_header http_500 http_503;

--- a/docs/products/compute/compute-instances/guides/manage-the-kernel/index.md
+++ b/docs/products/compute/compute-instances/guides/manage-the-kernel/index.md
@@ -128,7 +128,7 @@ At the time of this writing, if you wish to switch from a Linode kernel to GRUB2
 
 Users can generally resolve this issue by either using the latest upstream kernel instead, or by adding a kernel parameter to the grub configuration file, usually found in `/etc/default/grub` to disable the asynchronous scanning which causes the issue. To do this, ensure that you do not delete other lines in the grub configuration file and append the following line to the end of the file:
 
-```file {title"/etc/default/grub"}
+```file {title="/etc/default/grub"}
 scsi_mod.scan=sync
 ```
 


### PR DESCRIPTION
* With older Hugo versions, these malformed attributes is just dropped.
* With the latest Hugo version, you will get a validation error.