### PR TITLE
Fixed order of two Cloud Manager release notes

### DIFF
--- a/docs/release-notes/cloud-manager/v1.93.2.md
+++ b/docs/release-notes/cloud-manager/v1.93.2.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Manager v1.93.2
-date: 2023-05-22
+date: 2023-05-22T10:34:00Z
 version: 1.93.2
 ---
 

--- a/docs/release-notes/cloud-manager/v1.93.3.md
+++ b/docs/release-notes/cloud-manager/v1.93.3.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Manager v1.93.3
-date: 2023-05-22
+date: 2023-05-22T16:54:00Z
 version: 1.93.3
 ---
 


### PR DESCRIPTION
This PR fixes the order of Cloud Manager v1.93.2 and v1.93.3 release notes.