### PR TITLE
[Update] Linode Writer's Formatting Guide

### DIFF
--- a/docs/guides/linode-writers-formatting-guide/index.md
+++ b/docs/guides/linode-writers-formatting-guide/index.md
@@ -5,7 +5,7 @@ keywords: ["style guide", "format", "formatting", "how to write", "write for us"
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/linode-writers-formatting-guide/','/linode-writers-guide/','/style-guide/']
 published: 2014-01-15
-modified: 2023-08-29
+modified: 2023-09-11
 modified_by:
   name: Linode
 title: Linode Writer's Formatting Guide
@@ -511,6 +511,8 @@ Images can add value to the surrounding text by providing context or additional 
 
 -   **Image size:** Images are displayed in their original size, up to the maximum width of the content area. If an image's width is larger than the width of the content area, the image is scaled down to fit within the content area and a user can click on the image to view it in a modal.
 
+To add an image to a guide, first move it the same directory as the guide or shortguide. Then, enter the following Markdown syntax at the location you wish the image to appear:
+
 ```file {lang="md"}
 ![Alt text](filename.png "Title text")
 ```
@@ -521,7 +523,7 @@ Images can add value to the surrounding text by providing context or additional 
 
 #### Image Recommendations
 
-The height of our images, especially screenshots, should be as minimal as possible. This is to avoid screenshots taking up a lot of vertical space within our documentation, which often results in visually breaking up content that otherwise should appear together. Our Cloud Manager favors vertically stacked fields and options, which can make it difficult to minimize the height of our screenshots. Use your best judgement when determine what part of the UI is needed to convey the required information.
+The height of our images, especially screenshots, should be as minimal as possible. This is to avoid screenshots taking up a lot of vertical space within our documentation, which often results in visually breaking up content that otherwise should appear together. Our Cloud Manager favors vertically stacked fields and options, which can make it difficult to minimize the height of our screenshots. Use your best judgement when determining what part of the UI is needed to convey the required information.
 
 Avoid including too much detail or information within an image. Many images are used to either show a result of an action (like displaying a web page) or are used to supplement instructions asking the reader to perform an action (like click a button). Images that show too much may confuse the reader or otherwise call attention to details that aren't important to the task at hand. In practice, this means not taking a screenshot of the entire application or browser window and instead focusing only on the UI elements related to the instructions or text.
 


### PR DESCRIPTION
This PR adds a few sentences on adding images to a guide, specifically that most images should be stored in the same directory as the guide's `index.md` file.