### PR TITLE
Theme updates

### DIFF
--- a/_vendor/github.com/linode/linode-docs-theme/assets/css/components/note.css
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/css/components/note.css
@@ -1,19 +1,24 @@
 :root {
-  --color-note--secondary:94,96,101;
-  --color-note--primary:2,177,89;
-  --color-note--warning:255,147,7;
-  --color-note--alert:240,38,38;
+  --color-note--secondary: 94, 96, 101;
+  --color-note--primary: 2, 177, 89;
+  --color-note--warning: 255, 147, 7;
+  --color-note--alert: 240, 38, 38;
 
-  --alpha-note--bg:0.1;
-  --alpha-note--border:1;
-  --alpha-note--pre:0.2;
+  --alpha-note--bg: 0.1;
+  --alpha-note--border: 1;
+  --alpha-note--pre: 0.2;
 }
 .note {
   display: block;
   @apply text-titlecolor text-base mb-2 p-4 border-l-2;
 }
-.content .note-content pre code{
-  background-color: transparent
+
+div + .note {
+  margin-top: 1em;
+}
+
+.content .note-content pre code {
+  background-color: transparent;
 }
 .content .note-content :last-child .code {
   margin-bottom: 0;
@@ -25,10 +30,12 @@
   background-color: rgba(var(--color-note--secondary), var(--alpha-note--bg));
   border-color: rgba(var(--color-note--secondary), var(--alpha-note--border));
 }
-.note.note-secondary .copy-button svg{
+.note.note-secondary .copy-button svg {
   color: rgba(var(--color-note--secondary), 1);
 }
-.note.note-secondary code, .note.note-secondary pre:not(.chroma,.dark), .note.note-secondary .code.light {
+.note.note-secondary code,
+.note.note-secondary pre:not(.chroma, .dark),
+.note.note-secondary .code.light {
   background-color: #dcdddd;
 }
 
@@ -36,10 +43,12 @@
   background-color: rgba(var(--color-note--primary), var(--alpha-note--bg));
   border-color: rgba(var(--color-note--primary), var(--alpha-note--border));
 }
-.note.note-primary .copy-button svg{
+.note.note-primary .copy-button svg {
   color: rgba(var(--color-note--primary), 1);
 }
-.note.note-primary code, .note.note-primary pre:not(.chroma,.dark), .note.note-primary .code.light {
+.note.note-primary code,
+.note.note-primary pre:not(.chroma, .dark),
+.note.note-primary .code.light {
   background-color: #c0e9d4;
 }
 
@@ -48,13 +57,15 @@
   border-color: rgba(var(--color-note--warning), var(--alpha-note--border));
 }
 .note.note-warning a,
-.note.note-warning .copy-button svg{
+.note.note-warning .copy-button svg {
   color: rgba(var(--color-note--warning), 1);
 }
-.note.note-warning a:hover{
+.note.note-warning a:hover {
   color: rgba(var(--color-note--warning), 0.6);
 }
-.note.note-warning code, .note.note-warning pre:not(.chroma,.dark), .note.note-warning .code.light {
+.note.note-warning code,
+.note.note-warning pre:not(.chroma, .dark),
+.note.note-warning .code.light {
   background-color: #fee1c7;
 }
 
@@ -63,13 +74,15 @@
   border-color: rgba(var(--color-note--alert), var(--alpha-note--border));
 }
 .note.note-alert a,
-.note.note-alert .copy-button svg{
+.note.note-alert .copy-button svg {
   color: rgba(var(--color-note--alert), 1);
 }
-.note.note-alert a:hover{
+.note.note-alert a:hover {
   color: rgba(var(--color-note--alert), 0.6);
 }
-.note.note-alert code, .note.note-alert pre:not(.chroma,.dark), .note.note-alert .code.light {
+.note.note-alert code,
+.note.note-alert pre:not(.chroma, .dark),
+.note.note-alert .code.light {
   background-color: #fac1c9;
 }
 .note-content > :first-child {

--- a/_vendor/github.com/linode/linode-docs-theme/assets/js/main/navigation/language-switcher.js
+++ b/_vendor/github.com/linode/linode-docs-theme/assets/js/main/navigation/language-switcher.js
@@ -64,7 +64,17 @@ export function newLanguageSwitcherController(weglot_api_key) {
 					return element.lang === this.currentLang;
 				});
 			},
-
+			languageIDs: function (prefix) {
+				//A string of language IDs prefixed with the given prefix separated by spaces.
+				let s = '';
+				for (let i = 0; i < this.languages.length; i++) {
+					s += prefix + this.languages[i].lang;
+					if (i < this.languages.length - 1) {
+						s += ' ';
+					}
+				}
+				return s;
+			},
 			isDefaultLanguage: function () {
 				return this.currentLang === 'en';
 			},

--- a/_vendor/github.com/linode/linode-docs-theme/content/testpages/tabs-page-1.md
+++ b/_vendor/github.com/linode/linode-docs-theme/content/testpages/tabs-page-1.md
@@ -85,6 +85,10 @@ Tempor voluptate quis reprehenderit excepteur fugiat id sit ad ipsum reprehender
 
 Et ad duis ex proident esse eu Lorem quis exercitation magna ad cupidatat cillum dolor. Est consequat dolor incididunt magna reprehenderit culpa in et mollit fugiat fugiat culpa. Proident officia sit sint elit commodo laboris eu occaecat ullamco ex irure non do. Amet in do nostrud mollit tempor est deserunt ut laboris qui anim. Sunt id occaecat est commodo reprehenderit dolore.
 
+{{% note %}}
+This is a note.
+{{% /note %}}
+
 Exercitation voluptate anim mollit elit ipsum enim non proident eu tempor quis veniam fugiat. Occaecat adipisicing aliqua occaecat consequat ullamco do est magna. Aliquip proident veniam quis consequat esse pariatur sint et laboris consectetur mollit. Velit non enim consectetur excepteur. Sunt nulla dolore incididunt id eu nulla ipsum qui sit tempor proident voluptate. Nisi eiusmod quis aliqua minim aliqua. Elit nostrud sint ut nulla et sit aute excepteur dolore irure aliqua.
 
 Nostrud ea minim magna ipsum elit elit ipsum fugiat consequat dolore. Tempor minim proident quis quis sint laborum incididunt Lorem amet. Pariatur est irure id qui do irure ea incididunt commodo eu. Nisi non sunt consectetur nostrud dolore incididunt tempor elit consequat cillum dolore laborum dolore irure. Voluptate ullamco cillum labore commodo sit enim laboris adipisicing voluptate anim nulla. Dolore magna esse tempor aliquip Lorem eu ea in est ad tempor pariatur.

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/api/__common.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/api/__common.html
@@ -177,16 +177,33 @@ This template includes common API logic and functions.
     {{ end }}
 
     {{/* Code samples */}}
-    {{ with .ExtensionProps.Extensions }}
-      {{ with index . "x-code-samples" }}
-        {{ template "openapi3/print-title" (dict "level" 3 "title" "Request Samples" "id" (printf "%s__request-samples" $action ) ) }}
-        {{ $samples := . | transform.Unmarshal }}
-        {{ $samplesTabs := slice }}
-        {{ range $samples }}
-          {{ $samplesTabs =  $samplesTabs | append (dict "title" .lang "lang" .lang "body" .source) }}
+    {{ if gt hugo.Version "0.111.3" }}
+      {{/* Hugo 0.112.0 updated kin-openapi, which had a breaking change: */}}
+      {{/* - the ExtensionProps is now just a map. */}}
+      {{/* - the code samples are now just strings, not raw JSON. */}}
+      {{ with .Extensions }}
+        {{ with index . "x-code-samples" }}
+          {{ template "openapi3/print-title" (dict "level" 3 "title" "Request Samples" "id" (printf "%s__request-samples" $action ) ) }}
+          {{ $samplesTabs := slice }}
+          {{ range . }}
+            {{ $samplesTabs =  $samplesTabs | append (dict "title" .lang "lang" .lang "body" .source) }}
+          {{ end }}
+          {{ $.Set "dot" $samplesTabs }}
+          {{ template "openapi3/component-tabs" $ }}
         {{ end }}
-        {{ $.Set "dot" $samplesTabs }}
-        {{ template "openapi3/component-tabs" $ }}
+      {{ end }}
+    {{ else }}
+      {{ with .ExtensionProps.Extensions }}
+        {{ with index . "x-code-samples" }}
+          {{ template "openapi3/print-title" (dict "level" 3 "title" "Request Samples" "id" (printf "%s__request-samples" $action ) ) }}
+          {{ $samples := . | transform.Unmarshal }}
+          {{ $samplesTabs := slice }}
+          {{ range $samples }}
+            {{ $samplesTabs =  $samplesTabs | append (dict "title" .lang "lang" .lang "body" .source) }}
+          {{ end }}
+          {{ $.Set "dot" $samplesTabs }}
+          {{ template "openapi3/component-tabs" $ }}
+        {{ end }}
       {{ end }}
     {{ end }}
 

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/head.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/head.html
@@ -7,10 +7,23 @@
 {{ if or site.Params.TestEnv (.Param "noindex") }}
   <meta name="robots" content="noindex" />
 {{ end }}
-<link
-  rel="shortcut icon"
-  href="{{ "favicon.ico" | relURL }}"
-  type="image/x-icon" />
+
+<link rel="apple-touch-icon" sizes="57x57" href="https://assets.linode.com/icons/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="https://assets.linode.com/icons/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="https://assets.linode.com/icons/apple-touch-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="https://assets.linode.com/icons/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="https://assets.linode.com/icons/apple-touch-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="https://assets.linode.com/icons/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="https://assets.linode.com/icons/apple-touch-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="https://assets.linode.com/icons/apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="https://assets.linode.com/icons/apple-touch-icon-180x180.png">
+<link rel="mask-icon" href="https://assets.linode.com/icons/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="icon" type="image/png" sizes="32x32" href="https://assets.linode.com/icons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="194x194" href="https://assets.linode.com/icons/favicon-194x194.png">
+<link rel="icon" type="image/png" sizes="96x96" href="https://assets.linode.com/icons/favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="192x192" href="https://assets.linode.com/icons/android-chrome-192x192.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://assets.linode.com/icons/favicon-16x16.png">
+<link rel="shortcut icon" href="https://assets.linode.com/icons/favicon.ico">
 
 {{/* Adobe Analytics.
   This is configured for the environments production, development (Netlify and local) and staging.

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/navigation/language-switcher.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/navigation/language-switcher.html
@@ -9,8 +9,9 @@
   role="listbox"
   class="weglot_switcher wg-drop country-selector wg-mouse-click'"
   :class="{'closed': !open, 'weg-openleft': open}"
-  aria-activedescendant="weglot-language-en"
-  aria-label="Language selected: English">
+  :aria-owns="languageIDs('weglot-language-')"
+  :aria-activedescendant="`weglot-language-${currentLanguage().lang}`"
+  :aria-label="`Language selected: ${currentLanguage().name}`">
   <div
     @click="$root.focus(); open = !open"
     @click.away="open = false"

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/linode/linode-docs-theme v0.0.0-20230502181945-ae5e0e817313
+# github.com/linode/linode-docs-theme v0.0.0-20230531141205-214ed902f759
 # github.com/linode/linode-website-partials v0.0.0-20230425151945-bcf8272ed6cc
 # github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.401.201
 # github.com/gohugoio/hugo-mod-jslibs/turbo/v7 v7.20001.20100

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/hotwired/turbo v7.0.1+incompatible // indirect
 	github.com/linode/linode-api-docs/v4 v4.153.3-patch.1 // indirect
-	github.com/linode/linode-docs-theme v0.0.0-20230502181945-ae5e0e817313 // indirect
+	github.com/linode/linode-docs-theme v0.0.0-20230531141205-214ed902f759 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/linode/linode-docs-theme v0.0.0-20230425171755-1c28bfa41ce0 h1:/YvBel
 github.com/linode/linode-docs-theme v0.0.0-20230425171755-1c28bfa41ce0/go.mod h1:adjSG8lrb1hNRoZqwxWc8LKr/FQlPGsKv7sByMHFk1c=
 github.com/linode/linode-docs-theme v0.0.0-20230502181945-ae5e0e817313 h1:h8XDZ158VQYM4dRR5b8W3hD4OPuoM11DqtRRYogFLrA=
 github.com/linode/linode-docs-theme v0.0.0-20230502181945-ae5e0e817313/go.mod h1:adjSG8lrb1hNRoZqwxWc8LKr/FQlPGsKv7sByMHFk1c=
+github.com/linode/linode-docs-theme v0.0.0-20230531141205-214ed902f759 h1:WJSWP6p11YAMbrUCbbC76gjC1wdbOH2X8iexKAHg9VM=
+github.com/linode/linode-docs-theme v0.0.0-20230531141205-214ed902f759/go.mod h1:adjSG8lrb1hNRoZqwxWc8LKr/FQlPGsKv7sByMHFk1c=
 github.com/linode/linode-website-partials v0.0.0-20221205205120-b6ea1aaa59fb/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
 github.com/linode/linode-website-partials v0.0.0-20221222200538-99862e429110/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
 github.com/linode/linode-website-partials v0.0.0-20230201145731-a8703d0a954a/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=


### PR DESCRIPTION
- Add margin between tabs and note shortcodes
- Fix for a breaking change in API rendering in new Hugo versions
- Add aria-owns label to language switcher
- Update favicon assets