### PR TITLE
[New] Network Configuration Using Netplan

### DIFF
--- a/docs/products/compute/compute-instances/guides/manual-network-configuration/index.md
+++ b/docs/products/compute/compute-instances/guides/manual-network-configuration/index.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn how to manually edit your distribution-specific network configuration files to set static IPs, routes and DNS resolvers."
 keywords: ["static", "ip address", "addresses"]
-published: 2022-07-19
+published: 2023-09-05
 modified_by:
   name: Linode
 title: "Manual Network Configuration on a Compute Instance"
@@ -30,19 +30,19 @@ The following table contains a list of each Linux distribution offered by Linode
 
 | Distribution | Network Manager |
 | -- | -- |
-| AlmaLinux 8 and 9 | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
+| AlmaLinux 8 and above | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
 | Alpine | [ifupdown-ng](/docs/products/compute/compute-instances/guides/ifupdown/) |
 | Arch | [systemd-networkd](/docs/products/compute/compute-instances/guides/systemd-networkd/) |
 | CentOS 7 and 8 | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
-| CentOS Stream 8 and 9 | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
-| Debian 9-11 | [ifupdown](/docs/products/compute/compute-instances/guides/ifupdown/) |
-| Fedora 34-36 | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
+| CentOS Stream 8 and above | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
+| Debian 9 and above | [ifupdown](/docs/products/compute/compute-instances/guides/ifupdown/) |
+| Fedora | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
 | Gentoo | netifrc |
-| Rocky Linux 8 and 9 | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
+| Rocky Linux 8 and above | [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/) |
 | Slackware | netconfig |
 | openSUSE Leap | wicked |
 | Ubuntu 16.04 | [ifupdown](/docs/products/compute/compute-instances/guides/ifupdown/) |
-| Ubuntu 18.04 - 22.04 | [systemd-networkd](/docs/products/compute/compute-instances/guides/systemd-networkd/) and Netplan |
+| Ubuntu 18.04 and above | [systemd-networkd](/docs/products/compute/compute-instances/guides/systemd-networkd/) and [Netplan](/docs/products/compute/compute-instances/guides/netplan/) |
 
 To manually configure networking, follow the associated guide and/or the official manual for the networking software and Linux distribution you are using.
 

--- a/docs/products/compute/compute-instances/guides/netplan/index.md
+++ b/docs/products/compute/compute-instances/guides/netplan/index.md
@@ -40,7 +40,7 @@ The following details show where and how Netplan's configuration files operate:
 
 ## Starter Configuration
 
-To get a sense of how Netplan's configuration files operate, here is the default configuration file. A breakdown of the file follows, elaborating on each part's role.
+To get a sense of how Netplan's configuration files operate, here is a starter configuration file. A breakdown of the file follows, elaborating on each part's role.
 
 ```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
 network:
@@ -49,6 +49,8 @@ network:
   ethernets:
     eth0:
       dhcp4: yes
+      accept-ra: yes
+      ipv6-privacy: no
 ```
 
 -   `version`: Indicates the configuration format. The only option currently supported is `2`.
@@ -185,17 +187,17 @@ Conversely, you can disable IPv6 SLAAC addressing and, instead, statically confi
 
 ## Configuring Additional IPv6 Addresses
 
-You can configure additional IPv6 addresses just as you would IPv4 addresses, by adding `addresses` entries beneath the interface.
+You can configure additional IPv6 addresses similar to as you would IPv4 addresses, by adding `addresses` entries beneath the interface. The one main difference is that IPv6 addresses (and their associated prefixes) should be surrounded by quotation marks. In addition, the default gateway for all IPv6 addresses should be `fe80::1`.
 
 ```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
 ...
   ethernets:
     eth0:
       addresses:
-        - [ip-address]/[prefix]
+        - "[ip-address]/[prefix]"
      routes:
       - to: default
-        via: fe80::1
+        via: "fe80::1"
 ```
 
 Each `addresses` entry consists of two parts: the IP address and the subnet prefix. For an IPv6 address, that breaks down as follows:
@@ -207,8 +209,6 @@ Each `addresses` entry consists of two parts: the IP address and the subnet pref
     -   IPv6 SLAAC address: `/128` (though it is recommended to configure this automatically through SLAAC, as shown in the previous section).
 
     -   IPv6 address from a range: `/64` or `/56` (depending on the size of the range).
-
--   **[gateway-ip]**: The IPv6 address of the gateway corresponding to the primary IPv6 address on your instance.
 
 A similar break down is given specifically for IPv4 addresses in the [Configuring Additional IPv4 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv4-addresses) section further above.
 

--- a/docs/products/compute/compute-instances/guides/netplan/index.md
+++ b/docs/products/compute/compute-instances/guides/netplan/index.md
@@ -1,0 +1,210 @@
+---
+slug: netplan
+title: "Network Configuration Using Netplan"
+description: 'Learn how to manually configure your Compute Instance’s networking using the netplan utility on Ubuntu 18.04 and newer.'
+og_description: 'Learn how to manually configure your Compute Instance’s networking using the netplan utility on Ubuntu 18.04 and newer.'
+keywords: ['netplan','network configuration','ip address']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+authors: ["Nathaniel Stickman"]
+published: 2023-08-16
+modified_by:
+  name: Nathaniel Stickman
+external_resources:
+- '[Netplan Documentation](https://netplan.readthedocs.io/en/stable/)'
+---
+
+[Netplan](https://netplan.io/) is a utility designed to make network configurations easier and more descriptive. It operates on Ubuntu 18.04 and newer, and it works by abstracting lower level configurations in [systemd-networkd](/docs/products/compute/compute-instances/guides/systemd-networkd/) and [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/). Provided a YAML file describing your desired network setup, Netplan implements the necessary back-end configurations to realize the setup.
+
+{{< note >}}
+This guide serves as a supplement to the main [Manual Network Configuration on a Compute Instance](/docs/products/compute/compute-instances/guides/manual-network-configuration/) guide. Please review that guide before making any configuration changes to your Compute Instance.
+{{< /note >}}
+
+## Configuration Files
+
+The following details show where and how Netplan's configuration files operate.
+
+-   **File extension:** `.yaml`
+
+-   **File location:** `/etc/netplan/`
+
+-   **Naming convention:** `[priority]-[name].yaml`, with *[priority]* being a two-digit number (`01` through `99`) defines file ordering (processed in alpha-numeric order) and with *[name]* being a short, descriptive title
+
+-   **Default configuration file:** `/etc/netplan/01-netcfg.yaml`.
+
+## Starter Configuration
+
+To get a sense of how Netplan's configuration files operate, here is the default configuration file. A breakdown of the file follows, elaborating on each part's role.
+
+```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: yes
+```
+
+-   `version`: Indicates the configuration format. The only option currently supported is `2`.
+
+-   `renderer`: Defines which underlying network configuration tool to use, either `networkd` or `NetworkManager`. The default is `networkd`.
+
+-   [ethernets](https://netplan.readthedocs.io/en/stable/netplan-yaml/#properties-for-device-type-ethernets): Configures physical network interfaces.
+
+    In the default configuration, `eth0` introduces a configuration mapping for the primary Ethernet interface. The only option set in this case indicates that DHCP (`dhcp4`) should be used, enabling dynamic IP address assignment.
+
+Learn more about the full extent of Netplan's YAML configuration options in the [official documentation](https://netplan.readthedocs.io/en/stable/netplan-yaml/).
+
+But to get started, the rest of this guide covers many configuration use cases, showing you the steps to take to achieve them.
+
+## Configuring IP Addresses Manually
+
+1.  Log in to the [Cloud Manager](https://cloud.linode.com/), and review your Compute Instance's IP addresses. See [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/). Make a note of the following pieces of information or keep this page accessible so you can reference it later.
+
+    - Public IPv4 address(es) and the associated IPv4 gateway
+
+    - Private IPv4 address (if one has been added)
+
+    - IPv6 SLAAC address and the associated IPv6 gateway
+
+    - IPv6 /64 or /56 routed range (if one has been added)
+
+    - DNS resolvers (if you want to use Linode's resolvers)
+
+1.  Disable Network Helper on the Compute Instance so that it doesn't overwrite any of your changes on the next system reboot. For instructions, see the [Network Helper](/docs/products/compute/compute-instances/guides/network-helper/#single-per-linode) guide. This guide covers disabling Network Helper *globally* (for all Compute Instances on your account) or just for a single instance.
+
+1.  Log in to the Compute Instance using [SSH](/docs/guides/connect-to-server-over-ssh/) or [Lish](/docs/products/compute/compute-instances/guides/lish/). You may want to consider using Lish to avoid getting locked out in the case of a configuration error.
+
+1.  Perform any necessary configuration steps as outlined in the workflows below. You can edit your network configuration file using a text editor like [nano](/docs/guides/use-nano-to-edit-files-in-linux/) or [vim](/docs/guides/what-is-vi/).
+
+    ```command
+    sudo nano /etc/netplan/01-netcfg.yaml
+    ```
+
+1.  Once you've edited the configuration file to fit your needs, you need to generate matching backend configurations and apply the changes. To do so, run the follow Netplan commands:
+
+    ```command
+    sudo netplan generate
+    sudo netplan apply
+    ```
+
+## Changing the Primary IPv4 Address
+
+In Netplan, IP address configuration uses the `addresses` option beneath the interface. So, to change the primary IPv4 address on `eth0` to a static IP address, you can use the following approach.
+
+```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
+...
+  ethernets:
+    eth0:
+      addresses:
+        - 192.0.2.123/24
+```
+
+Each `addresses` entry takes an IP address along with the subnet prefix length. You can learn more about this with a breakdown in the [Configuring Additional IPv4 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv4-addresses) section further below.
+
+## Configuring the Primary IPv4 Address through DHCP
+
+With DHCP, your instance's primary IPv4 address gets configured automatically. The primary IPv4 address is defined as the IPv4 address assigned to your system that is in the first position when sorted numerically.
+
+The default Netplan configuration file shows how to enable DHCP on an interface. Include the `dhcp4` option with a value of `true`, and remove any `addresses` lines that define static IP addresses, like the one shown in the section above.
+
+```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
+...
+  ethernets:
+    eth0:
+      dhcp4: yes
+```
+
+{{< note type="alert" >}}
+When using DHCP, the IPv4 address configured on your system may change if you add or remove IPv4 addresses on your Compute Instance. If this happens, any tool or system using the original IPv4 address is no longer able to connect.
+{{< /note >}}
+
+## Configuring Additional IPv4 Addresses
+
+You can configure additional IPv4 addresses within Netplan by adding `addresses` entries beneath the interface.
+
+```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
+...
+  ethernets:
+    eth0:
+      addresses:
+        - [ip-address]/[prefix]
+```
+
+The placeholder in the example above shows how each `addresses` entry consists of two parts: the IP address and the subnet prefix. For an IPv4 address, this breaks down as follows:
+
+-   **[ip-address]**: The IP address to be statically configured. The address can be IPv4 — as in `192.0.2.2` — or IPv6 — as shown in the [Configuring Additional IPv6 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv6-addresses) section further below.
+
+-   **[prefix]**: The subnet prefix for the address. This depends on the type of IPv4 address you are adding:
+
+    - Public IPv4 address: `/24`
+
+    - Private IPv4 address: `/17`
+
+## Configuring the Primary IPv6 Address through SLAAC
+
+Your primary IPv6 address can be configured automatically through SLAAC. To do so, your Netplan configuration needs to allow router advertisements and disable IPv6 privacy extensions.
+
+```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
+...
+  ethernets:
+    eth0:
+      accept-ra: true
+      ipv6-privacy: false
+```
+
+Conversely, you can disable IPv6 SLAAC addressing and, instead, statically configure your IPv6 address, though doing so is not recommended. For this, disable router advertisements and add your primary IPv6 address with the `/128` subnet prefix, as detailed in the next section.
+
+```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
+...
+  ethernets:
+    eth0:
+      accept-ra: false
+      addresses:
+        - 2001:db8:e001:1b8c::3/128
+```
+
+## Configuring Additional IPv6 Addresses
+
+You can configure additional IPv6 addresses just as you would IPv4 addresses, by adding `addresses` entries beneath the interface.
+
+```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
+...
+  ethernets:
+    eth0:
+      addresses:
+        - [ip-address]/[prefix]
+```
+
+Each `addresses` entry consists of two parts: the IP address and the subnet prefix. For an IPv6 address, that breaks down as follows:
+
+-   **[ip-address]**: The IP address to be statically configured. The address can be IPv4, as shown further above, or IPv6 — as in `2001:db8:e001:1b8c::2`.
+
+-   **[prefix]**: The subnet prefix for the address. This depends on the type of IPv6 address you are adding:
+
+    - IPv6 SLAAC address: `/128` (though it is recommended to configure this automatically through SLAAC, as shown in the previous section)
+
+    - IPv6 address from a range: `/64` or `/56` (depending on the size of the range)
+
+A similar break down is given specifically for IPv4 addresses in the [Configuring Additional IPv4 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv4-addresses) section further above.
+
+## Changing the DNS Resolvers
+
+DNS resolvers ensure that domain names are matched to their corresponding IP addresses. By default, each Compute Instance uses DNS resolvers specific to the data center in which the instance resides.
+
+You can alter the DNS resolvers within Netplan using the `nameservers` option. Use an `addresses` list under that option to enter the IP addresses of the DNS resolvers you wish to use. Both IPv4 and IPv6 addresses can be used.
+
+The configuration example below includes additional options that are necessary if you want to define custom DNS resolvers while retaining DHCP. The `dhcp4` option enables DHCP dynamic IP address assignment, while the `use-dns` under `dhcp4-overrides` ensures that the DHCP does not override your custom DNS resolvers.
+
+```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
+...
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp4-overrides:
+        use-dns: false
+      nameservers:
+        addresses:
+          - 203.0.113.1
+          - 203.0.113.2
+          - 203.0.113.3
+```

--- a/docs/products/compute/compute-instances/guides/netplan/index.md
+++ b/docs/products/compute/compute-instances/guides/netplan/index.md
@@ -4,10 +4,10 @@ title: "Network Configuration Using Netplan"
 description: "Learn how to manually configure your Compute Instance’s networking using the netplan utility on Ubuntu 18.04 and newer."
 keywords: ['netplan','network configuration','ip address']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-authors: ["Nathaniel Stickman"]
-published: 2023-09-05
+authors: ["Linode","Nathaniel Stickman"]
+published: 2023-09-12
 modified_by:
-  name: Nathaniel Stickman
+  name: Linode
 external_resources:
 - '[Netplan Documentation](https://netplan.readthedocs.io/en/stable/)'
 ---

--- a/docs/products/compute/compute-instances/guides/netplan/index.md
+++ b/docs/products/compute/compute-instances/guides/netplan/index.md
@@ -108,9 +108,9 @@ In Netplan, IP address configuration uses the `addresses` option beneath the int
     eth0:
       addresses:
         - [ip-address]/[prefix]
-     routes:
-      - to: default
-        via: [gateway-ip]
+      routes:
+        - to: default
+          via: [gateway-ip]
 ```
 
 Each `addresses` entry takes an IP address along with the subnet prefix length. In addition, you also need to add a route to the gateway.
@@ -153,9 +153,9 @@ You can configure additional IPv4 addresses within Netplan by adding them to the
       addresses:
         - 192.0.2.17/24
         - [ip-address]/[prefix]
-     routes:
-      - to: default
-        via: 192.0.2.1
+      routes:
+        - to: default
+          via: 192.0.2.1
 ```
 
 Replace *[ip-address]* with the additional IPv4 address and *[prefix]* with either `24` for public addresses or `17` for private addresses. To learn more, see the [Changing the Primary IPv4 Address](#changing-the-primary-ipv4-address) section above.
@@ -192,22 +192,23 @@ You can configure additional IPv6 addresses just as you would IPv4 addresses, by
   ethernets:
     eth0:
       addresses:
-        - 192.0.2.17/24
         - [ip-address]/[prefix]
      routes:
       - to: default
-        via: 192.0.2.1
+        via: fe80::1
 ```
 
 Each `addresses` entry consists of two parts: the IP address and the subnet prefix. For an IPv6 address, that breaks down as follows:
 
--   **[ip-address]**: The IP address to be statically configured. The address can be IPv6 (e.g. `2001:db8:e001:1b8c::2`) or IPv4 as shown further above.
+-   **[ip-address]**: The IP address to be statically configured. The address can be IPv6 (e.g., `2001:db8:e001:1b8c::2`) or IPv4 as shown further above.
 
 -   **[prefix]**: The subnet prefix for the address. This depends on the type of IPv6 address you are adding:
 
     -   IPv6 SLAAC address: `/128` (though it is recommended to configure this automatically through SLAAC, as shown in the previous section).
 
     -   IPv6 address from a range: `/64` or `/56` (depending on the size of the range).
+
+-   **[gateway-ip]**: The IPv6 address of the gateway corresponding to the primary IPv6 address on your instance.
 
 A similar break down is given specifically for IPv4 addresses in the [Configuring Additional IPv4 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv4-addresses) section further above.
 

--- a/docs/products/compute/compute-instances/guides/netplan/index.md
+++ b/docs/products/compute/compute-instances/guides/netplan/index.md
@@ -13,7 +13,7 @@ external_resources:
 - '[Netplan Documentation](https://netplan.readthedocs.io/en/stable/)'
 ---
 
-[Netplan](https://netplan.io/) is a utility designed to make network configurations easier and more descriptive. It operates on Ubuntu 18.04 and newer, and it works by abstracting lower level configurations in [systemd-networkd](/docs/products/compute/compute-instances/guides/systemd-networkd/) and [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/). Provided a YAML file describing your desired network setup, Netplan implements the necessary back-end configurations to realize the setup.
+[Netplan](https://netplan.io/) is a utility designed to make network configurations easier and more descriptive. It operates on Ubuntu 18.04 and newer, and works by abstracting lower level configurations in [systemd-networkd](/docs/products/compute/compute-instances/guides/systemd-networkd/) and [NetworkManager](/docs/products/compute/compute-instances/guides/networkmanager/). Simply provide a YAML file describing your desired network setup, and Netplan implements the necessary back-end configurations to realize it.
 
 {{< note >}}
 This guide serves as a supplement to the main [Manual Network Configuration on a Compute Instance](/docs/products/compute/compute-instances/guides/manual-network-configuration/) guide. Please review that guide before making any configuration changes to your Compute Instance.
@@ -21,15 +21,15 @@ This guide serves as a supplement to the main [Manual Network Configuration on a
 
 ## Configuration Files
 
-The following details show where and how Netplan's configuration files operate.
+The following details show where and how Netplan's configuration files operate:
 
--   **File extension:** `.yaml`
+-   **File Extension**: `.yaml`
 
--   **File location:** `/etc/netplan/`
+-   **File Location**: `/etc/netplan/`
 
--   **Naming convention:** `[priority]-[name].yaml`, with *[priority]* being a two-digit number (`01` through `99`) defines file ordering (processed in alpha-numeric order) and with *[name]* being a short, descriptive title
+-   **Naming Convention**: `PRIORITY-NAME.yaml`, with `PRIOTITY` being a two-digit number (`01` through `99`) that defines file ordering (processed in alpha-numeric order) and with `NAME` being a short, descriptive title.
 
--   **Default configuration file:** `/etc/netplan/01-netcfg.yaml`.
+-   **Default Configuration File**: `/etc/netplan/01-netcfg.yaml`
 
 ## Starter Configuration
 
@@ -54,31 +54,33 @@ network:
 
 Learn more about the full extent of Netplan's YAML configuration options in the [official documentation](https://netplan.readthedocs.io/en/stable/netplan-yaml/).
 
-But to get started, the rest of this guide covers many configuration use cases, showing you the steps to take to achieve them.
+To get started, the rest of this guide covers many configuration use cases, providing the steps needed to achieve them.
 
 ## Configuring IP Addresses Manually
 
-1.  Log in to the [Cloud Manager](https://cloud.linode.com/), and review your Compute Instance's IP addresses. See [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/). Make a note of the following pieces of information or keep this page accessible so you can reference it later.
+1.  Log in to the [Cloud Manager](https://cloud.linode.com/), and review your Compute Instance's IP addresses. See [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) for assistance. Make a note of the following pieces of information or keep this page accessible so you can reference it later.
 
-    - Public IPv4 address(es) and the associated IPv4 gateway
+    -   Public IPv4 address(es) and the associated IPv4 gateway
 
-    - Private IPv4 address (if one has been added)
+    -   Private IPv4 address (if one has been added)
 
-    - IPv6 SLAAC address and the associated IPv6 gateway
+    -   IPv6 SLAAC address and the associated IPv6 gateway
 
-    - IPv6 /64 or /56 routed range (if one has been added)
+    -   IPv6 `/64` or `/56` routed range (if one has been added)
 
-    - DNS resolvers (if you want to use Linode's resolvers)
+    -   DNS resolvers (if you want to use Linode's resolvers)
 
 1.  Disable Network Helper on the Compute Instance so that it doesn't overwrite any of your changes on the next system reboot. For instructions, see the [Network Helper](/docs/products/compute/compute-instances/guides/network-helper/#single-per-linode) guide. This guide covers disabling Network Helper *globally* (for all Compute Instances on your account) or just for a single instance.
 
 1.  Log in to the Compute Instance using [SSH](/docs/guides/connect-to-server-over-ssh/) or [Lish](/docs/products/compute/compute-instances/guides/lish/). You may want to consider using Lish to avoid getting locked out in the case of a configuration error.
 
-1.  Perform any necessary configuration steps as outlined in the workflows below. You can edit your network configuration file using a text editor like [nano](/docs/guides/use-nano-to-edit-files-in-linux/) or [vim](/docs/guides/what-is-vi/).
+1.  Edit your network configuration file using a text editor like [nano](/docs/guides/use-nano-to-edit-files-in-linux/) or [vim](/docs/guides/what-is-vi/) with root permissions.
 
     ```command
     sudo nano /etc/netplan/01-netcfg.yaml
     ```
+
+1.  Perform any necessary configuration steps as outlined in the workflows below. When done, press <kbd>CTRL</kbd>+<kbd>X</kbd>, followed by <kbd>Y</kbd> then <kbd>Enter</kbd> to save the file and exit `nano`.
 
 1.  Once you've edited the configuration file to fit your needs, you need to generate matching backend configurations and apply the changes. To do so, run the follow Netplan commands:
 
@@ -89,7 +91,7 @@ But to get started, the rest of this guide covers many configuration use cases, 
 
 ## Changing the Primary IPv4 Address
 
-In Netplan, IP address configuration uses the `addresses` option beneath the interface. So, to change the primary IPv4 address on `eth0` to a static IP address, you can use the following approach.
+In Netplan, IP address configuration uses the `addresses` option beneath the interface. So, to change the primary IPv4 address on `eth0` to a static IP address, you can use the following approach:
 
 ```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
 ...
@@ -99,13 +101,13 @@ In Netplan, IP address configuration uses the `addresses` option beneath the int
         - 192.0.2.123/24
 ```
 
-Each `addresses` entry takes an IP address along with the subnet prefix length. You can learn more about this with a breakdown in the [Configuring Additional IPv4 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv4-addresses) section further below.
+Each `addresses` entry takes an IP address along with the subnet prefix length. Learn more about this with a breakdown in the [Configuring Additional IPv4 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv4-addresses) section further below.
 
 ## Configuring the Primary IPv4 Address through DHCP
 
-With DHCP, your instance's primary IPv4 address gets configured automatically. The primary IPv4 address is defined as the IPv4 address assigned to your system that is in the first position when sorted numerically.
+With DHCP, your instance's primary IPv4 address is configured automatically. The primary IPv4 address is the first IPv4 address assigned to your system when sorted numerically.
 
-The default Netplan configuration file shows how to enable DHCP on an interface. Include the `dhcp4` option with a value of `true`, and remove any `addresses` lines that define static IP addresses, like the one shown in the section above.
+The default Netplan configuration file shows how to enable DHCP on an interface. Include the `dhcp4` option with a value of `yes`, and remove any `addresses` lines that define static IP addresses, like the one shown in the section above.
 
 ```file {title="/etc/netplan/01-netcfg.yaml" lang="yaml"}
 ...
@@ -114,7 +116,7 @@ The default Netplan configuration file shows how to enable DHCP on an interface.
       dhcp4: yes
 ```
 
-{{< note type="alert" >}}
+{{< note type="warning" >}}
 When using DHCP, the IPv4 address configured on your system may change if you add or remove IPv4 addresses on your Compute Instance. If this happens, any tool or system using the original IPv4 address is no longer able to connect.
 {{< /note >}}
 
@@ -127,18 +129,18 @@ You can configure additional IPv4 addresses within Netplan by adding `addresses`
   ethernets:
     eth0:
       addresses:
-        - [ip-address]/[prefix]
+        - IP_ADDRESS/SUBNET_PREFIX
 ```
 
 The placeholder in the example above shows how each `addresses` entry consists of two parts: the IP address and the subnet prefix. For an IPv4 address, this breaks down as follows:
 
--   **[ip-address]**: The IP address to be statically configured. The address can be IPv4 — as in `192.0.2.2` — or IPv6 — as shown in the [Configuring Additional IPv6 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv6-addresses) section further below.
+-   **IP_ADDRESS**: The IP address to be statically configured. The address can be IPv4 (e.g `192.0.2.2`) or IPv6, as shown in the [Configuring Additional IPv6 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv6-addresses) section further below.
 
--   **[prefix]**: The subnet prefix for the address. This depends on the type of IPv4 address you are adding:
+-   **SUBNET_PREFIX**: The subnet prefix for the address. This depends on the type of IPv4 address you are adding:
 
-    - Public IPv4 address: `/24`
+    -   Public IPv4 addresses: `/24`
 
-    - Private IPv4 address: `/17`
+    -   Private IPv4 addresses: `/17`
 
 ## Configuring the Primary IPv6 Address through SLAAC
 
@@ -148,8 +150,8 @@ Your primary IPv6 address can be configured automatically through SLAAC. To do s
 ...
   ethernets:
     eth0:
-      accept-ra: true
-      ipv6-privacy: false
+      accept-ra: yes
+      ipv6-privacy: no
 ```
 
 Conversely, you can disable IPv6 SLAAC addressing and, instead, statically configure your IPv6 address, though doing so is not recommended. For this, disable router advertisements and add your primary IPv6 address with the `/128` subnet prefix, as detailed in the next section.
@@ -158,7 +160,7 @@ Conversely, you can disable IPv6 SLAAC addressing and, instead, statically confi
 ...
   ethernets:
     eth0:
-      accept-ra: false
+      accept-ra: no
       addresses:
         - 2001:db8:e001:1b8c::3/128
 ```
@@ -172,18 +174,18 @@ You can configure additional IPv6 addresses just as you would IPv4 addresses, by
   ethernets:
     eth0:
       addresses:
-        - [ip-address]/[prefix]
+        - IP_ADDRESS/SUBNET_PREFIX
 ```
 
 Each `addresses` entry consists of two parts: the IP address and the subnet prefix. For an IPv6 address, that breaks down as follows:
 
--   **[ip-address]**: The IP address to be statically configured. The address can be IPv4, as shown further above, or IPv6 — as in `2001:db8:e001:1b8c::2`.
+-   **IP_ADDRESS**: The IP address to be statically configured. The address can be IPv6 (e.g. `2001:db8:e001:1b8c::2`) or IPv4 as shown further above.
 
--   **[prefix]**: The subnet prefix for the address. This depends on the type of IPv6 address you are adding:
+-   **SUBNET_PREFIX**: The subnet prefix for the address. This depends on the type of IPv6 address you are adding:
 
-    - IPv6 SLAAC address: `/128` (though it is recommended to configure this automatically through SLAAC, as shown in the previous section)
+    -   IPv6 SLAAC address: `/128` (though it is recommended to configure this automatically through SLAAC, as shown in the previous section).
 
-    - IPv6 address from a range: `/64` or `/56` (depending on the size of the range)
+    -   IPv6 address from a range: `/64` or `/56` (depending on the size of the range).
 
 A similar break down is given specifically for IPv4 addresses in the [Configuring Additional IPv4 Addresses](/docs/products/compute/compute-instances/guides/netplan/#configuring-additional-ipv4-addresses) section further above.
 
@@ -199,9 +201,9 @@ The configuration example below includes additional options that are necessary i
 ...
   ethernets:
     eth0:
-      dhcp4: true
+      dhcp4: yes
       dhcp4-overrides:
-        use-dns: false
+        use-dns: no
       nameservers:
         addresses:
           - 203.0.113.1

--- a/docs/products/compute/compute-instances/guides/systemd-networkd/index.md
+++ b/docs/products/compute/compute-instances/guides/systemd-networkd/index.md
@@ -14,7 +14,7 @@ authors: ["Linode"]
 The [systemd-networkd](https://wiki.archlinux.org/title/systemd-networkd) tool is a newer tool developed as part of systemd. Arch and modern versions of Ubuntu (17.10 and above) currently use systemd-networkd as their default network configuration software.
 
 {{< note >}}
-Ubuntu also has utility called Netplan that serves as a frontend for configuring either systemd-networkd or NetworkManager. By default, NetworkHelper manages networking in Ubuntu using systemd-networkd though you can decide which one works best for your needs.
+By default, Linode's Network Helper tool manages networking in Ubuntu using systemd-networkd. Ubuntu also has utility called Netplan that serves as a frontend for configuring either systemd-networkd or NetworkManager. To use Netplan instead, review the [Network Configuration Using Netplan](/docs/products/compute/compute-instances/guides/netplan/) guide.
 {{< /note >}}
 
 {{< note >}}


### PR DESCRIPTION
This PR adds the "Network Configuration Using Netplan" guide, which is part of our Manual Network Configuration series. This guide walks readers through using Netplan on Ubuntu 18.04 (and newer) to modify their network configuration files manually instead of leaning on Network Helper.