### PR TITLE
Removed header notes from various OBJ guides

### DIFF
--- a/docs/guides/platform/object-storage/host-static-site-object-storage/index.md
+++ b/docs/guides/platform/object-storage/host-static-site-object-storage/index.md
@@ -4,7 +4,7 @@ description: "This article shows you how you can host a static website from Lino
 keywords: ['hugo','static site','object storage']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2019-04-09
-modified: 2022-02-04
+modified: 2023-08-15
 modified_by:
   name: Linode
 title: "Deploy a Static Site using Hugo and Object Storage"
@@ -17,10 +17,6 @@ aliases: ['/platform/object-storage/host-static-site-object-storage/']
 image: host-a-static-site-using-linode-object-storage.png
 authors: ["Linode"]
 ---
-
-{{< content "object-storage-ga-shortguide" >}}
-
-{{< content "object-storage-cancellation-shortguide" >}}
 
 ## Why Host a Static Site on Object Storage?
 

--- a/docs/guides/platform/object-storage/server-side-encryption/index.md
+++ b/docs/guides/platform/object-storage/server-side-encryption/index.md
@@ -6,6 +6,7 @@ keywords: ['object','storage','security', 'sse-c', 'aes-256', 'terraform']
 tags: ["linode platform","python","ssl"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 published: 2020-08-14
+modified: 2023-08-15
 image: UseServerSideEnc_LinObjStorage.png
 modified_by:
   name: Linode
@@ -14,10 +15,6 @@ title_meta: "How to Use Server-Side Encryption with Linode Object Storage"
 aliases: ['/platform/object-storage/server-side-encryption/']
 authors: ["Ben Bigger"]
 ---
-
-{{< content "object-storage-ga-shortguide" >}}
-
-{{< content "object-storage-cancellation-shortguide" >}}
 
 Server-side encryption secures data on Linode Object Storage. Using your own encryption key, Linode will encrypt your data at the object level prior to storing it to disk. Once encrypted, Linode will only decrypt data if that same encryption key is provided with the retrieval request. This enables you to use Linode Object Storage to confidently handle sensitive data like [Terraform configurations](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/) that contain passwords and SSH keys.
 

--- a/docs/products/storage/object-storage/guides/lifecycle-policies/index.md
+++ b/docs/products/storage/object-storage/guides/lifecycle-policies/index.md
@@ -2,7 +2,7 @@
 description: "Use lifecycle policies to manage deleting objects in Linode Object Storage."
 keywords: ['object','storage','lifecycle','policy','policies','delete','bucket','version','multipart']
 published: 2019-10-18
-modified: 2022-03-11
+modified: 2023-08-15
 modified_by:
   name: Linode
 title: "Lifecycle Policies"
@@ -10,10 +10,6 @@ aliases: ['/platform/object-storage/how-to-manage-objects-with-lifecycle-policie
 tags: ["linode platform"]
 authors: ["Linode"]
 ---
-
-{{< content "object-storage-ga-shortguide" >}}
-
-{{< content "object-storage-cancellation-shortguide" >}}
 
 While deleting a few objects in an Object Storage bucket might not take that long, when the objects number in the thousands or even millions the time required to complete the delete operations can easily become unmanageable. When deleting a substantial amount of objects, it's best to use *lifecycle policies*. These policies can be represented in XML; here's an (incomplete) snippet of an action that will delete objects after 1 day:
 


### PR DESCRIPTION
Removed notes specifying DC availability & pricing details from the following OBJ guides:
- Deploy a Static Site using Hugo and Object Storage
- Using Server-Side Encryption with Linode Object Storage
- Guides - Lifecycle Policies
