### PR TITLE
Small edits to Fail2Ban guide

### DIFF
--- a/docs/guides/security/basics/using-fail2ban-to-secure-your-server-a-tutorial/index.md
+++ b/docs/guides/security/basics/using-fail2ban-to-secure-your-server-a-tutorial/index.md
@@ -1,4 +1,6 @@
 ---
+title: "Using Fail2ban to Secure Your Server"
+title_meta: "How to Use Fail2ban to Secure Your Server (A Tutorial)"
 slug: using-fail2ban-to-secure-your-server-a-tutorial
 description: "This guide shows you how to set up Fail2Ban, a log-parsing application, to monitor system logs, and detect automated attacks on your Linode."
 keywords: ["fail2ban", "ip whitelisting", "jail.local"]
@@ -6,12 +8,10 @@ aliases: ['/tools-reference/tools/using-fail2ban-to-block-network-probes/','/sec
 bundles: ['debian-security', 'centos-security']
 tags: ["monitoring","security"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2021-01-08
+published: 2015-10-12
+modified: 2023-06-27
 modified_by:
   name: Linode
-published: 2015-10-12
-title: "Using Fail2ban to Secure Your Server"
-title_meta: "How to Use Fail2ban to Secure Your Server (A Tutorial)"
 authors: ["Linode"]
 ---
 
@@ -25,11 +25,11 @@ When an attempted compromise is located, using the defined parameters, Fail2ban 
 
 Fail2ban is primarily focused on SSH attacks, although it can be further configured to work for any service that uses log files and can be subject to a compromise.
 
-{{< note respectIndent=false >}}
+{{< note >}}
 The steps in this guide require root privileges. Be sure to run the steps below as **root** or with the `sudo` prefix. For more information on privileges, see our [Users and Groups](/docs/guides/linux-users-and-groups) guide.
 {{< /note >}}
 
-{{< note type="alert" respectIndent=false >}}
+{{< note type="alert" >}}
 Fail2ban is intended to be used in conjunction with an already-hardened server and should not be used as a replacement for secure firewall rules.
 {{< /note >}}
 
@@ -41,90 +41,124 @@ Follow the [Getting Started](/docs/products/platform/get-started/) guide to conf
 
 1.  Ensure your system is up to date and install the EPEL repository:
 
-        yum update -y && yum install epel-release -y
+    ```command
+    yum update -y && yum install epel-release -y
+    ```
 
-2.  Install Fail2Ban:
+1.  Install Fail2Ban:
 
-        yum install fail2ban
+    ```command
+    yum install fail2ban
+    ```
 
-3.  Install Sendmail if you additionally would like email support. Sendmail is not required to use Fail2Ban.:
+1.  Install Sendmail if you additionally would like email support. Sendmail is not required to use Fail2Ban.:
 
-        yum install sendmail
+    ```command
+    yum install sendmail
+    ```
 
-4.  Start and enable Fail2ban and, if needed, Sendmail:
+1.  Start and enable Fail2ban and, if needed, Sendmail:
 
-        systemctl enable --now fail2ban
-        systemctl enable --now sendmail
+    ```command
+    systemctl enable --now fail2ban
+    systemctl enable --now sendmail
+    ```
 
-    {{< note respectIndent=false >}}
-If you encounter the error that there is `no directory /var/run/fail2ban to contain the socket file /var/run/fail2ban/fail2ban.sock`, create the directory manually:
+    {{< note >}}
+    If you encounter the error that there is `no directory /var/run/fail2ban to contain the socket file /var/run/fail2ban/fail2ban.sock`, create the directory manually:
 
+    ```command
     mkdir /var/run/fail2ban
-{{< /note >}}
+    ```
+    {{< /note >}}
 
 ### Debian
 
 1.  Ensure your system is up to date:
 
-        apt-get update && apt-get upgrade -y
+    ```command
+    apt update && apt upgrade -y
+    ```
 
 2.  Install Fail2ban:
 
-        apt-get install fail2ban
+    ```command
+    apt install fail2ban
+    ```
 
     The service automatically starts.
 
 3.  (Optional) If you would like email support, install Sendmail:
 
-        apt-get install sendmail-bin sendmail
+    ```command
+    apt install sendmail-bin sendmail
+    ```
 
-    {{< note respectIndent=false >}}
-The current version of Sendmail in Debian Jessie has an [upstream bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=293017) which causes the following errors when installing `sendmail-bin`. The installation hangs for a minute, but then completes.
+    {{< note >}}
+    The current version of Sendmail in Debian Jessie has an [upstream bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=293017) which causes the following errors when installing `sendmail-bin`. The installation hangs for a minute, but then completes.
 
+    ```output
     Creating /etc/mail/sendmail.cf...
     ERROR: FEATURE() should be before MAILER() MAILER('local') must appear after FEATURE('always_add_domain')
     ERROR: FEATURE() should be before MAILER() MAILER('local') must appear after FEATURE('allmasquerade')
-{{< /note >}}
+    ```
+    {{< /note >}}
 
 ### Fedora
 
 1.  Update your system:
 
-        dnf update
+    ```command
+    dnf update
+    ```
 
 2.  Install Fail2ban:
 
-        dnf install fail2ban
+    ```command
+    dnf install fail2ban
+    ```
 
 3.  (Optional) If you would like email support, install Sendmail:
 
-        dnf install sendmail
+    ```command
+    dnf install sendmail
+    ```
 
 4.  Start and enable Fail2ban and, if needed, Sendmail:
 
-        systemctl enable --now fail2ban
-        systemctl enable --now sendmail
+    ```command
+    systemctl enable --now fail2ban
+    systemctl enable --now sendmail
+    ```
 
 ### Ubuntu
 
 1.  Ensure your system is up to date:
 
-        apt-get update && apt-get upgrade -y
+    ```command
+    apt update && apt upgrade -y
+    ```
 
 2.  Install Fail2ban:
 
-        apt-get install fail2ban
+    ```command
+    apt install fail2ban
+    ```
 
     The service automatically starts.
 
 3.  (Optional) If you would like email support, install Sendmail:
 
-        apt-get install sendmail
+    ```command
+    apt install sendmail
+    ```
 
 4.  Allow SSH access through UFW and then enable the firewall:
 
-        ufw allow ssh
-        ufw enable
+    ```command
+    ufw allow ssh
+    ufw enable
+    ```
 
 ## How to Configure Fail2ban
 
@@ -134,9 +168,11 @@ This section contains examples of common Fail2ban configurations using `fail2ban
 
 1.  `fail2ban.conf` contains the default configuration profile. The default settings give you a reasonable working setup. If you want to make any changes, it's best to do it in a separate file, `fail2ban.local`, which overrides `fail2ban.conf`. Rename a copy `fail2ban.conf` to `fail2ban.local`.
 
-        cp /etc/fail2ban/fail2ban.conf /etc/fail2ban/fail2ban.local
+    ```command
+    cp /etc/fail2ban/fail2ban.conf /etc/fail2ban/fail2ban.local
+    ```
 
-2.  From here, you can opt to edit the definitions in `fail2ban.local` to match your desired configuration. The values that can be changed are:
+1.  From here, you can opt to edit the definitions in `fail2ban.local` to match your desired configuration. The values that can be changed are:
 
     -   `loglevel`: The level of detail that Fail2ban's logs provide can be set to 1 (error), 2 (warn), 3 (info), or 4 (debug).
     -   `logtarget`: Logs actions into a specific file. The default value of `/var/log/fail2ban.log` puts all logging into the defined file. Alternately, you can change the value to:
@@ -151,60 +187,57 @@ This section contains examples of common Fail2ban configurations using `fail2ban
 
 1.  The `jail.conf` file enables Fail2ban for SSH by default for Debian and Ubuntu, but not CentOS. All other protocols and configurations (HTTP, FTP, etc.) are commented out. If you want to change this, create a `jail.local` for editing:
 
-        cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local
+    ```command
+    cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local
+    ```
 
-2.  **If using CentOS or Fedora** you need to change the `backend` option in `jail.local` from *auto* to *systemd*. This is not necessary on Debian 8 or Ubuntu 16.04, even though both use systemd as well.
+1.  **If using CentOS or Fedora** you need to change the `backend` option in `jail.local` from *auto* to *systemd*. This is not necessary on Debian 8 or Ubuntu 16.04, even though both use systemd as well.
 
-    {{< file "/etc/fail2ban/jail.local" aconf >}}
+    ```file {title="/etc/fail2ban/jail.local" lang="aconf"}
     # "backend" specifies the backend used to get files modification.
     # Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
     # This option can be overridden in each jail as well.
-    
+
     . . .
-    
+
     backend = systemd
-    
-    {{< /file >}}
+    ```
 
-{{< note respectIndent=false >}}
-If the `backend` configuration is set to `auto`, Fail2ban monitors log files by first using `pyinotify`. Next, it tries `gamin`. If neither are available, a polling algorithm decides what to try next.
-{{< /note >}}
+    {{< note >}}
+    If the `backend` configuration is set to `auto`, Fail2ban monitors log files by first using `pyinotify`. Next, it tries `gamin`. If neither are available, a polling algorithm decides what to try next.
+    {{< /note >}}
 
+    No jails are enabled by default in CentOS 7. For example, to enable the SSH daemon jail, uncomment the following lines in `jail.local`:
 
-No jails are enabled by default in CentOS 7. For example, to enable the SSH daemon jail, uncomment the following lines in `jail.local`:
-
-{{< file "/etc/fail2ban/jail.local" aconf >}}
-[sshd]
-enabled = true
-
-{{< /file >}}
+    ```file {title="/etc/fail2ban/jail.local" lang="aconf"}
+    [sshd]
+    enabled = true
+    ```
 
 ### Fail2ban jail.local Configurations
 
 To become more familiar with Fail2ban's available settings, open your `jail.local` file and browse the available configurations.
 
-{{< file "/etc/fail2ban/jail.local" >}}
+```file {title="/etc/fail2ban/jail.local"}
+[DEFAULT]
 
-    [DEFAULT]
-
-    ignoreip = 127.0.0.1/8
-    bantime = 600
-    findtime = 600
-    maxretry = 3
-    backend = auto
-    usedns = warn
-    destemail = root@localhost
-    sendername = Fail2Ban
-    banaction = iptables-multiport
-    mta = sendmail
-    protocol = tcp
-    chain = INPUT
-    action_ = %(banaction)...
-    action_mw = %(banaction)...
-    protocol="%(protocol)s"...
-    action_mwl = %(banaction)s...
-
-{{</ file >}}
+ignoreip = 127.0.0.1/8
+bantime = 600
+findtime = 600
+maxretry = 3
+backend = auto
+usedns = warn
+destemail = root@localhost
+sendername = Fail2Ban
+banaction = iptables-multiport
+mta = sendmail
+protocol = tcp
+chain = INPUT
+action_ = %(banaction)...
+action_mw = %(banaction)...
+protocol="%(protocol)s"...
+action_mwl = %(banaction)s...
+```
 
 For example, if you set the `usedns` setting to `no`, Fail2ban does not use reverse DNS to set its bans, and instead bans the IP address. When set as `warn`, Fail2ban performs a reverse lookup of the hostname and uses it to perform a ban.
 
@@ -214,11 +247,13 @@ The `chain` setting refers to the series of [iptables](/docs/guides/what-is-ipta
 
 You can use iptables' `--line-numbers` option to view your Fail2ban rules.
 
-        iptables -L f2b-sshd -v -n --line-numbers
+```command
+iptables -L f2b-sshd -v -n --line-numbers
+```
 
 You should receive a similar output:
 
-{{< output >}}
+```output
 Chain fail2ban-SSH (1 references)
 num   pkts bytes target     prot opt in     out   source              destination
 1       19  2332 DROP       all  --  *      *     192.0.0.0           0.0.0.0/0
@@ -226,17 +261,19 @@ num   pkts bytes target     prot opt in     out   source              destinatio
 3       15   980 DROP       all  --  *      *     192.0.0.2           0.0.0.0/0
 4        6   360 DROP       all  --  *      *     192.0.0.3           0.0.0.0/0
 5     8504  581K RETURN     all  --  *      *     0.0.0.0/0           0.0.0.0/0
-{{</ output >}}
+```
 
 You can remove a rule applied to an IP address using the `iptables -D chain rulenum` command. Replace `rulenum` with the corresponding IP address rule number from the `num` column. For example, to remove the IP address `192.0.0.1`, issue the following command:
 
-        iptables -D fail2ban-SSH 2
+```command
+iptables -D fail2ban-SSH 2
+```
 
 ### Ban Time and Retry Amount Fail2Ban Configuration
 
 Set `bantime`, `findtime`, and `maxretry` to define the circumstances and the length of time of a ban:
 
-{{< file "/etc/fail2ban/jail.local" aconf >}}
+```file {title="/etc/fail2ban/jail.local" lang="aconf"}
 # "bantime" is the number of seconds that a host is banned.
 bantime  = 600
 
@@ -244,8 +281,7 @@ bantime  = 600
 # seconds.
 findtime = 600
 maxretry = 3
-
-{{< /file >}}
+```
 
 -   `findtime`: The lengths of time between login attempts before a ban is set. For example, if Fail2ban is set to ban an IP after five (5) failed log-in attempts, those 5 attempts must occur within the set 10-minute `findtime` limit. The `findtime` value should be a set number of seconds.
 
@@ -257,21 +293,22 @@ maxretry = 3
 
 To ignore specific IPs, add them to the `ignoreip` line. By default, this command does not ban the localhost. If you work from a single IP address often, it may be beneficial to add it to the ignore list:
 
-{{< file "/etc/fail2ban/jail.local" aconf >}}
+```file {title="/etc/fail2ban/jail.local" lang="aconf"}
 [DEFAULT]
 
 # "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban will not
 # ban a host which matches an address in this list. Several addresses can be
 # defined using space separator.
 ignoreip = 127.0.0.1/8 123.45.67.89
-
-{{< /file >}}
+```
 
 `ignoreip`: This setting helps you define IP addresses that should be excluded from Fail2ban rules. To ignore specific IPs, add them to the `ignoreip` configuration, as shown in the example. By default, this command does not ban the `localhost`. If you often work from a single IP address, you should consider adding it to the ignore list.
 
 If you wish to allow IPs only for certain jails, this can be done with the `fail2ban-client` command. Replace `JAIL` with the name of your jail, and `192.0.0.1` with the IP you wish to allow.
 
-    fail2ban-client set JAIL addignoreip 192.0.0.1
+```command
+fail2ban-client set JAIL addignoreip 192.0.0.1
+```
 
 ### Fail2ban Email Alerts
 
@@ -285,7 +322,7 @@ To receive email when fail2ban is triggered, adjust the email settings:
 
 -  `sender`: The email address from which Fail2ban sends emails.
 
-{{< note respectIndent=false >}}
+{{< note >}}
 If unsure of what to put under `sender`, run the command `sendmail -t user@email.com`, replacing `user@email.com` with your email address. Check your email (including spam folders, if needed) and review the sender email. This address can be used for the above configuration.
 {{< /note >}}
 
@@ -297,7 +334,7 @@ Beyond the basic settings address above, jail.local also contains various jail c
 
 An average jail configuration resembles the following:
 
-{{< file "/etc/fail2ban/jail.local" >}}
+```file {title="/etc/fail2ban/jail.local"}
 # Default banning action (e.g. iptables, iptables-new,
 # iptables-multiport, shorewall, etc) It is used to define
 # action_* variables. Can be overridden globally or per
@@ -312,8 +349,7 @@ port     = ssh
 filter   = sshd
 logpath  = /var/log/auth.log
 maxretry = 6
-
-{{< /file >}}
+```
 
 -   `banaction`: Determines the action to use when the threshold is reached. If you have configured the firewall to use firewalld set the value to `firewallcmd-ipset` and if you have configured the firewall to use UFW set the value to `ufw`.
 -   `banaction_allports`: Blocks a remote IP in every port. If you have configured the firewall to use firewalld set the value to `firewallcmd-ipset`.
@@ -324,7 +360,7 @@ maxretry = 6
 -   `maxretry`: Will override the global `maxretry` for the defined service. `findtime` and `bantime` can also be added.
 -   `action`: This can be added as an additional setting, if the default action is not suitable for the jail. Additional actions can be found in the `action.d` folder.
 
-{{< note respectIndent=false >}}
+{{< note >}}
 Jails can also be configured as individual `.conf` files placed in the `jail.d` directory. The format remains the same.
 {{< /note >}}
 
@@ -336,7 +372,7 @@ Depending on your system's Fail2ban version, you can find your system's filters 
 
 Open your `/etc/fail2ban/jail.conf` file and examine the `ssh/sshd` filter:
 
-{{< file "/etc/fail2ban/jail.conf" >}}
+```file {title="/etc/fail2ban/jail.local"}
 [ssh]
 
 enabled  = true
@@ -344,42 +380,44 @@ port     = ssh
 filter   = sshd
 logpath  = /var/log/auth.log
 maxretry = 5
-
-{{</ file >}}
+```
 
 If you are using a Fail2ban version greater than `0.8`, check both your `defaults-*.conf` and `jail.conf` files.
 
 If your system has Fail2ban version 0.8 or greater, your `jail.conf` file resembles the following example:
 
-{{< file "/etc/fail2ban/jail.conf" >}}
+```file {title="/etc/fail2ban/jail.local"}
 [sshd]
 
 port    = ssh
 logpath = %(sshd_log)s
-{{</ file >}}
+```
 
 Finally, a system using Fail2ban 0.8 or greater has a `defaults-*.conf` that includes the following filters:
 
-{{< file "/etc/fail2ban/jail.d/defaults-*.conf" >}}
+```file {title="/etc/fail2ban/jail.d/defaults-*.conf"}
 [sshd]
 
 enabled  = true
 maxretry = 3
-{{</ file >}}
+```
 
 You can test your existing filters by running the example command and replacing `logfile`, `failregex`, and `ignoreregex` with your own values.
 
-    fail2ban-regex logfile failregex ignoreregex
+```command
+fail2ban-regex logfile failregex ignoreregex
+```
 
 Using the examples from the beginning of this section, the command resembles the following:
 
-    fail2ban-regex /var/log/auth.log /etc/fail2ban/filter.d/sshd.conf
+```command
+fail2ban-regex /var/log/auth.log /etc/fail2ban/filter.d/sshd.conf
+```
 
 Your Fail2ban filters have to work with:
 
-1.  Different types of logs generated by different software
-
-1.  Different configurations and multiple operating systems
+1. Different types of logs generated by different software
+2. Different configurations and multiple operating systems
 
 In addition to the above, they also have to be log-format agnostic, must be safeguarded against DDoS, and have to be compatible with future versions of the software.
 
@@ -389,12 +427,12 @@ Before making changes to the `failregex` configuration, you have to customize `i
 
 For example, to exclude activity cron from running on your server or to exclude MySQL, you can configure `ignoreregex` to filter logs generated by these two programs:
 
-{{< file "/etc/fail2ban/filter.d/sshd.conf" >}}
+```file {title="/etc/fail2ban/filter.d/sshd.conf"}
 ignoreregex = : pam_unix\((cron|sshd):session\): session (open|clos)ed for user (daemon|munin|mysql|root)( by \(uid=0\))?$
             : Successful su for (mysql) by root$
             New session \d+ of user (mysql)\.$
             Removed session \d+\.$
-{{</ file >}}
+```
 
 Now that you have filtered for the each program's logs, you can customize `failregexs` to block what you want.
 
@@ -408,23 +446,21 @@ The best way to understand how failregex works is to write one. Although we do n
 
 1.  Navigate to your website's `access.log` (generally located at `/var/www/example.com/logs/access.log`) and find a failed login attempt. It resembles:
 
-    {{< file "/var/www/example.com/logs/access.log" resource >}}
-123.45.67.89 - - [01/Oct/2015:12:46:34 -0400] "POST /wp-login.php HTTP/1.1" 200 1906 "http://example.com/wp-login.php" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:40.0) Gecko/20100101 Firefox/40.0"
-
-{{< /file >}}
-
+    ```file {title="/var/www/example.com/logs/access.log" lang="resource"}
+    123.45.67.89 - - [01/Oct/2015:12:46:34 -0400] "POST /wp-login.php HTTP/1.1" 200 1906 "http://example.com/wp-login.php" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:40.0) Gecko/20100101 Firefox/40.0"
+    ```
 
     Note that you only need to track up to the `200`:
 
-    {{< file "/var/www/example.com/logs/access.log" resource >}}
-123.45.67.89 - - [01/Oct/2015:12:46:34 -0400] "POST /wp-login.php HTTP/1.1" 200
-
-{{< /file >}}
-
+    ```file {title="/var/www/example.com/logs/access.log" lang="resource"}
+    123.45.67.89 - - [01/Oct/2015:12:46:34 -0400] "POST /wp-login.php HTTP/1.1" 200
+    ```
 
 1.  The IP address from where the failed attempt originated is always be defined as `<HOST>`. The subsequent few characters are unchanging and can be input as literals:
 
-        <HOST> - - \[
+    ```command
+    <HOST> - - \[
+    ```
 
     The `\` before the `[` denotes that the square bracket is to be read literally.
 
@@ -432,31 +468,45 @@ The best way to understand how failregex works is to write one. Although we do n
 
     Thus far, you should have:
 
-        <HOST> - - \[(\d{2})
+    ```command
+    <HOST> - - \[(\d{2})
+    ```
 
     The following forward slash is then be called with a literal forward slash, followed by `\w{3}` which looks for a series of `3` alpha-numeric characters (i.e., A-Z, 0-9, any case). The following forward slash should also be literal:
 
-        <HOST> - - \[(\d{2})/\w{3}/
+    ```command
+    <HOST> - - \[(\d{2})/\w{3}/
+    ```
 
     The section for the year should be written similar to the day, but without the need for a capture group, and for four consecutive characters (and a literal colon):
 
-        <HOST> - - \[(\d{2})/\w{3}/\d{4}:
+    ```command
+    <HOST> - - \[(\d{2})/\w{3}/\d{4}:
+    ```
 
 1.  The next sequence is a series of two-digit numbers that make up the time. Because we defined the day of the month as a two-digit number in a capture group (the parentheses), we can backreference it using `\1` (since it is the *first* capture group). Again, the colons are literals:
 
-        <HOST> - - \[(\d{2})/\w{3}/\d{4}:\1:\1:\1
+    ```command
+    <HOST> - - \[(\d{2})/\w{3}/\d{4}:\1:\1:\1
+    ```
 
     If you do not want to use backreferences this can also be written as:
 
-        <HOST> - - \[\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2}
+    ```command
+    <HOST> - - \[\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2}
+    ```
 
 1.  The `-0400` segment should be written similarly to the year, with the additional literal `-`: `-\d{4}`. Finally, you can close the square bracket (escaping with a backslash first), and finish the rest with the literal string:
 
-        <HOST> - - \[(\d{2})/\w{3}/\d{4}:\1:\1:\1 -\d{4}\] "POST /wp-login.php HTTP/1.1" 200
+    ```command
+    <HOST> - - \[(\d{2})/\w{3}/\d{4}:\1:\1:\1 -\d{4}\] "POST /wp-login.php HTTP/1.1" 200
+    ```
 
     Or:
 
-        <HOST> - - \[\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2} -\d{4}\] "POST /wp-login.php HTTP/1.1" 200
+    ```command
+    <HOST> - - \[\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2} -\d{4}\] "POST /wp-login.php HTTP/1.1" 200
+    ```
 
 ### Apply the Failregex
 
@@ -464,34 +514,32 @@ With the failregex created, it then needs to be added to a filter.
 
 1.  Navigate to Fail2ban's `filter.d` directory:
 
-        cd /etc/fail2ban/filter.d
+    ```command
+    cd /etc/fail2ban/filter.d
+    ```
 
 1.  Create a file called `wordpress.conf`, and add your failregex:
 
-{{< file "/etc/fail2ban/filter.d/wordpress.conf" aconf >}}
-# Fail2Ban filter for WordPress
+    ```file {title="/etc/fail2ban/filter.d/wordpress.conf" lang="aconf"}
+    # Fail2Ban filter for WordPress
 
-[Definition]
+    [Definition]
 
-failregex = <HOST> - - \[(\d{2})/\w{3}/\d{4}:\1:\1:\1 -\d{4}\] "POST /wp-login.php HTTP/1.1" 200
-ignoreregex =
-
-{{< /file >}}
-
+    failregex = <HOST> - - \[(\d{2})/\w{3}/\d{4}:\1:\1:\1 -\d{4}\] "POST /wp-login.php HTTP/1.1" 200
+    ignoreregex =
+    ```
 
     Save and quit.
 
 1.  Add a WordPress section to `jail.local`:
 
-{{< file "/etc/fail2ban/jail.local" aconf >}}
-[wordpress]
-enabled  = true
-filter   = wordpress
-logpath  = /var/www/html/andromeda/logs/access.log
-port     = 80,443
-
-{{< /file >}}
-
+    ```file {title="/etc/fail2ban/jail.local" lang="aconf"}
+    [wordpress]
+    enabled  = true
+    filter   = wordpress
+    logpath  = /var/www/html/andromeda/logs/access.log
+    port     = 80,443
+    ```
 
 This uses the default ban and email action. Other actions can be defined by adding an `action =` line.
 
@@ -501,7 +549,9 @@ Save and exit, then restart Fail2ban.
 
 Fail2ban provides a command `fail2ban-client` that can be used to run Fail2ban from the command line:
 
-    fail2ban-client COMMAND
+```command
+fail2ban-client COMMAND
+```
 
 -   `start`: Starts the Fail2ban server and jails.
 -   `reload`: Reloads Fail2ban's configuration files.
@@ -512,13 +562,17 @@ Fail2ban provides a command `fail2ban-client` that can be used to run Fail2ban f
 
 For example, to check that the Fail2Ban is running and the SSHd jail is enabled, run:
 
-    fail2ban-client status
+```command
+fail2ban-client status
+```
 
 The output should be:
 
-    Status
-    |- Number of jail:      1
-    `- Jail list:   sshd
+```output
+Status
+|- Number of jail:      1
+`- Jail list:   sshd
+```
 
 For additional information about `fail2ban-client` commands, see the [Fail2ban wiki](http://www.fail2ban.org/wiki/index.php/Commands).
 
@@ -528,33 +582,40 @@ In the event that you find yourself locked out of your Linode due to fail2ban, y
 
 From here, you can view your firewall rules to ensure that it is fail2ban that blocked your IP, and not something else. To do this, enter the following command:
 
-    iptables -n -L
+```command
+iptables -n -L
+```
 
 Look for your IP address in the `source` column of any fail2ban chains (always prefixed by `f2b` or `fail2ban`) to confirm whether or not you were blocked by the fail2ban service:
 
-{{< output >}}
+```output
 Chain f2b-sshd (1 references)
 target     prot opt source               destination
 REJECT     all  --  203.0.113.0        0.0.0.0/0            reject-with icmp-e
-{{< /output >}}
+```
 
 To remove your IP address from a [jail](#configure-jail-local-settings), you can use the following command, replacing `203.0.113.0` and `jailname` with the IP address and name of the jail that you'd like to unban:
 
-    fail2ban-client set jailname unbanip 203.0.113.0
+```command
+fail2ban-client set jailname unbanip 203.0.113.0
+```
 
-{{< note respectIndent=false >}}
-
+{{< note >}}
 If you can't remember your jail name, then you can always use the following command to list all jails:
 
-    fail2ban-client status
-
+```command
+fail2ban-client status
+```
 {{< /note >}}
 
 If you find that you would like to stop using your fail2ban service at any time, you can enter the following:
 
-    fail2ban-client stop
+```command
+fail2ban-client stop
+```
 
 CentOS 7 and Fedora additionally require two extra commands to be fully stopped and disabled:
 
-    systemctl stop fail2ban
-    systemctl disable fail2ban
+```command
+systemctl disable --now fail2ban
+```

--- a/docs/guides/security/basics/using-fail2ban-to-secure-your-server-a-tutorial/index.md
+++ b/docs/guides/security/basics/using-fail2ban-to-secure-your-server-a-tutorial/index.md
@@ -53,10 +53,8 @@ Follow the [Getting Started](/docs/products/platform/get-started/) guide to conf
 
 4.  Start and enable Fail2ban and, if needed, Sendmail:
 
-        systemctl start fail2ban
-        systemctl enable fail2ban
-        systemctl start sendmail
-        systemctl enable sendmail
+        systemctl enable --now fail2ban
+        systemctl enable --now sendmail
 
     {{< note respectIndent=false >}}
 If you encounter the error that there is `no directory /var/run/fail2ban to contain the socket file /var/run/fail2ban/fail2ban.sock`, create the directory manually:
@@ -81,7 +79,7 @@ If you encounter the error that there is `no directory /var/run/fail2ban to cont
         apt-get install sendmail-bin sendmail
 
     {{< note respectIndent=false >}}
-The current version of Sendmail in Debian Jessie has an [upstream bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=293017) which causes the following errors when installing `sendmail-bin`. The installation hangs for a minute, but then complete.
+The current version of Sendmail in Debian Jessie has an [upstream bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=293017) which causes the following errors when installing `sendmail-bin`. The installation hangs for a minute, but then completes.
 
     Creating /etc/mail/sendmail.cf...
     ERROR: FEATURE() should be before MAILER() MAILER('local') must appear after FEATURE('always_add_domain')
@@ -104,10 +102,8 @@ The current version of Sendmail in Debian Jessie has an [upstream bug](https://b
 
 4.  Start and enable Fail2ban and, if needed, Sendmail:
 
-        systemctl start fail2ban
-        systemctl enable fail2ban
-        systemctl start sendmail
-        systemctl enable sendmail
+        systemctl enable --now fail2ban
+        systemctl enable --now sendmail
 
 ### Ubuntu
 
@@ -159,16 +155,16 @@ This section contains examples of common Fail2ban configurations using `fail2ban
 
 2.  **If using CentOS or Fedora** you need to change the `backend` option in `jail.local` from *auto* to *systemd*. This is not necessary on Debian 8 or Ubuntu 16.04, even though both use systemd as well.
 
-{{< file "/etc/fail2ban/jail.local" aconf >}}
-# "backend" specifies the backend used to get files modification.
-# Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
-# This option can be overridden in each jail as well.
-
-. . .
-
-backend = systemd
-
-{{< /file >}}
+    {{< file "/etc/fail2ban/jail.local" aconf >}}
+    # "backend" specifies the backend used to get files modification.
+    # Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
+    # This option can be overridden in each jail as well.
+    
+    . . .
+    
+    backend = systemd
+    
+    {{< /file >}}
 
 {{< note respectIndent=false >}}
 If the `backend` configuration is set to `auto`, Fail2ban monitors log files by first using `pyinotify`. Next, it tries `gamin`. If neither are available, a polling algorithm decides what to try next.


### PR DESCRIPTION
Some edits I found while using the guide myself. Namely:

- reduce commands by using `enable --now` with systemd.
- typo correction
- indent file example to nest under numbered step.