### PR TITLE
Remove MongoDB Managed Database

### DIFF
--- a/docs/products/databases/managed-databases/_index.md
+++ b/docs/products/databases/managed-databases/_index.md
@@ -11,7 +11,7 @@ cascade:
     date: 2022-02-23
     product_description: "Fully managed cloud database clusters built on top of Linode’s trusted and reliable platform."
 aliases: ['/products/database/']
-modified: 2022-10-31
+modified: 2023-05-02
 ---
 
 {{< content "managed-databases-beta-notice-shortguide" >}}
@@ -34,15 +34,11 @@ Managed Databases can be configured with either 1 or 3 underlying machines, also
 
 ## Database Engines
 
-The following database management systems (DBMSs) are available (or coming soon) to Managed Databases:
+The following database management systems (DBMSs) are available on Managed Databases:
 
 - **MySQL:** An industry standard relational database management system that uses the SQL query language. Many popular applications (including WordPress) require MySQL or MySQL compatible databases.
 
 - **PostgreSQL:** An object-relational database management system that can use either SQL or JSON queries. It's generally more flexible and feature-rich than MySQL, though it's not a drop-in replacement and applications need to have built-in support for it.
-
-- **MongoDB:** A document-oriented database software that uses JSON files to store data. It is one of the most popular NoSQL databases and, as such, it is *unstructured* and very flexible.
-
-    {{< content "managed-database-mongodb-private-notice-shortguide" >}}
 
 See [Choosing a Database Engine and Plan](/docs/products/databases/managed-databases/guides/database-engines/) for more details on each of the available database engines.
 
@@ -94,7 +90,5 @@ In addition to the resources allocated to each available plan (outlined above), 
 - The default user cannot be changed or removed, though the password can be reset at any time.
 
 - You are not able to access the underlying operating system of a database cluster. Configuration files (such as `my.cnf` ) cannot be directly edited and configuration changes done through the `SET PERSIST` command do not persist when the cluster is rebooted.
-
-- MongoDB database clusters are currently only accessible over public IP addresses. As such, any traffic counts towards your monthly network transfer usage. Support for private IP addresses will be available in the coming months.
 
 - Live replicas or standby nodes for a high availability Managed Database cluster cannot be created or hosted outside of Linode's Managed Database service.

--- a/docs/products/databases/managed-databases/get-started/index.md
+++ b/docs/products/databases/managed-databases/get-started/index.md
@@ -25,7 +25,6 @@ Once a Managed Database has been provisioned, you can connect to it from any com
 - [Manage Access Controls](/docs/products/databases/managed-databases/guides/manage-access-controls/)
 - [Connect to a MySQL Managed Database](/docs/products/databases/managed-databases/guides/mysql-connect/)
 - [Connect to a PostgreSQL Managed Database](/docs/products/databases/managed-databases/guides/postgresql-connect/)
-- [Connect to a MongoDB Managed Database](/docs/products/databases/managed-databases/guides/mongodb-connect/)
 
 ## Migrate an Existing Database
 

--- a/docs/products/databases/managed-databases/guides/_index.md
+++ b/docs/products/databases/managed-databases/guides/_index.md
@@ -4,7 +4,8 @@ title_meta: "Guides and Tutorials for Managed Databases"
 description: "A collection of guides on using Linode's Managed Database service"
 tab_group_main:
     weight: 30
-modified: 2022-06-06
+published: 2022-06-06
+modified: 2023-05-02
 ---
 
 ## Basics
@@ -50,17 +51,4 @@ General PostgreSQL guides (not specific to Managed Databases):
 
 - [An Introduction to PostgreSQL](/docs/guides/an-introduction-to-postgresql/)
 - [Backing Up a PostgreSQL Database (Database Dump)](/docs/guides/how-to-back-up-your-postgresql-database/)
-{{< /note >}}
-
-## MongoDB
-
-- [Connect to a MongoDB Managed Database](/docs/products/databases/managed-databases/guides/mongodb-connect/)
-
-- [Migrate a MongoDB Database to a Managed Database](/docs/products/databases/managed-databases/guides/mongodb-migrate/)
-
-{{< note >}}
-General MongoDB guides (not specific to Managed Databases):
-
-- [Introduction To MongoDB And Its Use Cases](/docs/guides/mongodb-introduction/)
-- [How to Install and Use the MongoDB Community Shell](/docs/guides/mongodb-community-shell-installation/)
 {{< /note >}}

--- a/docs/products/databases/managed-databases/guides/database-engines/index.md
+++ b/docs/products/databases/managed-databases/guides/database-engines/index.md
@@ -2,7 +2,7 @@
 title: "Database Engines and Plans"
 description: "Learn the differences between the database engines offered by Linode's Managed Database service."
 published: 2022-06-06
-modified: 2022-08-09
+modified: 2023-05-02
 authors: ["Linode"]
 ---
 
@@ -14,7 +14,6 @@ The following database engines are available on Linode's platform:
 
 - [MySQL](#mysql)
 - [PostgreSQL](#postgresql)
-- [MongoDB](#mongodb)
 
 ### MySQL
 
@@ -39,25 +38,11 @@ PostgreSQL is an object-relational database management system (ORDBMS) that can 
 
 **Available versions:**
 
-- PostgreSQL 13.2
-- PostgreSQL 12.6
-- PostgreSQL 11.11
-- PostgreSQL 10.14
-
-### MongoDB
-
-**Starting at $15 ($0.0225/hr) for a single node and $45 ($0.0675/hr) for a 3 node high availability cluster.**
-
-MongoDB is a document-oriented *NoSQL* database software that uses JSON files to store data. It is one of the most popular NoSQL databases and, as such, it is *unstructured* and very flexible.
-
-*Best for caching systems, log storage, and for storing data that is too complex, too large, or too variable to be used within a traditional relational database*
-
-**Available versions:**
-
-- MongoDB 4.4
-- MongoDB 4.2
-- MongoDB 4.0
-- MongoDB 3.6
+- PostgreSQL 14
+- PostgreSQL 13
+- PostgreSQL 12
+- PostgreSQL 11
+- PostgreSQL 10
 
 ## Database Plans
 

--- a/docs/products/databases/managed-databases/guides/manage-backups/index.md
+++ b/docs/products/databases/managed-databases/guides/manage-backups/index.md
@@ -53,14 +53,3 @@ For more instructions, see [Backing Up MySQL Databases Using mysqldump](/docs/gu
     pg_dump -Fd --host lin-1111-1111-pgsql-primary.servers.linodedb.net --dbname Example --quote-all-identifiers --verbose --lock-wait-timeout=480000 --no-unlogged-table-data --serializable-deferrable --jobs=1 --username linpostgres --file database.backup
 
 For more information, review the [Backing Up a PostgreSQL Database (Database Dump)](/docs/guides/how-to-back-up-your-postgresql-database/) guide.
-
-### MongoDB
-
-One of MongoDB's primary backup tools is[mongodump](https://www.mongodb.com/docs/database-tools/mongodump/#mongodb-binary-bin.mongodump), installed as a separate utility to MongoDB Server. It can create BSON backup files of MongoDB databases. The following command exports the database called *Example* within the given single node MongoDB Managed Database cluster. Replace the host and database name with your own values. MongoDB also requires you to download and reference the CA certificate, replacing *[certificate-file]* with the path and filename of the certificate. See [Connect to a PostgreSQL Managed Database](/docs/products/databases/managed-databases/guides/postgresql-connect/) guide for instructions on viewing the connection details (including the username, password, host, port, and certificate file).
-
-    mongodump --username=linroot --host=lin-1111-1111.servers.linodedb.net:27017 --db=Example --authenticationDatabase=admin --ssl --sslCAFile=[certificate-file] --gzip --archive=database.archive
-
-For more details as well as instructions on backing up a high availability cluster, see [Exporting from a MongoDB Database](/docs/products/databases/managed-databases/guides/mongodb-migrate/#export-from-the-source-database)
-.
-
-

--- a/docs/products/databases/managed-databases/guides/mongodb-connect/index.md
+++ b/docs/products/databases/managed-databases/guides/mongodb-connect/index.md
@@ -2,6 +2,7 @@
 title: "Connect to a MongoDB Database"
 description: "Learn how to connect to a MongoDB Managed Databse through the command line or Compass"
 published: 2022-06-06
+expiryDate: 2023-05-01
 authors: ["Linode"]
 ---
 

--- a/docs/products/databases/managed-databases/guides/mongodb-migrate/index.md
+++ b/docs/products/databases/managed-databases/guides/mongodb-migrate/index.md
@@ -2,6 +2,7 @@
 title: "Migrate a MongoDB Database to a Managed Database"
 description: "Learn how to migrate an existing MongoDB database to Linode's Managed Database service."
 published: 2022-06-17
+expiryDate: 2023-05-01
 authors: ["Linode"]
 ---
 
@@ -66,7 +67,7 @@ MongoDB Database Tools can be downloaded directly from the [MongoDB Download](ht
 
 ## Export from the Source Database
 
-Exporting the data from the original database is facilitated through the [mongodump](https://www.mongodb.com/docs/database-tools/mongodump/) utility. The following commands create a BSON export of the contents of a specified database. Replace *[username]* with your database user, *[database-name]* with the name of your database, and *[host]* with the hostname/domain of your source database. For Linode Managed Databases, see [Connect to a MongoDB Database](/docs/products/databases/managed-databases/guides/mongodb-connect/#view-connection-details) for connection details.
+Exporting the data from the original database is facilitated through the [mongodump](https://www.mongodb.com/docs/database-tools/mongodump/) utility. The following commands create a BSON export of the contents of a specified database. Replace *[username]* with your database user, *[database-name]* with the name of your database, and *[host]* with the hostname/domain of your source database.
 
 -   **Standalone cluster (single node)**
 
@@ -79,14 +80,14 @@ Exporting the data from the original database is facilitated through the [mongod
         mongodump --username=[username] --host=[replica-set]/[host1]:27017,[host2]:27017,[host3]:27017 --db=[database-name] --gzip --archive=database.archive
 
 {{< note >}}
-If your source database is also a Linode Managed Database, add the following options to either of the above commands: `--authenticationDatabase=admin --ssl --sslCAFile=[certificate-file]`. Replace *[certificate-file]* with the filename and path of your CA Certificate (see [Connection Details](/docs/products/databases/managed-databases/guides/mongodb-connect/#view-connection-details)).
+If your source database is also a Linode Managed Database, add the following options to either of the above commands: `--authenticationDatabase=admin --ssl --sslCAFile=[certificate-file]`. Replace *[certificate-file]* with the filename and path of your CA Certificate.
 {{< /note >}}
 
 See the [mongodump](https://www.mongodb.com/docs/database-tools/mongodump/) documentation to learn more about the [options](https://www.mongodb.com/docs/database-tools/mongodump/#options) available for this utility and to view common [examples](https://www.mongodb.com/docs/database-tools/mongodump/#examples).
 
 ## Import to the Target Managed Database
 
-Once you've successfully backed up the source database, you can import your data into your Managed Database (the *target* database). To import the database, this guide covers the [mongorestore](https://www.mongodb.com/docs/database-tools/mongorestore/) utility, which is the counterpart to mongodump. It restores a BSON dump created by mongodump to a MongoDB database instance. In the below commands, replace *[database-name]* with the name of your database and replace *[host]* with the hostname of your Managed Database (see [Connection Details](/docs/products/databases/managed-databases/guides/mongodb-connect/#view-connection-details)).
+Once you've successfully backed up the source database, you can import your data into your Managed Database (the *target* database). To import the database, this guide covers the [mongorestore](https://www.mongodb.com/docs/database-tools/mongorestore/) utility, which is the counterpart to mongodump. It restores a BSON dump created by mongodump to a MongoDB database instance. In the below commands, replace *[database-name]* with the name of your database and replace *[host]* with the hostname of your Managed Database.
 
 -   **Standalone cluster (single node)**
 
@@ -94,7 +95,7 @@ Once you've successfully backed up the source database, you can import your data
 
 -   **High availability cluster (3 nodes)**
 
-    When restoring to a high availability cluster, input each host (along with the port) separated by a comma. You must also replace *[replica-set]* with the replica set defined for your Managed Database and replace *[host1]*, *[host2]*, and *[host3]* with the hostnames of your Managed Database (see [Connection Details](/docs/products/databases/managed-databases/guides/mongodb-connect/#view-connection-details)).
+    When restoring to a high availability cluster, input each host (along with the port) separated by a comma. You must also replace *[replica-set]* with the replica set defined for your Managed Database and replace *[host1]*, *[host2]*, and *[host3]* with the hostnames of your Managed Database.
 
         mongorestore --username=linroot --host=[replica-set]/[host1]:27017,[host2]:27017,[host3]:27017 --nsInclude="[database-name].*" --ssl --sslCAFile=[certificate-file] --gzip --archive=database.archive
 

--- a/docs/products/databases/managed-databases/resources/index.md
+++ b/docs/products/databases/managed-databases/resources/index.md
@@ -16,5 +16,3 @@ tab_group_main:
 - [What is MySQL?](https://dev.mysql.com/doc/refman/8.0/en/what-is-mysql.html) (from MySQL's documentation)
 
 - [About PostgreSQL](https://www.postgresql.org/about/) (from the PostgreSQL website)
-
-- [Introduction to MongoDB](https://docs.mongodb.com/manual/introduction/) (from MongoDB's documentation)


### PR DESCRIPTION
This PR removes MongoDB from Managed Databases. All MongoDB-specific product guides are hidden and references to MongoDB as a database engine for Managed Database have been removed.