### PR TITLE
Update CLI instructions for boto3

### DIFF
--- a/docs/products/storage/object-storage/guides/linode-cli/index.md
+++ b/docs/products/storage/object-storage/guides/linode-cli/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Using the Linode CLI with Object Storage"
-description: "Learn how to use the Linode CLI to manage Linodes own Object Storage solution."
-modified: 2022-05-02
+description: "Learn how to use the Linode CLI to manage Linode's own Object Storage solution."
+modified: 2023-06-27
 authors: ["Linode"]
 ---
 
@@ -14,37 +14,47 @@ This guide details how to use the `obj` plugin. For `linode object-storage` usag
 
 ## Install and Configure the CLI
 
-Follow the instructions within the [Install and Configure the Linode CLI](/docs/products/tools/cli/guides/install/) guide to get started using the CLI. If you wish to use the obj plugin and perform operations on buckets and objects, be sure to also install the boto library.
+Follow the instructions within the [Install and Configure the Linode CLI](/docs/products/tools/cli/guides/install/) guide to get started using the CLI. Be sure to also install the boto3 library, as that enables you to use the Object Storage CLI plugin and perform operations on buckets and objects.
 
 ## Basic Commands
 
 To get a list of all available buckets, use the `ls` command:
 
-    linode-cli obj ls
+```command
+linode-cli obj ls
+```
 
 To get a list of all objects in a bucket, use the `ls` command with the label of a bucket:
 
-    linode-cli obj ls my-example-bucket
+```command
+linode-cli obj ls my-example-bucket
+```
 
 For a complete list of commands available with the Object Storage plugin, use the `--help` flag:
 
-    linode-cli obj --help
+```command
+linode-cli obj --help
+```
 
 ## Create a Bucket with the CLI
 
 To create a bucket with the Linode CLI, use the `mb` command. See the [Bucket Name](#bucket-names) section for rules on naming the bucket.
 
-    linode-cli obj mb my-example-bucket
+```command
+linode-cli obj mb my-example-bucket
+```
 
 To delete a bucket, use the `rb` command:
 
-    linode-cli obj rb my-example-bucket
+```command
+linode-cli obj rb my-example-bucket
+```
 
 Currently, the Linode CLI defaults to creating buckets in the Newark data center. To change the cluster a bucket is created in, use the `--cluster` option, followed by the cluster name below:
 
-  - `us-east-1` for the Newark data center. This is the current default.
-  - `eu-central-1` for the Frankfurt data center.
-  - `ap-south-1` for the Singapore data center.
+- `us-east-1` for the Newark data center. This is the current default.
+- `eu-central-1` for the Frankfurt data center.
+- `ap-south-1` for the Singapore data center.
 
 {{< note >}}
 You need to use the `--cluster` option for every interaction with your bucket if it is not in `us-east-1`.
@@ -56,11 +66,15 @@ If the bucket has objects in it, you can not delete it from the Linode CLI immed
 
 1.  As an example object, create a text file and fill it with some example text.
 
-        echo 'Hello World!' > example.txt
+    ```command
+    echo 'Hello World!' > example.txt
+    ```
 
 1.  To upload an object to a bucket using the Linode CLI, use the `put` command. Provide the object name as the first parameter and the bucket label as the second:
 
-        linode-cli obj put --acl-public example.txt my-example-bucket
+    ```command
+    linode-cli obj put --acl-public example.txt my-example-bucket
+    ```
 
     - If the bucket is in the Newark data center, the file is accessible at the URL `http://my-example-bucket.us-east-1.linodeobjects.com/example.txt`.
     - If the bucket is in the Frankfurt data center, the file is accessible at the URL `http://my-example-bucket.eu-central-1.linodeobjects.com/example.txt`.
@@ -71,22 +85,30 @@ If the bucket has objects in it, you can not delete it from the Linode CLI immed
 
     For example, if you want to make a public file private, you would append the `--acl-private` flag:
 
-        linode-cli obj setacl --acl-private my-example-bucket example.txt
+    ```command
+    linode-cli obj setacl --acl-private my-example-bucket example.txt
+    ```
     {{< /note >}}
 
 1.  To download an object, use the `get` command. Provide the label of the bucket as the first parameter and the name of the file as the second:
 
-        linode-cli obj get my-example-bucket example.txt
+    ```command
+    linode-cli obj get my-example-bucket example.txt
+    ```
 
 1.  To delete an object, use the `rm` or `del` command. Provide the label of the bucket as the first parameter and the name of the object as the second:
 
-        linode-cli obj rm my-example-bucket example.txt
+    ```command
+    linode-cli obj rm my-example-bucket example.txt
+    ```
 
 ## Create a Signed URL with the CLI
 
 Creating a **signed URL** allows you to create a link to objects with limited permissions and a time limit to access them. To create a signed URL on a preexisting object with the CLI, use the following syntax:
 
-    linode-cli obj signurl my-example-bucket example.txt +300
+```command
+linode-cli obj signurl my-example-bucket example.txt +300
+```
 
 The output of the command is a URL that can be used for a set period of time to access the object, even if the ACL is set to private. In this case, `+300` represents the amount of time in seconds that the link remains active, or five minutes total. After this time has passed, the link expires and can no longer be used.
 
@@ -96,20 +118,26 @@ To create a static website from a bucket:
 
 1.  Use the `ws-create` command, including the `--ws-index` and `--ws-error` flags:
 
-        linode-cli obj ws-create my-example-bucket --ws-index=index.html --ws-error=404.html
+    ```command
+    linode-cli obj ws-create my-example-bucket --ws-index=index.html --ws-error=404.html
+    ```
 
     The `--ws-index` and `--ws-error` flags specify which objects the bucket should use to serve the static site's index page and error page, respectively.
 
 1.  You need to separately upload the `index.html` and `404.html` files (or however you have named the index and error pages) to the bucket:
 
-        echo 'Index page' > index.html
-        echo 'Error page' > 404.html
-        linode-cli obj put index.html 404.html my-example-bucket
+    ```command
+    echo 'Index page' > index.html
+    echo 'Error page' > 404.html
+    linode-cli obj put index.html 404.html my-example-bucket
+    ```
 
 1.  Set the `--aclpublic` flag on both the `index.html` and `404.html` files:
 
-        linode-cli obj setacl --acl-public my-example-bucket index.html
-        linode-cli obj setacl --acl-public my-example-bucket 404.html
+    ```command
+    linode-cli obj setacl --acl-public my-example-bucket index.html
+    linode-cli obj setacl --acl-public my-example-bucket 404.html
+    ```
 
 1.  The static site is accessed from a different URL than the generic URL for the Object Storage bucket. Static sites are available at the `website-us-east-1` subdomain for the Newark data center, the `website-eu-central-1` subdomain for the Frankfurt data center, or the `website-ap-south-1` subdomain for the Singapore data center. Using `my-example-bucket` as an example, navigate to either:
 
@@ -129,11 +157,15 @@ Error: InvalidAccessKeyId
 
 You can create and configure a new Access Key at any time by running the following command:
 
-    linode-cli obj regenerate-keys
+```command
+linode-cli obj regenerate-keys
+```
 
 After running the command the access is restored, and you can see the new key listed at any time using the following command:
 
-    linode-cli object-storage keys-list
+```command
+linode-cli object-storage keys-list
+```
 
 {{< note >}}
 Any new object storage keys issued through the CLI is prefixed with `linode-cli` as the label.

--- a/docs/products/tools/cli/guides/install/index.md
+++ b/docs/products/tools/cli/guides/install/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Install and Configure the Linode CLI"
 description: "Learn how to install the Linode CLI on most common operating systems"
-modified: 2022-05-05
+modified: 2023-06-27
 authors: ["Linode"]
 ---
 
@@ -13,20 +13,28 @@ The [Linode CLI](https://github.com/linode/linode-cli) is officially managed thr
 
 1.  Ensure that Python 3 and `pip3` are both installed. If not, follow the instructions within the [Install Python 3 and pip3](#install-python-3-and-pip3) section.
 
-        python3 --version
-        pip3 --version
+    ```command
+    python3 --version
+    pip3 --version
+    ```
 
 1.  To install or upgrade the Linode CLI, run the following command:
 
-        pip3 install linode-cli --upgrade
+    ```command
+    pip3 install linode-cli --upgrade
+    ```
 
 1.  Install the boto library if you intend to interact with Linode's Object Storage service.
 
-        pip3 install boto
+    ```command
+    pip3 install boto3
+    ```
 
 1.  To confirm that the Linode CLI has been successfully installed, run the help command.
 
-        linode-cli --help
+    ```command
+    linode-cli --help
+    ```
 
 ## Configure the Linode CLI
 
@@ -38,11 +46,15 @@ The first time you interact with the Linode CLI, you need to complete the initia
 
     -   **Web-based authentication:** Prompts you to sign in to your Linode account through a web browser.
 
-            linode-cli configure
+        ```command
+        linode-cli configure
+        ```
 
     -   **Manually create a personal access token:** Prompts you for a token that you need to manually create. See [Linode API Keys and Tokens](/docs/products/tools/api/guides/manage-api-tokens/).
 
-            linode-cli configure --token
+        ```command
+        linode-cli configure --token
+        ```
 
 1.  After authenticating or providing a token, you are presented with a series of prompts to select your preferred defaults, such as the region, Compute Instance type, and distribution. These are optional and can be overridden when running individual commands. Update these defaults at any time by running `linode-cli configure` again or by editing the `.config/linode-cli` configuration file.
 
@@ -50,7 +62,9 @@ The first time you interact with the Linode CLI, you need to complete the initia
 
 To configure the CLI without any interactive prompts, you can set the token through the following environment variable, replacing *[token]* with the token you've manually generated. See [Linode API Keys and Tokens](/docs/products/tools/api/guides/manage-api-tokens/).
 
-    export LINODE_CLI_TOKEN="[token]"
+```command
+export LINODE_CLI_TOKEN="[token]"
+```
 
 This allows you to bypass the initial configuration. If this variable is unset, the Linode CLI will stop working until it is set again or until the CLI is reconfigured through the interactive prompts.
 
@@ -94,18 +108,24 @@ On most Linux distributions, you can use the distribution's package manager to i
 
 -   **Ubuntu and Debian:** *Ubuntu 22.04, 20.04, 18.04, and 16.04 | Debian 11, 10, and 9*
 
-        sudo apt update
-        sudo apt install python3 && sudo apt install python3-pip
+    ```command
+    sudo apt update
+    sudo apt install python3 && sudo apt install python3-pip
+    ```
 
 -   **CentOS Stream, RHEL 8, and Fedora:** *CentOS Stream 9 (and 8), CentOS 8, other RHEL derivatives (including AlmaLinux 8, and Rocky Linux 8), and Fedora.*
 
-        sudo dnf upgrade
-        sudo dnf install python3 && sudo dnf install python3-pip
+    ```command
+    sudo dnf upgrade
+    sudo dnf install python3 && sudo dnf install python3-pip
+    ```
 
 -   **CentOS 7**
 
-        sudo yum update
-        sudo yum install python3 && sudo yum install python3-pip
+    ```command
+    sudo yum update
+    sudo yum install python3 && sudo yum install python3-pip
+    ```
 
 ### Confirming Python and Pip Installation
 


### PR DESCRIPTION
This PR updates the CLI installation instructions to use boto3, which is now a requirement of the Object Storage plugin.

- [Update] Install and Configure the Linode CLI
- [Update] Using the Linode CLI with Object Storage