### PR TITLE
Update Lish gateway information

### DIFF
--- a/docs/products/compute/compute-instances/guides/lish/index.md
+++ b/docs/products/compute/compute-instances/guides/lish/index.md
@@ -210,8 +210,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `us-southeast.webconsole.linode.com`
--   **Glish Gateway:** `us-southeast.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `us-southeast.webconsole.linode.com`
 
 #### Chicago, IL (USA)
 
@@ -225,8 +224,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `us-ord.webconsole.linode.com`
--   **Glish Gateway:** `us-ord.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `us-ord.webconsole.linode.com`
 
 #### Dallas, TX (USA)
 
@@ -240,8 +238,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `us-central.webconsole.linode.com`
--   **Glish Gateway:** `us-central.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `us-central.webconsole.linode.com`
 
 #### Frankfurt (Germany)
 
@@ -255,8 +252,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `eu-central.webconsole.linode.com`
--   **Glish Gateway:** `eu-central.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `eu-central.webconsole.linode.com`
 
 #### Fremont, CA (USA)
 
@@ -270,8 +266,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `us-west.webconsole.linode.com`
--   **Glish Gateway:** `us-west.webconsole.linode.com`
+-   **Weblish/Glish Gateway:**`us-west.webconsole.linode.com`
 
 #### London (UK)
 
@@ -285,8 +280,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `eu-west.webconsole.linode.com`
--   **Glish Gateway:** `eu-west.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `eu-west.webconsole.linode.com`
 
 #### Mumbai (India)
 
@@ -300,8 +294,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `ap-west.webconsole.linode.com`
--   **Glish Gateway:** `ap-west.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `ap-west.webconsole.linode.com`
 
 #### Newark, NJ (USA)
 
@@ -315,8 +308,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `us-east.webconsole.linode.com`
--   **Glish Gateway:** `us-east.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `us-east.webconsole.linode.com`
 
 #### Paris, France
 
@@ -330,8 +322,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `fr-par.webconsole.linode.com`
--   **Glish Gateway:** `fr-par.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `fr-par.webconsole.linode.com`
 
 #### Singapore
 
@@ -345,8 +336,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `ap-south.webconsole.linode.com`
--   **Glish Gateway:** `ap-south.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `ap-south.webconsole.linode.com`
 
 #### Sydney (Australia)
 
@@ -360,8 +350,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `ap-southeast.webconsole.linode.com`
--   **Glish Gateway:** `ap-southeast.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `ap-southeast.webconsole.linode.com`
 
 #### Tokyo (Japan)
 
@@ -375,8 +364,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `ap-northeast.webconsole.linode.com`
--   **Glish Gateway:** `ap-northeast.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `ap-northeast.webconsole.linode.com`
 
 #### Toronto (Canada)
 
@@ -390,8 +378,7 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `ca-central.webconsole.linode.com`
--   **Glish Gateway:** `ca-central.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `ca-central.webconsole.linode.com`
 
 #### Washington, DC (USA)
 
@@ -405,5 +392,4 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `us-iad.webconsole.linode.com`
--   **Glish Gateway:** `us-iad.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `us-iad.webconsole.linode.com`

--- a/docs/products/compute/compute-instances/guides/lish/index.md
+++ b/docs/products/compute/compute-instances/guides/lish/index.md
@@ -4,7 +4,7 @@ title_meta: "Access Your System Console Using Lish"
 description: "Learn how to use Lish as a shell for managing or rescuing your Compute Instances."
 keywords: ["Console", "Shell", "Lish", "rescue", "weblish"]
 published: 2009-08-04
-modified: 2023-07-05
+modified: 2023-08-07
 modified_by:
   name: Linode
 tags: ["linode platform","cloud manager"]

--- a/docs/products/compute/compute-instances/guides/lish/index.md
+++ b/docs/products/compute/compute-instances/guides/lish/index.md
@@ -200,19 +200,18 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
 
 #### Atlanta, GA (USA)
 
--   **Lish SSH Gateway:** `lish-atlanta.linode.com`
+-   **Lish SSH Gateway:** `lish-us-southeast.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 59:30:1a:0b:93:5e:3f:4b:6f:d1:96:ff:7e:9e:12:f8
-    ECDSA SHA256:8emv5PuUgPB2GFejMYWl1f4x1yj3YqAQPAYIrBm43ZI
-    Ed25519 SHA256:7k2c442k+zqbGaraZvmqXM3MA5lCcthaR2lbrB651lg
-    Ed25519 MD5:b3:76:56:3a:d8:66:5e:0c:61:90:03:b7:0b:ca:58:25
+    RSA 3072 SHA256:OWzHHclIp4zt5sHt+QZ002HYgnxtec+skWPAgFNfx4w lish-us-southeast.linode.com
+    ECDSA 256 SHA256:qVMUsKTjxiSFvElIRMvjzKv4eRth37i2OBaaSODO6us lish-us-southeast.linode.com
+    ED25519 256 SHA256:ZpNQYxIc25e4vVfFgscSJm1/jGaUy3Gti4kuzB1aTuc lish-us-southeast.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `atlanta.webconsole.linode.com`
--   **Glish Gateway:** `atlanta.webconsole.linode.com`
+-   **Weblish Gateway:** `us-southeast.webconsole.linode.com`
+-   **Glish Gateway:** `us-southeast.webconsole.linode.com`
 
 #### Chicago, IL (USA)
 
@@ -227,103 +226,97 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     {{< /note >}}
 
 -   **Weblish Gateway:** `us-ord.webconsole.linode.com`
--   **Glish Gateway:** `ord2.glish.linode.com`
+-   **Glish Gateway:** `us-ord.webconsole.linode.com`
 
 #### Dallas, TX (USA)
 
--   **Lish SSH Gateway:** `lish-dallas.linode.com`
+-   **Lish SSH Gateway:** `lish-us-central.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 6d:3d:b5:d0:42:1c:49:45:a6:47:29:bd:88:4e:58:d4
-    ECDSA SHA256:1fL1HTGas1APIpshCu1ZWys7LI97s8eTFN3+f8zEYXA
-    Ed25519 SHA256:Ime9h7IAxAjBvMGR+G+EnbaLWpvXO+Z7TaGHzM9g5Sc
-    Ed25519 MD5:23:c1:02:ba:40:77:f7:73:0b:d4:0f:3a:f1:8c:74:b6
+    RSA 3072 SHA256:y1H5qzNB3yjvmPX/e8HcYbTffQb9qANjtT7r5vqIZl8 lish-us-central.linode.com
+    ECDSA 256 SHA256:3FY9mXdhRJjaJ7eTDO8SUWoLxdJBshz5229Wwsg7/iQ lish-us-central.linode.com
+    ED25519 256 SHA256:bC/I0G2IrWlICtzsGYT84dzdft1weRd28SIUt+D31P8 lish-us-central.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `dallas.webconsole.linode.com`
--   **Glish Gateway:** `dallas.webconsole.linode.com`
+-   **Weblish Gateway:** `us-central.webconsole.linode.com`
+-   **Glish Gateway:** `us-central.webconsole.linode.com`
 
 #### Frankfurt (Germany)
 
--   **Lish SSH Gateway:** `lish-frankfurt.linode.com`
+-   **Lish SSH Gateway:** `lish-eu-central.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 43:76:22:43:0e:01:cb:84:6a:80:b9:9b:90:34:c7:b1
-    ECDSA SHA256:e1FxEXiZVi6n13tagd1ZAQEW/fsRqz29ez5IfWf9kxg
-    Ed25519 SHA256:vG1rnoGe7XRRY0nauJREQk75OamxCwRRpeaTDB8LpgM
-    Ed25519 MD5:9e:83:86:e2:f9:f7:f7:56:fc:bf:54:bb:75:7e:79:37
+    RSA 3072 SHA256:4Xkz0V7ZQd277GpfnHzvdshuH3gjsv9+UXlgO0/gNhA lish-eu-central.linode.com
+    ECDSA 256 SHA256:W3V3zB1vYWlpoRaBy97RZk6GP+DZrFLsm1vAE27eCXQ lish-eu-central.linode.com
+    ED25519 256 SHA256:/105/zGMByknAKw5Hm7554oZ25wwN0+3owhJTZWOvNc lish-eu-central.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `frankfurt.webconsole.linode.com`
--   **Glish Gateway:** `frankfurt.webconsole.linode.com`
+-   **Weblish Gateway:** `eu-central.webconsole.linode.com`
+-   **Glish Gateway:** `eu-central.webconsole.linode.com`
 
 #### Fremont, CA (USA)
 
--   **Lish SSH Gateway:** `lish-fremont.linode.com`
+-   **Lish SSH Gateway:** `lish-us-west.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 2c:43:0e:fc:88:f2:3a:dd:01:43:3a:fc:9f:67:9f:66
-    ECDSA SHA256:fwuaKryHbvtKjFFviDocnMTNKWXUzfZSGPY8mgLgiNM
-    Ed25519 SHA256:s3MVXFaTiL7Fb5oB0s9zMBk9VJsrkNxXXZfdeJG2enQ
-    Ed25519 MD5:c8:eb:9d:e6:b0:60:b1:ca:9e:89:d1:e4:6a:3c:10:31
+    RSA 3072 SHA256:s4ACk4T42uMnOpMWybsZFSVn9PCd/0Q/LEqs0pWKVj4 lish-us-west.linode.com
+    ECDSA 256 SHA256:2CnS4CkZsymw6PuT5bE8hLfVTMwkMPr8D9lYbUOgE7E lish-us-west.linode.com
+    ED25519 256 SHA256:whGbGnOqEIv9HrvvEgXO6PdNnCDEr7OwL0pHzrTDBYo lish-us-west.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `fremont.webconsole.linode.com`
--   **Glish Gateway:** `fremont.webconsole.linode.com`
+-   **Weblish Gateway:** `us-west.webconsole.linode.com`
+-   **Glish Gateway:** `us-west.webconsole.linode.com`
 
 #### London (UK)
 
--   **Lish SSH Gateway:** `lish-london.linode.com`
+-   **Lish SSH Gateway:** `lish-eu-west.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 71:27:30:cd:dc:69:7a:fe:58:4a:04:e6:6b:5f:b4:e2
-    ECDSA SHA256:mE/plOHLl+NJ7LUdW7AaMEOnhskXZxav5Em/rD6VZ5g
-    Ed25519 SHA256:HXHM8/wCx7NrGsnfGpaexiBfOLKN9g0hoaL9wRaSeWg
-    Ed25519 MD5:c1:43:45:93:d6:96:4e:50:41:d2:d0:9f:81:e5:f8:9e
+    RSA 3072 SHA256:8EgXMpjYma0BpjghpUcFwlJCMv1cZROKv1CE35QElnI lish-eu-west.linode.com
+    ECDSA 256 SHA256:CfmDU3U4/F0z34iosz9uWrsmeuy2L/8W+otq44Avonw lish-eu-west.linode.com
+    ED25519 256 SHA256:K6Hh7inkt5vJYrPKz3sB3yLd/+rtyrmyV7vYSCQ+8mU lish-eu-west.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `london.webconsole.linode.com`
--   **Glish Gateway:** `london.webconsole.linode.com`
+-   **Weblish Gateway:** `eu-west.webconsole.linode.com`
+-   **Glish Gateway:** `eu-west.webconsole.linode.com`
 
 #### Mumbai (India)
 
--   **Lish SSH Gateway:** `lish-mum1.linode.com`
+-   **Lish SSH Gateway:** `lish-ap-west.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 57:72:e0:79:a6:48:13:2b:8a:cd:1e:35:7c:c1:a2:ed
-    ECDSA SHA256:uWVLSBPZ0E72VawrP4yWsW3YYHPM9b7A/seeEy7GG0c
-    Ed25519 SHA256:5VkP3/dLsfrKic9p6y9QnFq4sKa92RBzxGJrsX5/dBQ
-    Ed25519 MD5:e8:a7:f2:7c:5e:b3:ee:1d:bf:a3:37:68:d7:1d:b2:bf
+    RSA 3072 SHA256:cZv3NjjPKvjKuG4/ETTs8dQEn/sk/ryXJMn/wAqRSdk lish-ap-west.linode.com
+    ECDSA 256 SHA256:PUjmIqCe7ViewBrmronVU1Ss/yU63Zgp0yFe4PCZSQk lish-ap-west.linode.com
+    ED25519 256 SHA256:s5LimAwVgNrnDOVWhLhv8RyBo3jk6OjiSCxPUQSefQ8 lish-ap-west.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `mum1.webconsole.linode.com`
--   **Glish Gateway:** `mum1.webconsole.linode.com`
+-   **Weblish Gateway:** `ap-west.webconsole.linode.com`
+-   **Glish Gateway:** `ap-west.webconsole.linode.com`
 
 #### Newark, NJ (USA)
 
--   **Lish SSH Gateway:** `lish-newark.linode.com`
+-   **Lish SSH Gateway:** `lish-us-east.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 11:2a:57:a4:f8:ca:42:b2:c0:ab:17:58:0d:0c:b7:8b
-    ECDSA SHA256:57OGBNARJ1fhI+zrE3eTEeQWXVVDHRU8QHcP+BsWmN8
-    Ed25519 SHA256:tyelNHfgaPGbN2cppfJVr/db3/pHnItR9maW+ocAS18
-    Ed25519 MD5:c1:f7:57:1a:09:ca:46:f8:5d:d3:d4:8a:34:6f:77:ae
+    RSA 3072 SHA256:u7ayBzPWsFmc2/sLrP8zYh0pFGFvo2m/H13Gmw7tZlA lish-us-east.linode.com
+    ECDSA 256 SHA256:Q7TDu+Qa3OpO6TUlgtG8ROa0MfRP5uagjSfavqT4oqs lish-us-east.linode.com
+    ED25519 256 SHA256:uUaOWG4KM2k+ZLCgtVFEi90TiNbNElXEP/orB57+8WI lish-us-east.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `newark.webconsole.linode.com`
--   **Glish Gateway:** `newark.webconsole.linode.com`
+-   **Weblish Gateway:** `us-east.webconsole.linode.com`
+-   **Glish Gateway:** `us-east.webconsole.linode.com`
 
 #### Paris, France
 
@@ -338,71 +331,67 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     {{< /note >}}
 
 -   **Weblish Gateway:** `fr-par.webconsole.linode.com`
--   **Glish Gateway:** `par3.glish.linode.com`
+-   **Glish Gateway:** `fr-par.webconsole.linode.com`
 
 #### Singapore
 
--   **Lish SSH Gateway:** `lish-singapore.linode.com`
+-   **Lish SSH Gateway:** `lish-ap-south.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 06:26:d8:2a:12:8b:2f:d7:6c:54:72:5a:a7:7b:da:7b
-    ECDSA SHA256:rFYWuld4hWMbTzX+xZMuQ3kxiJ6t8A+FNQ5k889mKEA
-    Ed25519 SHA256:q1G1pBrLuhsUAnZ04SOYoxVthKYyLz+wA0hBAUVkKtE
-    Ed25519 MD5:4c:d1:55:68:a1:90:6c:15:9b:af:c1:f7:27:31:68:29
+    RSA 3072 SHA256:ed7vvOh2m4DtwwUruYiyDQLegcjh3AAeLZ/C9HYWjS0 lish-ap-south.linode.com
+    ECDSA 256 SHA256:dVVAqiJMdolMgD81T1ELjPPM2P3EZ9b9li8dj8UssTw lish-ap-south.linode.com
+    ED25519 256 SHA256:+gcOBQjBvMDrGuxKQdmV+fs7+sWqQ9e4khIFYlPvooM lish-ap-south.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `singapore.webconsole.linode.com`
--   **Glish Gateway:** `singapore.webconsole.linode.com`
+-   **Weblish Gateway:** `ap-south.webconsole.linode.com`
+-   **Glish Gateway:** `ap-south.webconsole.linode.com`
 
 #### Sydney (Australia)
 
--   **Lish SSH Gateway:** `lish-syd1.linode.com`
+-   **Lish SSH Gateway:** `lish-ap-southeast.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 31:89:80:92:aa:c0:2f:12:f6:2d:20:3a:27:88:ea:ba
-    ECDSA SHA256:whZwcrXeixljj6ZrrRYzLc6UguvkNqKmtXz+JrMSI9w
-    Ed25519 SHA256:0lOHVxRAMMOY3HDFIE4nMz11W4y+9OYqdtFqhi8NkWs
-    Ed25519 MD5:ef:2d:cc:c7:aa:10:6f:cd:de:8f:c1:5d:8b:68:56:2b
+    RSA 3072 SHA256:rbamZevowgslIHGX34frmWv/Qvt863skVo5q2gKFCFs lish-ap-southeast.linode.com
+    ECDSA 256 SHA256:FmtrulPNisf4KVfOEtxiC0jLQfLW6iNdM2bZ5AWWFyM lish-ap-southeast.linode.com
+    ED25519 256 SHA256:dRp40pJoimqpzoRM9yCY8OIzDxESMIkLWYCes0nFRdQ lish-ap-southeast.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `syd1.webconsole.linode.com`
--   **Glish Gateway:** `syd1.webconsole.linode.com`
+-   **Weblish Gateway:** `ap-southeast.webconsole.linode.com`
+-   **Glish Gateway:** `ap-southeast.webconsole.linode.com`
 
 #### Tokyo (Japan)
 
--   **Lish SSH Gateway:** `lish-tokyo2.linode.com` or `lish-shg1.linode.com`
+-   **Lish SSH Gateway:** `lish-ap-northeast.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 2c:60:9a:ce:cf:4b:8d:4e:8f:09:ae:e0:c2:b0:fb:b7
-    ECDSA SHA256:0sRmstQ+6lfa4KwnAIQvuZMunq8KKNmu/n4KeAcAXmg
-    Ed25519 SHA256:SWEV04SJt+DDG4ov2AfDYdZRavcg4GHufNP60QRkZzk
-    Ed25519 MD5:99:7c:4e:b3:2d:c9:79:53:a9:60:b0:40:b2:73:52:73
+    RSA 3072 SHA256:Ral4+nR7A3jnhOqcebKTZQ+uDCIJ2rHQLnDUizDwIHY lish-ap-northeast.linode.com
+    ECDSA 256 SHA256:mxhd/vUfH9+8CDfOVmpfAbGDXdt1o35QKwAxO20GAqw lish-ap-northeast.linode.com
+    ED25519 256 SHA256:CDH9IcgWQ2iwx27ZotyvNbWl5os+QbeRZ/SLagLBckQ lish-ap-northeast.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `shg1.webconsole.linode.com`
--   **Glish Gateway:** `shg1.webconsole.linode.com`
+-   **Weblish Gateway:** `ap-northeast.webconsole.linode.com`
+-   **Glish Gateway:** `ap-northeast.webconsole.linode.com`
 
 #### Toronto (Canada)
 
--   **Lish SSH Gateway:** `lish-tor1.linode.com`
+-   **Lish SSH Gateway:** `lish-ca-central.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 4a:d9:fb:43:b8:0e:7f:fd:d3:cd:fc:87:06:61:51:df
-    ECDSA SHA256:iAWnqR3XYcooliTQ7W1tiMmjsA4k1WJVItvLz4lUxQE
-    Ed25519 SHA256:TSbQmRFaaWEHKEwgwvqQFKMfHKduPftou9/ue9K/Z2c
-    Ed25519 MD5:84:02:57:5e:b7:90:e3:78:3c:57:91:1a:e0:b4:e1:d4
+    RSA 3072 SHA256:FetyiRe7La3cAdpHz17sfKgQHaXEQPWcIq8A0sI11go lish-ca-central.linode.com
+    ECDSA 256 SHA256:YhHGT3h4elvJjLTRBcjwNU+DK3TkvrQBrTtaiut5bIw lish-ca-central.linode.com
+    ED25519 256 SHA256:hf6BTXkLy8dnGBD1z2IiMwD+J+o9xc/nkhxmOX69hWM lish-ca-central.linode.com
     ```
     {{< /note >}}
 
--   **Weblish Gateway:** `tor1.webconsole.linode.com`
--   **Glish Gateway:** `tor1.webconsole.linode.com`
+-   **Weblish Gateway:** `ca-central.webconsole.linode.com`
+-   **Glish Gateway:** `ca-central.webconsole.linode.com`
 
 #### Washington, DC (USA)
 
@@ -417,4 +406,4 @@ If you are having issues accessing Lish, Weblish, or Glish, you may be blocked b
     {{< /note >}}
 
 -   **Weblish Gateway:** `us-iad.webconsole.linode.com`
--   **Glish Gateway:** `iad3.glish.linode.com`
+-   **Glish Gateway:** `us-iad.webconsole.linode.com`


### PR DESCRIPTION
The proposed changes here update Lish and Glish gateway information, specifically SSH key fingerprints and Weblish/Glish names to match what is actually used by the API.