### PR TITLE
Adds a note regarding lost connectivity when enabling IP Sharing

### DIFF
--- a/docs/products/compute/compute-instances/guides/failover/index.md
+++ b/docs/products/compute/compute-instances/guides/failover/index.md
@@ -1,11 +1,11 @@
 ---
+title: "Configure Failover on a Compute Instance"
 description: "This guide discusses how to enable failover on a Linode Compute Instance through using our IP Sharing feature with software such as keepalived or FRR."
 keywords: ['IP failover','IP sharing','elastic IP']
 published: 2022-03-23
-modified: 2023-04-18
+modified: 2023-04-27
 modified_by:
   name: Linode
-title: "Configure Failover on a Compute Instance"
 aliases: ['/guides/ip-failover/']
 authors: ["Linode"]
 tags: ["media"]
@@ -90,6 +90,10 @@ To configure failover, complete each section in the order shown:
 1. Add an additional IPv4 address _or_ IPv6 range (/64 or /56) to one of the Compute Instances. See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/#adding-an-ip-address) guide for instructions. Make a note of the newly assigned IP address. *Each additional IPv4 address costs $2 per month*.
 
 1. On the *other* Compute Instance, add the newly assigned IPv4 address or IPv6 range as a *Shared IP* using Linode's **IP Sharing** feature. See [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/#configuring-ip-sharing) for instructions on configuring IP sharing.
+
+    {{< note type=warning >}}
+    When IP Sharing is enabled for an IP address, all connectivity to that IP address is immediately lost *until* it is configured on [Lelastic](#install-and-configure-lelastic), [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/), or another BGP routing tool. This is not an issue when adding a new IP address, but should be considered if you are enabling IP Sharing on an existing IP address that is actively being used.
+    {{< /note >}}
 
 ### Add the Shared IP to the Networking Configuration
 

--- a/docs/products/compute/compute-instances/guides/manage-ip-addresses/index.md
+++ b/docs/products/compute/compute-instances/guides/manage-ip-addresses/index.md
@@ -1,13 +1,13 @@
 ---
+title: "Managing IP Addresses on a Compute Instance"
 description: "Instructions on viewing, adding, deleting, transferring IP addresses for Linode Compute Instances using the Cloud Manager"
 og_description: "Learn how to manage IP addresses on a Linode Compute Instance"
 keywords: ["ip addresses", "ip failover", "swapping ip addresses", "add ip address", "add additional ip address"]
 tags: ["linode platform","cloud manager","networking"]
-modified: 2023-04-14
+published: 2016-08-23
+modified: 2023-04-27
 modified_by:
   name: Linode
-published: 2016-08-23
-title: "Managing IP Addresses on a Compute Instance"
 aliases: ['/platform/manager/remote-access-classic-manager/','/platform/manager/remote-access/','/remote-access/','/networking/remote-access/', '/guides/remote-access/','/guides/managing-ip-addresses/']
 authors: ["Linode"]
 ---
@@ -156,6 +156,10 @@ IPv6 SLAAC addresses are not able to be transferred between Compute Instances. I
 
 {{< note >}}
 Not all data centers currently support IP Sharing. Additionally, some data centers only support IPv4 sharing, while others also support IPv6 routed ranges (/64 and /56). To determine if IP Sharing is supported in a particular data center, see [Configuring IP Failover > IP Sharing Availability](/docs/products/compute/compute-instances/guides/failover/#ip-sharing-availability).
+{{< /note >}}
+
+{{< note type=warning >}}
+When IP Sharing is enabled for an IP address, all connectivity to that IP address is immediately lost *until* it is configured on [Lelastic](/docs/products/compute/compute-instances/guides/failover/#install-and-configure-lelastic), [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/), or another routing software. This is not an issue when adding a new IP address, but should be considered if you are enabling IP Sharing on an existing IP address that is actively being used.
 {{< /note >}}
 
 To learn how to enable IP Sharing within the Cloud Manager, review the following steps.


### PR DESCRIPTION
When IP Sharing is enabled for an IP address, all connectivity is lost to that IP address until the appropriate routing software is properly configured. This PR notes that in the following guide:

- [Update] Configure Failover on a Compute Instance
- [Update] Managing IP Addresses on a Compute Instance