### PR TITLE
Remove MongoDB Marketplace deployment guides

### DIFF
--- a/docs/guides/databases/mongodb/_shortguides/mongodb-deployment-methods-shortguide/index.md
+++ b/docs/guides/databases/mongodb/_shortguides/mongodb-deployment-methods-shortguide/index.md
@@ -13,11 +13,7 @@ aliases: ['/mongodb-deployment-methods-shortguide/']
 authors: ["Linode"]
 ---
 
-To perform the steps in the guide, you need to have a running MongoDB database as well as the [MongoDB Shell](/docs/guides/mongodb-community-shell-installation/) installed (either locally or on your remote instance). If needed, follow one of the methods below to deploy MongoDB on Linode:
-
-- **Deploy a MongoDB Managed Database.** Use Linode's Managed Database service to deploy a fully-managed cloud-based MongoDB instance. See [Create a Managed Database](/docs/products/databases/managed-databases/guides/create-database/). Then, follow the [Connect to a MongoDB Database](/docs/products/databases/managed-databases/guides/mongodb-connect/) guide to learn how to connect to your database using the MongoDB Shell.
-- **Create a Compute Instance using the MongoDB Marketplace App.** To quickly deploy your own MongoDB instance on Linode, use the MongoDB Marketplace App. See [Deploy MongoDB through the Linode Marketplace](/docs/products/tools/marketplace/guides/mongodb/)
-- **Manually install MongoDB on a Compute Instance.** If you prefer to have complete control over the software that's installed and the configuration of MongoDB, you can create a Compute Instance and manually install MongoDB. You can follow the instructions on [MongoDB's documentation site](https://www.mongodb.com/docs/manual/administration/install-on-linux/) or use one of the following Linode guides:
+To perform the steps in the guide, you need to have a running MongoDB database as well as the [MongoDB Shell](/docs/guides/mongodb-community-shell-installation/) installed (either locally or on your remote instance). To deploy MongoDB, follow the instructions on [MongoDB's documentation site](https://www.mongodb.com/docs/manual/administration/install-on-linux/) or use one of the following Linode guides:
 
     - [Installing MongoDB on Ubuntu 20.04](/docs/guides/install-mongodb-on-ubuntu-20-04/)
     - [Installing MongoDB on CentOS 7](/docs/guides/install-mongodb-on-centos-7/)

--- a/docs/guides/databases/mongodb/mongodb-community-shell-installation/index.md
+++ b/docs/guides/databases/mongodb/mongodb-community-shell-installation/index.md
@@ -18,7 +18,7 @@ MongoDB is a non-relational, document-oriented database that can operate over ma
 
 ### Prerequisites
 
-- Ensure you have deployed a MongoDB server instance. You can use the [Linode Marketplace App](/docs/products/tools/marketplace/guides/mongodb/) to deploy a MongoDB server instance.
+- Ensure you have deployed a MongoDB server instance.
 
 - You must have access to your MongoDB server instance and the necessary credentials to connect to your database.
 
@@ -57,7 +57,7 @@ If, upon invocation, `mongosh` doesn't execute, it may be necessary (depending o
 
 ### Install the MongoDB Shell on Debian Linux
 
-MongoDB server instances installed with a Linux package manager (`apt` or `rpm`) often have the MongoDB Shell already installed. This also includes the [Linode Marketplace MondoDB Server instance](/docs/products/tools/marketplace/guides/mongodb/). To verify that `mongosh` is installed, issue the following command to connect to your MongoDB server:
+MongoDB server instances installed with a Linux package manager (`apt` or `rpm`) often have the MongoDB Shell already installed. To verify that `mongosh` is installed, issue the following command to connect to your MongoDB server:
 
     mongosh
 

--- a/docs/products/tools/marketplace/guides/_index.md
+++ b/docs/products/tools/marketplace/guides/_index.md
@@ -73,8 +73,6 @@ See the [Marketplace](/docs/marketplace/) listing page for a full list of all Ma
 - [Microweber](/docs/products/tools/marketplace/guides/microweber)
 - [Minecraft ](/docs/products/tools/marketplace/guides/minecraft/)
 - [Mist.io](/docs/products/tools/marketplace/guides/mistio/)
-- [MongoDB](/docs/products/tools/marketplace/guides/mongodb/)
-- [MongoDB Cluster](/docs/products/tools/marketplace/guides/mongodb-cluster/)
 - [Moodle](/docs/products/tools/marketplace/guides/moodle/)
 - [MySQL/MariaDB](/docs/products/tools/marketplace/guides/mysql/)
 - [Nextcloud](/docs/products/tools/marketplace/guides/nextcloud/)

--- a/docs/products/tools/marketplace/guides/mongodb-cluster/index.md
+++ b/docs/products/tools/marketplace/guides/mongodb-cluster/index.md
@@ -2,6 +2,7 @@
 title: "Deploy a MongoDB Cluster through the Linode Marketplace"
 description: "This guide shows how you can deploy MongoDB, a database engine that provides access to non-relational, document-oriented databases, using the Linode Marketplace."
 published: 2023-03-20
+expiryDate: 2023-05-01
 modified_by:
   name: Linode
 keywords: ['mongodb','marketplace', 'database']
@@ -18,7 +19,7 @@ authors: ["Linode"]
 MongoDB seeks to provide an alternative to traditional relational database management systems (RDBMS). In addition to its schema-free design and scalable architecture, MongoDB provides a JSON output and specialized, language-specific bindings that make it particularly attractive for use in custom application development and rapid prototyping. MongoDB has been used in a number of large scale [production deployments](https://www.mongodb.com/community/deployments) and is currently one of the most popular database engines across all systems.
 
 {{< note type="warning" title="Marketplace App Cluster Notice" >}}
-This Marketplace App deploys 3 Compute Instances to create a highly available and redundant MongoDB cluster, each with the plan type and size that you select. Please be aware that each of these Compute Instances will appear on your invoice as separate items. To instead deploy MongoDB on a single Compute Instance, see [Deploy MongoDB through the Linode Marketplace](/docs/products/tools/marketplace/guides/mongodb/).
+This Marketplace App deploys 3 Compute Instances to create a highly available and redundant MongoDB cluster, each with the plan type and size that you select. Please be aware that each of these Compute Instances will appear on your invoice as separate items.
 {{< /note >}}
 
 ## Deploying a Marketplace App

--- a/docs/products/tools/marketplace/guides/mongodb/index.md
+++ b/docs/products/tools/marketplace/guides/mongodb/index.md
@@ -3,6 +3,7 @@ description: "This guide shows how you can deploy MongoDB, a database engine tha
 keywords: ['mongodb','marketplace', 'database']
 tags: ["linode platform","database","marketplace","cloud-manager"]
 published: 2020-03-11
+expiryDate: 2023-05-01
 modified: 2022-03-08
 modified_by:
   name: Linode

--- a/docs/products/tools/marketplace/guides/percona-monitoring-management/index.md
+++ b/docs/products/tools/marketplace/guides/percona-monitoring-management/index.md
@@ -83,7 +83,6 @@ To begin monitoring a database node, you will need to install the [PMM Client](h
 
 -   [Deploying MySQL/MariaDB with Marketplace Apps](/docs/products/tools/marketplace/guides/mysql/)
 -   [Deploying PostgreSQL with Marketplace Apps](/docs/products/tools/marketplace/guides/postgresql/)
--   [Deploying MongoDB with Marketplace Apps](/docs/products/tools/marketplace/guides/mongodb/)
 
 {{< note >}}
 The PMM Server deployed with Linode's Percona (PMM) Marketplace App is compatible with [**PMM Client version 2**](https://www.percona.com/doc/percona-monitoring-and-management/2.x/index.html).


### PR DESCRIPTION
This PR marks the MongoDB marketplace app guides as expired so they no longer are rendered. It also removes links to those guides.