### PR TITLE
[Update] Redirect URLs with the Apache Web Server

### DIFF
--- a/docs/guides/web-servers/apache-tips-and-tricks/redirect-urls-with-the-apache-web-server/index.md
+++ b/docs/guides/web-servers/apache-tips-and-tricks/redirect-urls-with-the-apache-web-server/index.md
@@ -35,10 +35,14 @@ Remember to reload Apache configuration after making changes:
 
 {{< tabs >}}
 {{< tab "CentOS 7" >}}
+```command
 sudo systemctl restart httpd
+```
 {{< /tab >}}
 {{< tab "Ubuntu 16.04" >}}
+```command
 sudo systemctl restart apache2
+```
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/docs/guides/web-servers/apache-tips-and-tricks/redirect-urls-with-the-apache-web-server/index.md
+++ b/docs/guides/web-servers/apache-tips-and-tricks/redirect-urls-with-the-apache-web-server/index.md
@@ -16,11 +16,10 @@ external_resources:
  - '[Rewrite URLs with mod_rewrite and Apache](/docs/guides/rewrite-urls-with-modrewrite-and-apache/)'
 tags: ["web server","apache"]
 authors: ["Linode"]
+image: redirect-urls-with-the-apache-web-server.png
 ---
 
 In this guide, you'll learn how to redirect URLs with Apache. Redirecting a URL allows you to return an HTTP status code that directs the client to a different URL, making it useful for cases in which you've moved a piece of content. Redirect is part of Apache's [mod_alias](https://httpd.apache.org/docs/current/mod/mod_alias.html) module.
-
-![Redirect URLs with the Apache Web Server](redirect-urls-with-the-apache-web-server.png "Redirect URLs with the Apache Web Server")
 
 ## Before You Begin
 
@@ -34,25 +33,22 @@ The Apache virtual host configuration files are found in different places, depen
 
 Remember to reload Apache configuration after making changes:
 
-{{< code class="dark" title="CentOS 7" >}}
+{{< tabs >}}
+{{< tab "CentOS 7" >}}
 sudo systemctl restart httpd
-
-{{< /code >}}
-
-{{< code class="dark" title="Ubuntu 16.04" >}}
+{{< /tab >}}
+{{< tab "Ubuntu 16.04" >}}
 sudo systemctl restart apache2
-
-{{< /code >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ## The Redirect Directive
 
 `Redirect` settings can be located in your main Apache configuration file, but we recommend you keep them in your virtual host files or directory blocks. You can also use `Redirect` statements in `.htaccess` files. Here's an example of how to use `Redirect`:
 
-{{< file "Apache configuration option" apache >}}
+```file {title=".htaccess" lang="apache"}
 Redirect /username http://team.example.com/~username/
-
-{{< /file >}}
-
+```
 
 If no argument is given, `Redirect` sends a temporary (302) status code, and the client is informed that the resource available at `/username` has temporarily moved to `http://team.example.com/~username/`.
 
@@ -60,52 +56,45 @@ No matter where they are located, `Redirect` statements must specify the full fi
 
 You can also provide an argument to return a specific HTTP status:
 
-{{< file "Apache configuration option" apache >}}
+```file {title=".htaccess" lang="apache"}
+Redirect /username http://team.example.com/~username/
 Redirect permanent /username http://team.example.com/~username/
 Redirect temp /username http://team.example.com/~username/
 Redirect seeother /username http://team.example.com/~username/
 Redirect gone /username
+```
 
-{{< /file >}}
-
-
--   `permanent` tells the client the resource has moved permanently. This returns a 301 HTTP status code.
--   `temp` is the default behavior, and tells the client the resource has moved temporarily. This returns a 302 HTTP status code.
--   `seeother` tells the user the requested resource has been replaced by another one. This returns a 303 HTTP status code.
--   `gone` tells the user that the resource they are looking for has been removed permanently. When using this argument, you don't need to specify a final URL. This returns a 410 HTTP status code.
+- `permanent` tells the client the resource has moved permanently. This returns a 301 HTTP status code.
+- `temp` is the default behavior, and tells the client the resource has moved temporarily. This returns a 302 HTTP status code.
+- `seeother` tells the user the requested resource has been replaced by another one. This returns a 303 HTTP status code.
+- `gone` tells the user that the resource they are looking for has been removed permanently. When using this argument, you don't need to specify a final URL. This returns a 410 HTTP status code.
 
 You can also use the HTTP status codes as arguments. Here's an example using the status code options:
 
-{{< file "Apache configuration option" apache >}}
+```file {title=".htaccess" lang="apache"}
 Redirect 301 /username http://team.example.com/~username/
 Redirect 302 /username http://team.example.com/~username/
 Redirect 303 /username http://team.example.com/~username/
 Redirect 410 /username
-
-{{< /file >}}
-
+```
 
 Permanent and temporary redirects can also be done with `RedirectPermanent` and `RedirectTemp`, respectively:
 
-{{< file "Apache configuration option" apache >}}
+```file {title=".htaccess" lang="apache"}
 RedirectPermanent /username/bio.html http://team.example.com/~username/bio/
 RedirectTemp /username/bio.html http://team.example.com/~username/bio/
-
-{{< /file >}}
-
+```
 
 Redirects can be made with [regex patterns](https://en.wikipedia.org/wiki/Regular_expression) as well, using `RedirectMatch`:
 
-{{< file "Apache configuration option" apache >}}
+```file {title=".htaccess" lang="apache"}
 RedirectMatch (.*)\.jpg$ http://static.example.com$1.jpg
-
-{{< /file >}}
-
+```
 
 This matches any request for a file with a `.jpg` extension and replaces it with a location on a given domain. The parentheses allow you to get a specific part of the request, and insert it into the new location's URL as a variable (specified by `$1`, `$2`, etc.). For example:
 
--   A request for `http://www.example.com/avatar.jpg` will be redirected to `http://static.example.com/avatar.jpg` and
--   A request for `http://www.example.com/images/avatar.jpg` will be redirected to `http://static.example.com/images/avatar.jpg`.
+- A request for `http://www.example.com/avatar.jpg` will be redirected to `http://static.example.com/avatar.jpg` and
+- A request for `http://www.example.com/images/avatar.jpg` will be redirected to `http://static.example.com/images/avatar.jpg`.
 
 ## Beyond URL Redirection
 


### PR DESCRIPTION
This PR updates the formatting in the Apache Redirect guide. As part of this, it replaces the deprecated `code` shortcode with the newer `command` shortcode.