### PR TITLE
Fix 404s from external sources

### DIFF
--- a/docs/guides/applications/configuration-management/ansible/running-ansible-playbooks/index.md
+++ b/docs/guides/applications/configuration-management/ansible/running-ansible-playbooks/index.md
@@ -8,7 +8,7 @@ modified: 2015-09-21
 modified_by:
     name: Linode
 title: Automate Server Configuration with Ansible Playbooks
-aliases: ['/applications/configuration-management/ansible/running-ansible-playbooks/','/applications/configuration-management/running-ansible-playbooks/']
+aliases: ['/applications/configuration-management/ansible/running-ansible-playbooks/','/applications/configuration-management/running-ansible-playbooks/','/applications/configuration-management/learn-how-to-install-ansible-and-run-playbooks/']
 tags: ["automation"]
 authors: ["Joshua Lyman"]
 ---

--- a/docs/guides/applications/messaging/install-openfire-on-ubuntu-12-04-for-instant-messaging/index.md
+++ b/docs/guides/applications/messaging/install-openfire-on-ubuntu-12-04-for-instant-messaging/index.md
@@ -5,7 +5,7 @@ description: 'This guide shows how to install the popular collaborative instant 
 keywords: ["openfire", "ubuntu 12.04", "instant messaging", "xmpp server", "collaboration software", "chat software", "linux jabber server", "JRE", "configure openfire"]
 tags: ["ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/applications/messaging/instant-messaging-services-with-openfire-on-ubuntu-12-04-lts-precise-pangolin/','/applications/messaging/install-openfire-on-ubuntu-12-04-for-instant-messaging/','/communications/xmpp/openfire/ubuntu-12-04-precise-pangolin/']
+aliases: ['/applications/messaging/instant-messaging-services-with-openfire-on-ubuntu-12-04-lts-precise-pangolin/','/applications/messaging/install-openfire-on-ubuntu-12-04-for-instant-messaging/','/communications/xmpp/openfire/ubuntu-12-04-precise-pangolin/','/communications/xmpp/openfire/ubuntu-12.04-precise-pangolin/']
 modified: 2016-03-14
 modified_by:
   name: Phil Zona

--- a/docs/guides/databases/mysql/manage-mysql-with-phpmyadmin-on-ubuntu-10-10-maverick/index.md
+++ b/docs/guides/databases/mysql/manage-mysql-with-phpmyadmin-on-ubuntu-10-10-maverick/index.md
@@ -4,7 +4,7 @@ deprecated: true
 description: 'This guide will show you how to use phpMyAdmin to manage and maintain MySQL databases and users though a web interface on Ubuntu 10.10 "Maverick".'
 keywords: ["mysql", "phpmyadmin", "sql", "ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/databases/mysql/manage-mysql-with-phpmyadmin-on-ubuntu-10-10-maverick/','/databases/mysql/phpmyadmin-ubuntu-10-10-maverick/']
+aliases: ['/databases/mysql/manage-mysql-with-phpmyadmin-on-ubuntu-10-10-maverick/','/databases/mysql/phpmyadmin-ubuntu-10-10-maverick/','/databases/mysql/phpmyadmin-ubuntu-10.10-maverick/']
 modified: 2013-09-24
 modified_by:
   name: Linode

--- a/docs/guides/databases/redis/install-redis-ubuntu/index.md
+++ b/docs/guides/databases/redis/install-redis-ubuntu/index.md
@@ -10,6 +10,7 @@ modified_by:
   name: Linode
 title: "Install and Configure Redis on Ubuntu 20.04"
 title_meta: "How to Install and Configure Redis on Ubuntu 20.04"
+aliases: ['/databases/redis/ubuntu-12.04-precise-pangolin/']
 external_resources:
 - '[Redis](https://redis.io/)'
 - '[Redis commands](https://redis.io/commands)'

--- a/docs/guides/development/ror/ruby-on-rails-apache-debian/index.md
+++ b/docs/guides/development/ror/ruby-on-rails-apache-debian/index.md
@@ -5,7 +5,7 @@ og_description: 'This tutorial will teach you how to use an Apache web server wi
 keywords: ["ruby on rails", "rails on debian", "rails apps", "rails and apache", "deploy rails"]
 tags: ["web applications","debian","apache","ruby"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/development/ror/ruby-on-rails-apache-debian/','/websites/ror/ruby-on-rails-apache-debian-9/']
+aliases: ['/development/ror/ruby-on-rails-apache-debian/','/websites/ror/ruby-on-rails-apache-debian-9/','/frameworks/ruby-on-rails-apache/ubuntu-10.04-lucid/']
 published: 2018-03-12
 modified: 2018-03-12
 modified_by:

--- a/docs/guides/email/exim/_index.md
+++ b/docs/guides/email/exim/_index.md
@@ -5,7 +5,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2009-12-17
 title: Exim Guides
 show_in_lists: true
-aliases: ['/email/exim/']
+aliases: ['/email/exim/','/email/exim/send-only-mta-ubuntu-10.04-lucid/']
 authors: ["Linode"]
 ---
 

--- a/docs/guides/email/postfix/email-with-postfix-dovecot-and-mysql/index.md
+++ b/docs/guides/email/postfix/email-with-postfix-dovecot-and-mysql/index.md
@@ -20,7 +20,7 @@ relations:
         key: email-postfix-dovecot-mysql
         keywords:
             - distribution: Debian and Ubuntu
-aliases: ['/email/postfix/email-with-postfix-dovecot-and-mysql/']
+aliases: ['/email/postfix/email-with-postfix-dovecot-and-mysql/','/email/postfix/dovecot-mysql-ubuntu-10.04-lucid/']
 authors: ["Linode"]
 ---
 

--- a/docs/guides/email/zimbra/_index.md
+++ b/docs/guides/email/zimbra/_index.md
@@ -5,7 +5,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2009-09-13
 title: Zimbra Groupware
 show_in_lists: true
-aliases: ['/email/zimbra/']
+aliases: ['/email/zimbra/','/email/zimbra/install-zimbra-ubuntu-10.04-lucid/']
 authors: ["Linode"]
 ---
 

--- a/docs/guides/networking/diagnostics/diagnosing-network-issues-with-mtr/index.md
+++ b/docs/guides/networking/diagnostics/diagnosing-network-issues-with-mtr/index.md
@@ -4,7 +4,7 @@ description: MTR is a network diagnostic tool similar to ping and traceroute. Th
 keywords: ["mtr", "traceroute", "latency", "loss"]
 tags: ["monitoring","resolving","networking","linux"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/networking/diagnostics/diagnosing-network-issues-with-mtr/','/linux-tools/mtr/','/networking/diagnosing-network-issues-with-mtr/']
+aliases: ['/networking/diagnostics/diagnosing-network-issues-with-mtr/','/linux-tools/mtr/','/networking/diagnosing-network-issues-with-mtr/','/troubleshooting/interpreting-mtr-reports/']
 modified: 2018-05-10
 modified_by:
   name: Linode

--- a/docs/guides/security/ssh/use-public-key-authentication-with-ssh/index.md
+++ b/docs/guides/security/ssh/use-public-key-authentication-with-ssh/index.md
@@ -4,7 +4,7 @@ description: "Understand SSH public key authentication and learn how to generate
 keywords: ["ssh", "public key"]
 tags: ["ssh","security"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/security/ssh-keys/','/tools-reference/ssh/use-public-key-authentication-with-ssh/','/security/use-public-key-authentication-with-ssh/','/security/authentication/use-public-key-authentication-with-ssh/']
+aliases: ['/security/ssh-keys/','/tools-reference/ssh/use-public-key-authentication-with-ssh/','/security/use-public-key-authentication-with-ssh/','/security/authentication/use-public-key-authentication-with-ssh/','/networking/ssh/use-public-key-authentication-with-ssh/']
 bundles: ['debian-security', 'centos-security', 'network-security']
 modified_by:
   name: Linode

--- a/docs/guides/security/ssl/ssl-apache2-debian-ubuntu/index.md
+++ b/docs/guides/security/ssl/ssl-apache2-debian-ubuntu/index.md
@@ -4,7 +4,7 @@ description: 'This guide provides you with step-by-step instructions on how to e
 keywords: ["apache SSL", "ssl on debian", "web server", "debian", "apache", "ssl", "ubuntu", "ssl on ubuntu"]
 tags: ["ubuntu","debian","apache","security","ssl"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/security/ssl/ssl-certificates-with-apache-2-on-ubuntu/','/security/ssl/ssl-apache2-debian-ubuntu/','/web-servers/apache/ssl-guides/ubuntu-12.04-precise-pangolin']
+aliases: ['/security/ssl/ssl-certificates-with-apache-2-on-ubuntu/','/security/ssl/ssl-apache2-debian-ubuntu/','/web-servers/apache/ssl-guides/ubuntu-12.04-precise-pangolin/']
 modified: 2021-12-29
 modified_by:
   name: Nick Brewer

--- a/docs/guides/security/ssl/ssl-apache2-debian-ubuntu/index.md
+++ b/docs/guides/security/ssl/ssl-apache2-debian-ubuntu/index.md
@@ -4,7 +4,7 @@ description: 'This guide provides you with step-by-step instructions on how to e
 keywords: ["apache SSL", "ssl on debian", "web server", "debian", "apache", "ssl", "ubuntu", "ssl on ubuntu"]
 tags: ["ubuntu","debian","apache","security","ssl"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/security/ssl/ssl-certificates-with-apache-2-on-ubuntu/','/security/ssl/ssl-apache2-debian-ubuntu/']
+aliases: ['/security/ssl/ssl-certificates-with-apache-2-on-ubuntu/','/security/ssl/ssl-apache2-debian-ubuntu/','/web-servers/apache/ssl-guides/ubuntu-12.04-precise-pangolin']
 modified: 2021-12-29
 modified_by:
   name: Nick Brewer

--- a/docs/guides/security/ssl/using-openssls-subjectaltname-with-multiple-site-domains/index.md
+++ b/docs/guides/security/ssl/using-openssls-subjectaltname-with-multiple-site-domains/index.md
@@ -4,7 +4,7 @@ description: 'How to serve multiple SSL-enabled websites from a single public IP
 keywords: ["openssl", "apache ssl", "subjectaltname", "ssl linux"]
 tags: ["apache","security","ssl"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/security/ssl/multipls-ssl-sites-using-subjectaltname/','/security/ssl/using-openssls-subjectaltname-with-multiple-site-domains/','/security/ssl-certificates/subject-alternate-names/']
+aliases: ['/security/ssl/multipls-ssl-sites-using-subjectaltname/','/security/ssl/using-openssls-subjectaltname-with-multiple-site-domains/','/security/ssl-certificates/subject-alternate-names/', '/ssl-guides/subject-alt-name-ssl/']
 modified: 2017-11-27
 modified_by:
   name: Lukas Sabota

--- a/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-22-04/index.md
+++ b/docs/guides/security/upgrading/how-to-upgrade-to-ubuntu-22-04/index.md
@@ -16,6 +16,7 @@ external_resources:
 - '[Ubuntu Long Term Support Schedule](https://ubuntu.com/about/release-cycle)'
 - '[New features in Ubuntu 22.04](https://ubuntu.com/blog/ubuntu-22-04-lts-whats-new-linux-desktop)'
 authors: ["Jeff Novotny"]
+aliases: ['/upgrading/upgrade-to-ubuntu-12.04-precise/']
 ---
 
 Although Ubuntu 20.04 LTS (*Long Term Support*) is still supported, users should upgrade Ubuntu to the more recent 22.04 LTS. Upgrading to the new release ensures the system can access the most recent security upgrades and application packages. This guide describes how to perform an inline upgrade from Ubuntu 20.xx or 21.xx to 22.04.

--- a/docs/guides/tools-reference/basics/linux-users-and-groups/index.md
+++ b/docs/guides/tools-reference/basics/linux-users-and-groups/index.md
@@ -4,7 +4,7 @@ description: "Want to learn more about Linux users and groups? This guide covers
 keywords: ["users", "permissions", "access control lists", "chmod", "chown", "linux"]
 tags: ["security","linux"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/tools-reference/linux-users-and-groups/','/tools-reference/basics/linux-users-and-groups/','/docs/using-linux/users-and-groups/']
+aliases: ['/tools-reference/linux-users-and-groups/','/tools-reference/basics/linux-users-and-groups/','/docs/using-linux/users-and-groups/','/using-linux/users-and-groups/']
 bundles: ['debian-security', 'centos-security']
 modified: 2021-01-07
 modified_by:

--- a/docs/guides/tools-reference/custom-kernels-distros/_index.md
+++ b/docs/guides/tools-reference/custom-kernels-distros/_index.md
@@ -2,7 +2,7 @@
 description: "While the Linode Platform provides minimalist distribution templates and kernels complied to support the Linode's infrastructure explicitly, it is possible to deploy custom distributions and kernels within the context of the Linode Platform. These documents explore booting into a kernel of your choosing, and the procedure for creating and uploading custom distributions to run in your Linode instance."
 keywords: ["linode instances", "pv grub", "linux kernel", "linode platform", "linux distributions"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/custom-instances/','/tools-reference/custom-kernels-distros/']
+aliases: ['/custom-instances/','/tools-reference/custom-kernels-distros/', '/advanced/pv-grub-howto/']
 published: 2009-07-16
 title: Custom Kernels and Distributions
 show_in_lists: true

--- a/docs/guides/web-servers/apache/_index.md
+++ b/docs/guides/web-servers/apache/_index.md
@@ -2,7 +2,7 @@
 description: 'The Apache web server remains the most popular software for publishing websites on the Internet. This highly configurable, stable server is capable of handling the web serving needs of small and large sites alike. Read on for information on running Apache on your Linode.'
 keywords: ["Apache web server", "Apache on Linode", "Linode web server"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/web-servers/apache/','/websites/apache/']
+aliases: ['/web-servers/apache/','/websites/apache/','/web-servers/apache/php-cgi/ubuntu-10.04-lucid/','/web-servers/apache/mod-wsgi/ubuntu-10.04-lucid/']
 published: 2009-07-16
 title: Hosting Websites with Apache
 show_in_lists: true

--- a/docs/guides/web-servers/apache/apache-access-control/index.md
+++ b/docs/guides/web-servers/apache/apache-access-control/index.md
@@ -4,7 +4,7 @@ description: 'Using HTTP AUTH to limit and control access to resources hosted on
 keywords: ["access control", "http auth", "mod_auth", "http", "apache", "web server", "security"]
 tags: ["http","web server","apache","security"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/web-servers/apache/configuration/http-authentication/','/websites/apache/apache-access-control/','/web-servers/apache/apache-access-control/','/guides/authbased-access-control-with-apache/','/websites/apache/authbased-access-control-with-apache/','/web-servers/apache/authbased-access-control-with-apache/']
+aliases: ['/web-servers/apache/configuration/http-authentication/','/websites/apache/apache-access-control/','/web-servers/apache/apache-access-control/','/guides/authbased-access-control-with-apache/','/websites/apache/authbased-access-control-with-apache/','/web-servers/apache/authbased-access-control-with-apache/','/websites/authbased-access-control-with-apache/']
 modified: 2015-11-20
 modified_by:
   name: Linode

--- a/docs/guides/web-servers/apache/how-to-install-apache-web-server-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/apache/how-to-install-apache-web-server-ubuntu-18-04/index.md
@@ -19,7 +19,7 @@ relations:
         key: install-apache-server
         keywords:
             - distribution: Ubuntu 18.04
-aliases: ['/web-servers/apache/how-to-install-apache-web-server-ubuntu-18-04/']
+aliases: ['/web-servers/apache/how-to-install-apache-web-server-ubuntu-18-04/','/web-servers/apache/installation/ubuntu-10.10-maverick/','/web-servers/apache/installation/ubuntu-12.04-precise-pangolin/']
 authors: ["Linode"]
 ---
 

--- a/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-centos-8/index.md
+++ b/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-centos-8/index.md
@@ -21,7 +21,7 @@ relations:
         key: install-lamp-stack
         keywords:
             - distribution: CentOS 8
-aliases: ['/web-servers/lamp/how-to-install-a-lamp-stack-on-centos-8/']
+aliases: ['/web-servers/lamp/how-to-install-a-lamp-stack-on-centos-8/','/lamp-guides/centos-5.3/index-print/']
 authors: ["Linode"]
 ---
 

--- a/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-22-04/index.md
+++ b/docs/guides/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-22-04/index.md
@@ -22,6 +22,7 @@ relations:
         keywords:
            - distribution: Ubuntu 22.04
 authors: ["Jeff Novotny"]
+aliases: ['/lamp-guides/ubuntu-11.04-natty/']
 ---
 
 The [LAMP Stack](https://en.wikipedia.org/wiki/LAMP_(software_bundle)) includes an operating system, web server, programming language, and database. These applications are collectively able to implement web applications and other computing solutions. This guide provides some background about the LAMP stack and explains how to install and configure it on Ubuntu 22.04 LTS. It also explains how to quickly test interactions between the applications.

--- a/docs/guides/web-servers/lemp/how-to-install-a-lemp-stack-on-ubuntu-22-04/index.md
+++ b/docs/guides/web-servers/lemp/how-to-install-a-lemp-stack-on-ubuntu-22-04/index.md
@@ -23,6 +23,7 @@ relations:
         keywords:
             - distribution: Ubuntu 22.04 LTS
 authors: ["Jeff Novotny"]
+aliases: ['/lemp-guides/ubuntu-12.04-precise-pangolin/']
 ---
 
 Many [Ubuntu](https://ubuntu.com/server) systems use the well-known [LAMP Stack](https://en.wikipedia.org/wiki/LAMP_(software_bundle)) installation. However, many people consider the *LEMP Stack* to be an even better alternative. A LEMP stack uses the [NGINX web server](https://www.nginx.com/) instead of Apache. This guide explains how to install and configure a LEMP stack on Ubuntu 22.04 LTS. It also provides some background about the LEMP stack and how it contrasts with a LAMP stack.

--- a/docs/guides/web-servers/nginx/_index.md
+++ b/docs/guides/web-servers/nginx/_index.md
@@ -2,7 +2,7 @@
 description: 'The NGINX web server is a free and open source, fast, lightweight server designed to efficiently handle the needs of both low and high traffic websites.'
 keywords: ["nginx", "nginx linux", "nginx tutorials", " how to install nginx", " Linode", " configure nginx", " managing nginx", " cloud server", " install nginx on cloud server"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-aliases: ['/websites/nginx/','/web-servers/nginx/','/websites/nginx/index.cfm/']
+aliases: ['/websites/nginx/','/web-servers/nginx/','/websites/nginx/index.cfm/', '/web-servers/nginx/installation/','/web-servers/nginx/php-fastcgi/ubuntu-10.04-lucid/','/web-servers/nginx/python-uwsgi/ubuntu-10.10-maverick/']
 published: 2009-12-14
 title: 'NGINX'
 show_in_lists: true

--- a/docs/guides/web-servers/nginx/how-to-install-and-use-nginx-on-ubuntu-20-04/index.md
+++ b/docs/guides/web-servers/nginx/how-to-install-and-use-nginx-on-ubuntu-20-04/index.md
@@ -17,6 +17,7 @@ relations:
         keywords:
             - distribution: Ubuntu 20.04
 authors: ["Nathaniel Stickman"]
+aliases: ['/web-servers/nginx/installation/ubuntu-10.04-lucid/','/web-servers/nginx/installation/ubuntu-12.04-precise-pangolin/']
 ---
 
 [NGINX](https://nginx.org/) (pronounced "engine-X") is an open-source web server that excels at load balancing, caching, and acting as a reverse proxy. NGINX was developed with efficiency and concurrency in mind, seeking to address the scalability and performance issues in other popular web servers. Its event-driven architecture continues to set it apart as one of the highest-performing web servers available. This guide aims to show you how to install NGINX on your Ubuntu 20.04 server and how to get started using it.

--- a/docs/guides/web-servers/squid/squid-http-proxy-ubuntu-18-04/index.md
+++ b/docs/guides/web-servers/squid/squid-http-proxy-ubuntu-18-04/index.md
@@ -21,7 +21,7 @@ relations:
         key: install-squid-proxy
         keywords:
             - distribution: Ubuntu 18.04
-aliases: ['/web-servers/squid/squid-http-proxy-ubuntu-18-04/']
+aliases: ['/web-servers/squid/squid-http-proxy-ubuntu-18-04/','/networking/squid/squid-http-proxy-ubuntu-12-04/']
 authors: ["Linode"]
 ---
 


### PR DESCRIPTION
The following links are used by external sources and result in 404s:
https://www.linode.com/docs/communications/xmpp/openfire/ubuntu-12.04-precise-pangolin
https://www.linode.com/docs/advanced/pv-grub-howto
https://www.linode.com/docs/web-servers/nginx/installation
https://www.linode.com/docs/websites/authbased-access-control-with-apache
https://www.linode.com/docs/databases/mysql/phpmyadmin-ubuntu-10.10-maverick
https://www.linode.com/docs/databases/redis/ubuntu-12.04-precise-pangolin
https://www.linode.com/docs/email/postfix/dovecot-mysql-ubuntu-10.04-lucid
https://www.linode.com/docs/email/zimbra/install-zimbra-ubuntu-10.04-lucid
https://www.linode.com/docs/lamp-guides/centos-5.3/index-print
https://www.linode.com/docs/lamp-guides/ubuntu-11.04-natty
https://www.linode.com/docs/lemp-guides/ubuntu-12.04-precise-pangolin
https://www.linode.com/docs/networking/squid/squid-http-proxy-ubuntu-12-04
https://www.linode.com/docs/ssl-guides/subject-alt-name-ssl
https://www.linode.com/docs/web-servers/apache/php-cgi/ubuntu-10.04-lucid
https://www.linode.com/docs/web-servers/nginx/installation/ubuntu-10.04-lucid
https://www.linode.com/docs/web-servers/nginx/php-fastcgi/ubuntu-10.04-lucid
https://www.linode.com/docs/web-servers/nginx/python-uwsgi/ubuntu-10.10-maverick
https://www.linode.com/docs/applications/configuration-management/learn-how-to-install-ansible-and-run-playbooks/
https://www.linode.com/docs/communications/xmpp/openfire/ubuntu-12.04-precise-pangolin
https://www.linode.com/docs/email/exim/send-only-mta-ubuntu-10.04-lucid
https://www.linode.com/docs/frameworks/ruby-on-rails-apache/ubuntu-10.04-lucid
https://www.linode.com/docs/networking/squid/squid-http-proxy-ubuntu-12-04
https://www.linode.com/docs/networking/ssh/use-public-key-authentication-with-ssh
https://www.linode.com/docs/troubleshooting/interpreting-mtr-reports
https://www.linode.com/docs/upgrading/upgrade-to-ubuntu-12.04-precise
https://www.linode.com/docs/web-servers/apache/installation/ubuntu-10.10-maverick
https://www.linode.com/docs/web-servers/apache/installation/ubuntu-12.04-precise-pangolin
https://www.linode.com/docs/web-servers/apache/mod-wsgi/ubuntu-10.04-lucid
https://www.linode.com/docs/web-servers/nginx/installation/ubuntu-12.04-precise-pangolin
https://www.linode.com/docs/using-linux/users-and-groups
https://www.linode.com/docs/web-servers/apache/ssl-guides/ubuntu-12.04-precise-pangolin

Added aliases to related guides or sections for each of the above URLs in frontmatter

---

Note that 
https://www.linode.com/docs/guides/disk-images-and-configuration-profiles/ was originally included in the 404 report but that properly redirects to https://www.linode.com/docs/products/compute/compute-instances/guides/configuration-profiles/ already.