### PR TITLE
Run the docs404 on a schedule

### DIFF
--- a/.github/workflows/404.yaml
+++ b/.github/workflows/404.yaml
@@ -1,0 +1,81 @@
+name: 404 Test
+
+# Runs at 10AM every day
+on:
+  schedule:
+    - cron: "0 10 * * *"
+
+env:
+  hugo_image_cache_name: hugo-generated-images
+  hugo_image_cache_path: /home/runner/work/docs-publishing/docs-publishing/docs-repo/resources/_gen/images/
+
+jobs:
+  docs404:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout docs repo
+      uses: actions/checkout@v3
+      with:
+        path: 'docs-repo'
+    - name: List contents of images dir
+      continue-on-error: true
+      run: ls -al ${{ env.hugo_image_cache_path }}
+    - name: Restore Hugo generated images cache
+      uses: ylemkimon/cache-restore@v2
+      with:
+        path: ${{ env.hugo_image_cache_path }}
+        key: ${{ env.hugo_image_cache_name }}
+        restore-keys: ${{ env.hugo_image_cache_name }}
+    - name: List contents of images dir
+      continue-on-error: true
+      run: ls -al ${{ env.hugo_image_cache_path }}
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10.x'
+        architecture: 'x64'
+        cache: pip
+    - name: Install dependencies (Python)
+      working-directory: ./docs-repo
+      run: |
+        pip install -r ./ci/requirements.txt
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '14.x'
+    - name: Install dependencies (Node)
+      working-directory: ./docs-repo
+      run: npm ci
+    - name: Set up Hugo
+      uses: peaceiris/actions-hugo@v2
+      with:
+        hugo-version: '0.116.1'
+    - name: Start Hugo server
+      working-directory: ./docs-repo
+      run: |
+        # Start Hugo in background:
+        hugo server &
+
+        # Wait for server to start
+        # (or possibly fail to start):
+        while true
+        do
+            # Check if the server is responding on 1313,
+            # which means that the Hugo build finished.
+            if nc -z localhost 1313
+            then
+                exit 0
+            fi
+
+            # Check if the Hugo process is still running.
+            # If not, then the server failed to build.
+            if ! pgrep hugo > /dev/null
+            then
+                exit 1
+            fi
+
+            sleep 1
+        done
+    - name: Run tests
+      working-directory: ./docs-repo
+      run: python ./ci/docs404.py


### PR DESCRIPTION
This PR runs the docs404 test on a schedule (set to 10AM every day but that can be updated). The test is still always failing, but if we wanted to keep it around as a sort of double check, we can fix the test and run it on a schedule instead of on each PR.