### PR TITLE
[update] Rescue and Rebuild

### DIFF
--- a/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
+++ b/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
@@ -75,9 +75,9 @@ To boot a Compute Instance into Rescue Mode, follow the instructions below.
     {{< note >}}
     You can assign up to 7 disks in Rescue Mode. `/dev/sdh` is always assigned to the Finnix recovery distribution.
 
-    For best results, you should review the names that your Compute Instance's disks are using in your [configuration profile](/docs/products/compute/compute-instances/guides/configuration-profiles/) (`/dev/sda`, `/dev/sdb`, etc.) and match those names to the device assignments you specify in the Rescue form before starting Rescue Mode.
+    When you assign additional disks, these disks are not mounted by default. It is important that you review the names that your Compute Instance's disks are using in your [configuration profile](/docs/products/compute/compute-instances/guides/configuration-profiles/) (`/dev/sda`, `/dev/sdb`, etc.) and match those names to the device assignments you specify in the Rescue form before starting Rescue Mode.
 
-    Matching these names will be especially important if you need to [change root](#change-root) within Rescue Mode. The chroot will be able to read your Compute Instance's `/etc/fstab` file, which defines where and how your instance mounts its disks when booting up, to automatically apply the correct mount options and mount directories to your disks.
+    Matching these names is especially important if you need to [change root](#change-root) within Rescue Mode. The chroot will be able to read your Compute Instance's `/etc/fstab` file, which defines where and how your instance mounts its disks when booting up, to automatically apply the correct mount options and mount directories to your disks.
 
     A mismatch in the names of your disks between your Compute Instance's configuration profile and your Rescue Mode environment may cause the chroot to mount these disks in the wrong location or with the wrong mount options. As a result, it is important to ensure that these names match.
     {{< /note >}}

--- a/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
+++ b/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
@@ -4,7 +4,7 @@ description: 'Learn how to rescue and rebuild a Compute Instance by using the re
 keywords: ["rescue", "rebuild"]
 tags: ["cloud manager"]
 published: 2012-05-31
-modified: 2023-05-04
+modified: 2023-08-08
 modified_by:
   name: Linode
 image: rescue-rebuild.jpg
@@ -72,14 +72,16 @@ To boot a Compute Instance into Rescue Mode, follow the instructions below.
 
     ![Cloud Manager Rescue form - Add Disk highlighted](cloud-manager-rescue-form-add-disk-highlighted.png)
 
-    {{< note >}}
     You can assign up to 7 disks in Rescue Mode. `/dev/sdh` is always assigned to the Finnix recovery distribution.
 
-    When you assign additional disks, these disks are not mounted by default and you have to manually mount these disks later. It is important that you review the names that your Compute Instance's disks are using in your [configuration profile](/docs/products/compute/compute-instances/guides/configuration-profiles/) (`/dev/sda`, `/dev/sdb`, etc.) and match those names to the device assignments you specify in the Rescue form before starting Rescue Mode.
+    As a best practice, review the names that your Compute Instance's disks are using in your [configuration profile](/docs/products/compute/compute-instances/guides/configuration-profiles/) (`/dev/sda`, `/dev/sdb`, etc.) and match those names to the device assignments you specify in the Rescue form before starting Rescue Mode.
 
     Matching these names is especially important if you need to [change root](#change-root) within Rescue Mode. The chroot will be able to read your Compute Instance's `/etc/fstab` file, which defines where and how your instance mounts its disks when booting up, to automatically apply the correct mount options and mount directories to your disks.
 
     A mismatch in the names of your disks between your Compute Instance's configuration profile and your Rescue Mode environment may cause the chroot to mount these disks in the wrong location or with the wrong mount options. As a result, it is important to ensure that these names match.
+
+    {{< note noTitle=true type="warning" >}}
+    Disks are *not* mounted by default in Rescue Mode and will need to be mounted manually. See [Mounting Disks](#mounting-disks) for instructions on mounting individual disks.
     {{< /note >}}
 
 1.  Click the **Reboot into Rescue Mode** button. The Compute Instance reboots into Rescue Mode, and the progress percentage appears. When the instance appears as **Running** again, proceed to [Connecting to a Compute Instance Running in Rescue Mode](#connecting-to-a-compute-instance-running-in-rescue-mode).

--- a/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
+++ b/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
@@ -75,7 +75,7 @@ To boot a Compute Instance into Rescue Mode, follow the instructions below.
     {{< note >}}
     You can assign up to 7 disks in Rescue Mode. `/dev/sdh` is always assigned to the Finnix recovery distribution.
 
-    When you assign additional disks, these disks are not mounted by default and you will have to manually mount these disks later. It is important that you review the names that your Compute Instance's disks are using in your [configuration profile](/docs/products/compute/compute-instances/guides/configuration-profiles/) (`/dev/sda`, `/dev/sdb`, etc.) and match those names to the device assignments you specify in the Rescue form before starting Rescue Mode.
+    When you assign additional disks, these disks are not mounted by default and you have to manually mount these disks later. It is important that you review the names that your Compute Instance's disks are using in your [configuration profile](/docs/products/compute/compute-instances/guides/configuration-profiles/) (`/dev/sda`, `/dev/sdb`, etc.) and match those names to the device assignments you specify in the Rescue form before starting Rescue Mode.
 
     Matching these names is especially important if you need to [change root](#change-root) within Rescue Mode. The chroot will be able to read your Compute Instance's `/etc/fstab` file, which defines where and how your instance mounts its disks when booting up, to automatically apply the correct mount options and mount directories to your disks.
 

--- a/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
+++ b/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
@@ -75,7 +75,7 @@ To boot a Compute Instance into Rescue Mode, follow the instructions below.
     {{< note >}}
     You can assign up to 7 disks in Rescue Mode. `/dev/sdh` is always assigned to the Finnix recovery distribution.
 
-    When you assign additional disks, these disks are not mounted by default. It is important that you review the names that your Compute Instance's disks are using in your [configuration profile](/docs/products/compute/compute-instances/guides/configuration-profiles/) (`/dev/sda`, `/dev/sdb`, etc.) and match those names to the device assignments you specify in the Rescue form before starting Rescue Mode.
+    When you assign additional disks, these disks are not mounted by default and you will have to manually mount these disks later. It is important that you review the names that your Compute Instance's disks are using in your [configuration profile](/docs/products/compute/compute-instances/guides/configuration-profiles/) (`/dev/sda`, `/dev/sdb`, etc.) and match those names to the device assignments you specify in the Rescue form before starting Rescue Mode.
 
     Matching these names is especially important if you need to [change root](#change-root) within Rescue Mode. The chroot will be able to read your Compute Instance's `/etc/fstab` file, which defines where and how your instance mounts its disks when booting up, to automatically apply the correct mount options and mount directories to your disks.
 


### PR DESCRIPTION
_ clarify that the additional disks are not mounted by default.