### PR TITLE
Add additional keywords to troubleshooting guides

### DIFF
--- a/docs/products/compute/compute-instances/guides/troubleshooting-connection-issues/index.md
+++ b/docs/products/compute/compute-instances/guides/troubleshooting-connection-issues/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting Basic Connection Issues on Compute Instances"
 description: 'Troubleshooting steps to help restore basic connectivity to your Linode when it is unresponsive.'
-keywords: ['linux','reboot','lish']
+keywords: ['linux','reboot','lish','troubleshoot','packet loss']
 tags: ["networking", "linode platform"]
 published: 2019-02-01
 modified: 2023-03-14

--- a/docs/products/compute/compute-instances/guides/troubleshooting-firewall-issues/index.md
+++ b/docs/products/compute/compute-instances/guides/troubleshooting-firewall-issues/index.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting Firewall Issues on Compute Instances
 description: This guide presents troubleshooting strategies for Compute Instances that may be unresponsive due to issues caused by a firewall.
-keywords: ["Linode troubleshooting", "Cloud Firewall", "Firewall"]
+keywords: ["Linode troubleshooting", "Cloud Firewall", "Firewall","troubleshoot"]
 published: 2020-08-04
 modified: 2023-03-14
 modified_by:

--- a/docs/products/compute/compute-instances/guides/troubleshooting-general-issues/index.md
+++ b/docs/products/compute/compute-instances/guides/troubleshooting-general-issues/index.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting General Issues on Compute Instances
 description: 'This guide provides you with a reference for common troubleshooting scenarios you may encounter when managing your Linode. Multiple sections are included.'
-keywords: ['troubleshooting']
+keywords: ['troubleshooting','troubleshoot']
 tags: ["linode platform"]
 published: 2012-04-05
 modified: 2023-03-14

--- a/docs/products/compute/compute-instances/guides/troubleshooting-memory-issues/index.md
+++ b/docs/products/compute/compute-instances/guides/troubleshooting-memory-issues/index.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting Memory Issues on Compute Instances
 description: 'Many common issues with Compute Instances are caused by excessive memory consumption or errors. This guide provides suggestions for resolving this.'
-keywords: ["Linode troubleshooting", "Linode troubleshooting", "Linux configuration"]
+keywords: ["Linode troubleshooting", "Linux configuration","troubleshoot"]
 tags: ["networking", "mysql", "apache"]
 published: 2009-08-05
 modified: 2023-03-14

--- a/docs/products/compute/compute-instances/guides/troubleshooting-services/index.md
+++ b/docs/products/compute/compute-instances/guides/troubleshooting-services/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting Web Servers, Databases, and Other Services"
 description: "Troubleshooting steps for when you can't connect to a service that your Compute Instance runs."
-keywords: ['linux','reboot','lish']
+keywords: ['linux','reboot','lish','troubleshoot','website','webserver']
 tags: ["web server", "database", "networking"]
 published: 2019-02-01
 modified: 2023-03-14

--- a/docs/products/compute/compute-instances/guides/troubleshooting-ssh-issues/index.md
+++ b/docs/products/compute/compute-instances/guides/troubleshooting-ssh-issues/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting SSH on Compute Instances"
 description: "Troubleshooting steps for when you can't connect to your Compute Instance via SSH."
-keywords: ['linux','reboot','lish','ssh']
+keywords: ['linux','reboot','lish','ssh','troubleshoot']
 tags: ["ssh"]
 published: 2019-02-01
 modified: 2023-03-14


### PR DESCRIPTION
This PR adds a few keywords to some troubleshooting guides. The key one here is "troubleshoot" as these guides aren't surfacing in the search results when a user types in "troubleshoot ___". 