### PR TITLE
update certbot command for v2

### DIFF
--- a/docs/products/networking/nodebalancers/guides/ssl-termination/index.md
+++ b/docs/products/networking/nodebalancers/guides/ssl-termination/index.md
@@ -4,7 +4,7 @@ description: 'This guide provides you with step-by step instructions on how to f
 keywords: ["Linode", "NodeBalancer", "SSL", "redirect", "load balancing", "install", "certificate", "configuration"]
 tags: ["linode platform","security","networking","ssl"]
 published: 2015-09-01
-modified: 2022-10-07
+modified: 2023-04-18
 modified_by:
   name: Linode
 aliases: ['/platform/nodebalancer/nodebalancer-ssl-configuration/','/guides/nodebalancer-ssl-configuration/']

--- a/docs/products/networking/nodebalancers/guides/ssl-termination/index.md
+++ b/docs/products/networking/nodebalancers/guides/ssl-termination/index.md
@@ -25,7 +25,7 @@ Throughout this guide we will offer several suggested values for specific config
 - Generate an [SSL certificate](/docs/guides/security/ssl/) for your domain name that supports TLS version 1.2 or later. This can be done through any Certificate Authority, including Let's Encrypt using the [Certbot](https://certbot.eff.org/) tool. Since Certbot cannot run directly on the NodeBalancer, run the following command on any Linode to generate the certificate (after following [Certbot's installation instructions](https://certbot.eff.org/instructions)). This allows you to manually verify ownership by updating a DNS record on your domain:
 
     ```command
-    sudo certbot certonly --manual --preferred-challenges dns
+    sudo certbot certonly --key-type rsa --manual --preferred-challenges dns
     ```
 
     Most Certificate Authorities will generate an SSL certificate using the RSA digital signature algorithm, which is fully supported by NodeBalancers. Certificates using the ECDSA algorithm are not supported.


### PR DESCRIPTION
Let's Encrypt Certbot default key type is changed to ECDSA with the latest version 2.0.0.