### PR TITLE
Added trailing slash to a few Object Storage links

### DIFF
--- a/docs/guides/development/version-control/backing-up-gitlab-on-linode-object-storage/index.md
+++ b/docs/guides/development/version-control/backing-up-gitlab-on-linode-object-storage/index.md
@@ -49,7 +49,7 @@ The following chart will explain each configuration settings in additional detai
 
 | Descriptor | Setting|
 | ------------| --------------------- |
-| provider | AWS (The provider must be set to AWS because it is dependent on [s3cmd](/docs/products/storage/object-storage/guides/s3cmd)) |
+| provider | AWS (The provider must be set to AWS because it is dependent on [s3cmd](/docs/products/storage/object-storage/guides/s3cmd/)) |
 | region | The region the bucket was created in. A full list of regions can be found in the [Product Documentation](/docs/products/storage/object-storage/). |
 | endpoint | The endpoint url for the datacenter. Uses the syntax of **region.linodeobjects.com** |
 | aws_access_key-id | The Object Storage [Access Key](/docs/products/storage/object-storage/guides/access-keys/) created in a previous step. |

--- a/docs/guides/platform/object-storage/working-with-cors-linode-object-storage/index.md
+++ b/docs/guides/platform/object-storage/working-with-cors-linode-object-storage/index.md
@@ -34,7 +34,7 @@ This is where managing CORS policies on your object storage service becomes impe
 
 ## Working with CORS Policies on Linode Object Storage
 
-One of the best tools for managing policies on your S3, including Linode Object Storage, is `s3cmd`. Follow along with our guide [Using S3cmd with Object Storage](/docs/products/storage/object-storage/guides/s3cmd) to:
+One of the best tools for managing policies on your S3, including Linode Object Storage, is `s3cmd`. Follow along with our guide [Using S3cmd with Object Storage](/docs/products/storage/object-storage/guides/s3cmd/) to:
 
 1.  Install `s3cmd` on your system. The installation takes place on the system from which you intend to manage your S3 instance.
 

--- a/docs/products/storage/object-storage/_index.md
+++ b/docs/products/storage/object-storage/_index.md
@@ -47,7 +47,7 @@ Object Storage is available within the following data centers. The table below a
 | Singapore | 5 TB | 50 million | `ap-south-1` |
 | Washington, DC (USA) | 1,000 TB (1 PB) | 1 billion | `us-iad-1` |
 
-Object Storage deployments in each data center are assigned a cluster ID. These are used when [formatting URLs](/docs/products/storage/object-storage/guides/urls/) and integrating Object Storage with tools such as the [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli), [s3cmd](/docs/products/storage/object-storage/guides/s3cmd), [s4cmd](/docs/products/storage/object-storage/guides/s4cmd), and [Cyberduck](/docs/products/storage/object-storage/guides/cyberduck).
+Object Storage deployments in each data center are assigned a cluster ID. These are used when [formatting URLs](/docs/products/storage/object-storage/guides/urls/) and integrating Object Storage with tools such as the [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli/), [s3cmd](/docs/products/storage/object-storage/guides/s3cmd/), [s4cmd](/docs/products/storage/object-storage/guides/s4cmd/), and [Cyberduck](/docs/products/storage/object-storage/guides/cyberduck/).
 
 ## Pricing
 
@@ -81,5 +81,5 @@ See the [Network Transfer Usage and Costs](/docs/products/platform/get-started/g
 
 ### Additional Limits and Specifications
 
-- **Upload file size limit:** 5 GB. The maximum upload size of a single object is *5 GB*, though this can easily be overcome by using multi-part uploads. Both [s3cmd](/docs/products/storage/object-storage/guides/s3cmd) and [cyberduck](/docs/products/storage/object-storage/guides/cyberduck/) will do this for you automatically if a file exceeds this limit as part of the uploading process.
+- **Upload file size limit:** 5 GB. The maximum upload size of a single object is *5 GB*, though this can easily be overcome by using multi-part uploads. Both [s3cmd](/docs/products/storage/object-storage/guides/s3cmd/) and [cyberduck](/docs/products/storage/object-storage/guides/cyberduck/) will do this for you automatically if a file exceeds this limit as part of the uploading process.
 - **Restricted characters:** Objects uploaded to object storage cannot contain the following special characters when using Cloud Manager or the Linode CLI: `" ' < > & + =`.

--- a/docs/products/storage/object-storage/get-started/index.md
+++ b/docs/products/storage/object-storage/get-started/index.md
@@ -107,8 +107,8 @@ There are a number of tools that are available to help manage Linode Object Stor
 
 - The [Linode Cloud Manager](/docs/products/storage/object-storage/guides/) can be used to create buckets, and upload and delete objects, as well as create access keys for use with the S3 compatible clients.
 
-- The [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli) has an Object Storage plugin and can be used to create and remove buckets, add and remove objects, and convert a bucket into a static site from the command line.
+- The [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli/) has an Object Storage plugin and can be used to create and remove buckets, add and remove objects, and convert a bucket into a static site from the command line.
 
-- [s3cmd](/docs/products/storage/object-storage/guides/s3cmd) is a powerful command line utility that can be used with any S3-compatible object storage service, including Linode's. s3cmd can be used to create and remove buckets, add and remove objects, convert a bucket into a static site from the command line, plus other functions like syncing entire directories up to a bucket.
+- [s3cmd](/docs/products/storage/object-storage/guides/s3cmd/) is a powerful command line utility that can be used with any S3-compatible object storage service, including Linode's. s3cmd can be used to create and remove buckets, add and remove objects, convert a bucket into a static site from the command line, plus other functions like syncing entire directories up to a bucket.
 
-- [Cyberduck](/docs/products/storage/object-storage/guides/cyberduck) is a graphical utility available for Windows and macOS and is a great option if you prefer a GUI tool.
+- [Cyberduck](/docs/products/storage/object-storage/guides/cyberduck/) is a graphical utility available for Windows and macOS and is a great option if you prefer a GUI tool.

--- a/docs/products/storage/object-storage/guides/_index.md
+++ b/docs/products/storage/object-storage/guides/_index.md
@@ -41,10 +41,10 @@ tags: ["education","media"]
 
 Guides for using Object Storage with various clients and command-line tools:
 
-- [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli): An easy to use command-line tool for use with Linode's own services.
-- [s3cmd](/docs/products/storage/object-storage/guides/s3cmd): One of the most common command-line tools for interacting with S3-compatible object storage solutions, including Linode Object Storage.
-- [s4cmd](/docs/products/storage/object-storage/guides/s4cmd): A faster alternative to the s3cmd command-line tool.
-- [Cyberduck](/docs/products/storage/object-storage/guides/cyberduck): A cross-platform graphical interface for interacting with various cloud storage services.
+- [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli/): An easy to use command-line tool for use with Linode's own services.
+- [s3cmd](/docs/products/storage/object-storage/guides/s3cmd/): One of the most common command-line tools for interacting with S3-compatible object storage solutions, including Linode Object Storage.
+- [s4cmd](/docs/products/storage/object-storage/guides/s4cmd/): A faster alternative to the s3cmd command-line tool.
+- [Cyberduck](/docs/products/storage/object-storage/guides/cyberduck/): A cross-platform graphical interface for interacting with various cloud storage services.
 
 ## AWS Tooling
 

--- a/docs/products/storage/object-storage/guides/s4cmd/index.md
+++ b/docs/products/storage/object-storage/guides/s4cmd/index.md
@@ -4,7 +4,7 @@ description: "Learn how to use the s4cmd command-line tool with Linode's Object 
 authors: ["Linode"]
 ---
 
-The [s4cmd](https://github.com/bloomreach/s4cmd) software is a command-line tool that can access S3-compatible storage services, such as Linode's Object Storage. It uses the [S3 client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html) in Amazon's boto3 library. Compared to the popular s3cmd tool, s4cmd is typically much faster but it has less options and is less configurable. For many use cases, the [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli) or [s3cmd](/docs/products/storage/object-storage/guides/s3cmd) is recommended.
+The [s4cmd](https://github.com/bloomreach/s4cmd) software is a command-line tool that can access S3-compatible storage services, such as Linode's Object Storage. It uses the [S3 client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html) in Amazon's boto3 library. Compared to the popular s3cmd tool, s4cmd is typically much faster but it has less options and is less configurable. For many use cases, the [Linode CLI](/docs/products/storage/object-storage/guides/linode-cli/) or [s3cmd](/docs/products/storage/object-storage/guides/s3cmd/) is recommended.
 
 ## Installing s4cmd
 


### PR DESCRIPTION
This PR updates some of the links to our Object Storage guides that _did not use_ a trailing slash.