### PR TITLE
[Update] How to Install Canvas on Ubuntu 22.04

### DIFF
--- a/docs/guides/websites/lms/install-canvas-lms-on-ubuntu-2204/index.md
+++ b/docs/guides/websites/lms/install-canvas-lms-on-ubuntu-2204/index.md
@@ -30,7 +30,7 @@ Before you can clone and install Canvas, you must ensure certain prerequisite ap
 
 The following sections help you install the software you need before you can clone and install Canvas. Here is a quick list of the software and versions used for this guide:
 
-- Ruby [version 2.7 minimum](https://github.com/instructure/canvas-lms/wiki/Quick-Start#dependency-installation), version 3.0 and above are untested
+- Ruby [version 3.1 minimum](https://github.com/instructure/canvas-lms/wiki/Quick-Start#dependency-installation).
 - Apache version 2.4.52
 - Passenger version 6.0.10
 - Git version 2.34.1
@@ -150,11 +150,7 @@ The steps in this section explain how to install Ruby using the Ruby Environment
     ```
 
     If you have an old version of Ruby, you can upgrade it using the procedure explained in this section and select the version needed for the Canvas LMS installation.
-
-    {{< note type="warning">}}
-    You must use Ruby version 2.7.x, rather than version 3 and above. Version 3 is untested with Canvas and may cause problems.
-    {{< /note >}}
-
+   
 1. Obtain the Rbenv installation script using the following command:
 
     ```command
@@ -189,21 +185,21 @@ The steps in this section explain how to install Ruby using the Ruby Environment
     ```
 
     {{< note>}}
-    You should see the Ruby version 2.7.6 is on the list.
+    You should see the Ruby version 3.1.3 is on the list.
     {{< /note >}}
 
-1. Install the 2.7.6 version of Ruby used for this guide using the following command. The installation process takes several minutes to complete the installation.
+1. Install the 3.1.3 version of Ruby used for this guide using the following command. The installation process takes several minutes to complete the installation.
 
     ```command
-    rbenv install 2.7.6 --verbose
+    rbenv install 3.1.3 --verbose
     ```
 
     Eliminate the `--verbose` switch if you don’t want to see the installation process taking place.
 
-1. Select the 2.7.6 version of Ruby using the following command:
+1. Select the 3.1.3 version of Ruby using the following command:
 
     ```command
-    export RBENV_VERSION=2.7.6
+    export RBENV_VERSION=3.1.3
     ```
 
 1. Verify the Ruby installation using the following command:
@@ -229,7 +225,7 @@ Once you have the above prerequisites installed, follow the steps below to insta
 1. Add the specific version of Ruby Bundler to your Ruby by running the following command:
 
     ```command
-    sudo gem install bundler --version 2.2.19
+    sudo gem install bundler
     ```
 
     You should see an output as shown below:
@@ -237,11 +233,7 @@ Once you have the above prerequisites installed, follow the steps below to insta
     ```output
     1 gem installed
     ```
-
-    {{< note>}}
-    Using other installation methods tends to overwrite your Ruby installation with a 3.x version.
-    {{< /note >}}
-
+    
 1. You can check if the Bundler is installed correctly by running the following command:
 
     ```command
@@ -250,7 +242,7 @@ Once you have the above prerequisites installed, follow the steps below to insta
     You should see an output as shown below:
 
     ```output
-    Bundler version 2.2.19
+    Bundler version 2.4.5
     ```
 
 1. Verify that installing Bundler didn’t update Ruby by running the following command:
@@ -261,7 +253,7 @@ Once you have the above prerequisites installed, follow the steps below to insta
     You should see an output as shown below:
 
     ```output
-    2.7.6
+    3.1.3
     ```
 
 ### Install Apache and Passenger

--- a/docs/guides/websites/lms/install-canvas-lms-on-ubuntu-2204/index.md
+++ b/docs/guides/websites/lms/install-canvas-lms-on-ubuntu-2204/index.md
@@ -150,7 +150,7 @@ The steps in this section explain how to install Ruby using the Ruby Environment
     ```
 
     If you have an old version of Ruby, you can upgrade it using the procedure explained in this section and select the version needed for the Canvas LMS installation.
-   
+
 1. Obtain the Rbenv installation script using the following command:
 
     ```command
@@ -233,7 +233,7 @@ Once you have the above prerequisites installed, follow the steps below to insta
     ```output
     1 gem installed
     ```
-    
+
 1. You can check if the Bundler is installed correctly by running the following command:
 
     ```command


### PR DESCRIPTION
Updated the version of ruby and the install instructions based on https://github.com/instructure/canvas-lms/wiki/Quick-Start#dependency-installation

Fixes : https://github.com/linode/docs/issues/6446