### PR TITLE
Re-enable Wazuh Marketplace App guide

### DIFF
--- a/docs/products/tools/marketplace/guides/_index.md
+++ b/docs/products/tools/marketplace/guides/_index.md
@@ -124,6 +124,7 @@ See the [Marketplace](/docs/marketplace/) listing page for a full list of all Ma
 - [Virtualmin](/docs/products/tools/marketplace/guides/virtualmin/)
 - [VS Code](/docs/products/tools/marketplace/guides/vscode/)
 - [WarpSpeed VPN](/docs/products/tools/marketplace/guides/warpspeed/)
+- [Wazuh](/docs/products/tools/marketplace/guides/wazuh/)
 - [Webmin](/docs/products/tools/marketplace/guides/webmin/)
 - [Webuzo](/docs/products/tools/marketplace/guides/webuzo/)
 - [WireGuard](/docs/products/tools/marketplace/guides/wireguard/)

--- a/docs/products/tools/marketplace/guides/wazuh/index.md
+++ b/docs/products/tools/marketplace/guides/wazuh/index.md
@@ -3,7 +3,7 @@ description: "Deploy Wazuh on a Linode Compute Instance. This provides you with 
 keywords: ['security','vulnerability','monitoring']
 tags: ["marketplace", "linode platform", "cloud manager"]
 published: 2021-11-12
-modified: 2023-07-24
+modified: 2023-08-16
 modified_by:
   name: Linode
 title: "Deploy Wazuh through the Linode Marketplace"
@@ -11,14 +11,7 @@ external_resources:
 - '[Wazuh](https://wazuh.com/)'
 aliases: ['/guides/deploying-wazuh-marketplace-app/','/guides/wazuh-marketplace-app/']
 authors: ["Linode"]
-_build:
-  list: false
-noindex: true
 ---
-
-{{< note type="warning" >}}
-As of July 24th 2023, Wazuh is no longer available on the Linode Marketplace and the instructions within this guide no longer work as intended. For assistance deploying Wazuh on a Compute Instance, review the [official Wazuh installation guide for Linux](https://documentation.wazuh.com/current/installation-guide/wazuh-agent/wazuh-agent-package-linux.html).
-{{< /note >}}
 
 [Wazuh](https://wazuh.com/) provides a security solution for monitoring your infrastructure and detecting threats, intrusion attempts, system anomalies, poorly configured applications, and unauthorized user actions. It also provides a framework for incident response and regulatory compliance.
 


### PR DESCRIPTION
The Wazuh Marketplace App is now available again. This PR un-hides the guide from search and removes the notice that said the app was removed.