### PR TITLE
Added missing `relations: platform: key` parameter 

### DIFF
--- a/docs/guides/applications/cloud-storage/how-to-install-nextcloud-on-ubuntu-22-04/index.md
+++ b/docs/guides/applications/cloud-storage/how-to-install-nextcloud-on-ubuntu-22-04/index.md
@@ -24,6 +24,7 @@ external_resources:
 - '[ISO Alpha-2 country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
 relations:
     platform:
+        key: install-nextcloud
         keywords:
            - distribution: Ubuntu 22.04
 authors: ["Jeff Novotny"]

--- a/docs/guides/applications/cloud-storage/store-and-share-your-files-with-nextcloud-centos-7/index.md
+++ b/docs/guides/applications/cloud-storage/store-and-share-your-files-with-nextcloud-centos-7/index.md
@@ -8,13 +8,18 @@ published: 2017-12-15
 modified: 2018-12-18
 modified_by:
   name: Linode
-title: "Store and Share your Files with Nextcloud on Centos 7"
+title: "Store and Share your Files with Nextcloud on CentOS 7"
 external_resources:
   - '[Using the occ command](https://docs.nextcloud.com/server/12/admin_manual/configuration_server/occ_command.html#http-user-label)'
   - '[nginx Configuration](https://docs.nextcloud.com/server/12/admin_manual/installation/nginx.html)'
   - '[Enabling SSL](https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#enabling-ssl)'
 aliases: ['/applications/cloud-storage/store-and-share-your-files-with-nextcloud-centos-7/']
 authors: ["Andrew Lescher"]
+relations:
+    platform:
+        key: install-nextcloud
+        keywords:
+           - distribution: CentOS 7
 ---
 
 ![Store and Share your Files with Nextcloud on CentOS](Store_and_Share_your_Files_with_Nextcloud_on_Centos_smg.png "Store and Share your Files with Nextcloud on CentOS")

--- a/docs/guides/databases/mongodb/install-mongodb-on-ubuntu-20-04/index.md
+++ b/docs/guides/databases/mongodb/install-mongodb-on-ubuntu-20-04/index.md
@@ -1,7 +1,6 @@
 ---
 slug: install-mongodb-on-ubuntu-20-04
 description: 'This guide explains how to install MongoDB on Ubuntu 20.04'
-og_description: 'This guide explains how to install MongoDB on Ubuntu 20.04'
 keywords: ['install MongoDB','use MongoDB','configure MongoDB','what is MongoDB']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2023-01-12
@@ -18,6 +17,7 @@ external_resources:
 - '[MongoDB Troubleshooting Guide](https://www.mongodb.com/docs/manual/reference/installation-ubuntu-community-troubleshooting/)'
 relations:
     platform:
+        key: how-to-install-mongodb
         keywords:
            - distribution: Ubuntu 20.04
 authors: ["Jeff Novotny"]

--- a/docs/guides/databases/postgresql/how-to-install-use-postgresql-ubuntu-20-04/index.md
+++ b/docs/guides/databases/postgresql/how-to-install-use-postgresql-ubuntu-20-04/index.md
@@ -13,6 +13,7 @@ external_resources:
 - '[PostgreSQL](https://www.postgresql.org/)'
 relations:
     platform:
+        key: use-postrgesql-database
         keywords:
            - distribution: Ubuntu 20.04
 tags: ["ubuntu", "postgresql"]

--- a/docs/guides/databases/postgresql/ubuntu-10-04-lucid/index.md
+++ b/docs/guides/databases/postgresql/ubuntu-10-04-lucid/index.md
@@ -1,6 +1,7 @@
 ---
 slug: ubuntu-10-04-lucid
 deprecated: true
+deprecated_link: /docs/guides/how-to-install-use-postgresql-ubuntu-20-04/
 description: 'Using the PostgreSQL relational database server with Ubuntu 10.04 LTS (Lucid).'
 keywords: ["postgresql", "postgresql ubuntu 10.04", "postgreql lucid", "postgresql database", "open source database", "relational database"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/guides/databases/postgresql/ubuntu-10-10-maverick/index.md
+++ b/docs/guides/databases/postgresql/ubuntu-10-10-maverick/index.md
@@ -9,6 +9,7 @@ modified_by:
 published: 2010-10-25
 title: 'Use PostgreSQL Relational Databases on Ubuntu 10.10'
 deprecated: true
+deprecated_link: /docs/guides/how-to-install-use-postgresql-ubuntu-20-04/
 relations:
     platform:
         key: use-postrgesql-database

--- a/docs/guides/databases/postgresql/ubuntu-8-04-hardy/index.md
+++ b/docs/guides/databases/postgresql/ubuntu-8-04-hardy/index.md
@@ -1,6 +1,7 @@
 ---
 slug: ubuntu-8-04-hardy
 deprecated: true
+deprecated_link: /docs/guides/how-to-install-use-postgresql-ubuntu-20-04/
 description: 'Using the PostgreSQL relational database server with Ubuntu 8.04 (Hardy).'
 keywords: ["postgresql", "postgresql database", "postgresql on ubuntu", "relational database"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/guides/databases/postgresql/ubuntu-9-04-jaunty/index.md
+++ b/docs/guides/databases/postgresql/ubuntu-9-04-jaunty/index.md
@@ -1,6 +1,7 @@
 ---
 slug: ubuntu-9-04-jaunty
 deprecated: true
+deprecated_link: /docs/guides/how-to-install-use-postgresql-ubuntu-20-04/
 description: 'Using the PostgreSQL relational database server with Ubuntu 9.04 (Jaunty).'
 keywords: ["postgresql", "postgresql database", "postgresql on ubuntu", "relational database"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/guides/databases/postgresql/ubuntu-9-10-karmic/index.md
+++ b/docs/guides/databases/postgresql/ubuntu-9-10-karmic/index.md
@@ -1,6 +1,7 @@
 ---
 slug: ubuntu-9-10-karmic
 deprecated: true
+deprecated_link: /docs/guides/how-to-install-use-postgresql-ubuntu-20-04/
 description: 'Using the PostgreSQL relational database server with Ubuntu 9.10 (Karmic).'
 keywords: ["postgresql", "postgresql database", "postgresql ubuntu", "postgresql ubuntu 9.10", "postgresql ubuntu karmic", "relational database"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/guides/databases/postgresql/use-postgresql-relational-databases-on-ubuntu-12-04/index.md
+++ b/docs/guides/databases/postgresql/use-postgresql-relational-databases-on-ubuntu-12-04/index.md
@@ -1,6 +1,7 @@
 ---
 slug: use-postgresql-relational-databases-on-ubuntu-12-04
 deprecated: true
+deprecated_link: /docs/guides/how-to-install-use-postgresql-ubuntu-20-04/
 description: 'Using the PostgreSQL relational database server with Ubuntu 12.04 LTS (Precise Pangolin).'
 keywords: ["postgresql", "ubuntu 12.04", "postgresql database", "open source database", "relational database"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-22-04/index.md
+++ b/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-22-04/index.md
@@ -18,6 +18,7 @@ external_resources:
 - '[PHP Documentation](https://www.php.net/docs.php)'
 relations:
     platform:
+        key: install-lamp-stack
         keywords:
            - distribution: Ubuntu 22.04
 authors: ["Jeff Novotny"]

--- a/docs/guides/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/index.md
+++ b/docs/guides/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/index.md
@@ -11,7 +11,7 @@ modified_by:
 published: 2016-04-28
 title: 'How to Install a LAMP Stack on Ubuntu 16.04'
 deprecated: true
-deprecated_link: 'guides/how-to-install-a-lamp-stack-on-ubuntu-20-04/'
+deprecated_link: '/docs/guides/how-to-install-a-lamp-stack-on-ubuntu-22-04/'
 external_resources:
  - '[Ubuntu Server Edition Homepage](http://www.ubuntu.com/server)'
  - '[Apache HTTP Server Documentation](http://httpd.apache.org/docs/2.4/)'


### PR DESCRIPTION
Added missing key values to some newer guides, which allows the distribution drop down box to function properly and link to other distributions.