### PR TITLE
[update] Setting Up a Spigot Server for Minecraft on Ubuntu 14.04

### DIFF
--- a/docs/guides/game-servers/minecraft-with-spigot-ubuntu/index.md
+++ b/docs/guides/game-servers/minecraft-with-spigot-ubuntu/index.md
@@ -5,6 +5,7 @@ keywords: ["minecraft", "spigot"]
 tags: ["ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/applications/game-servers/minecraft-with-spigot-ubuntu/','/game-servers/minecraft-with-spigot-ubuntu/']
+deprecated: true
 published: 2015-04-21
 modified: 2019-02-01
 modified_by:


### PR DESCRIPTION
Added deprecation tag to this guide because "The latest version of spigot is no longer compatible with openjdk-7-jre-headless"
