### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/docs/guides/game-servers/how-to-set-up-minecraft-server-on-ubuntu-or-debian/index.md
+++ b/docs/guides/game-servers/how-to-set-up-minecraft-server-on-ubuntu-or-debian/index.md
@@ -14,9 +14,9 @@ title_meta: "How to Set Up a Minecraft Server on Ubuntu or Debian"
 image: How_to_Set_Up_a_Minecraft_Server_smg.jpg
 external_resources:
  - '[Minecraft.net](https://minecraft.net/)'
- - '[The Official Minecraft Wiki](http://minecraft.gamepedia.com/Minecraft_Wiki)'
- - '[Official MineCraft Install Guide](http://minecraft.gamepedia.com/Tutorials/Setting_up_a_server#Debian)'
- - '[Documentation on the World of Color Update](http://minecraft.gamepedia.com/1.12)'
+ - '[Minecraft Wiki](http://minecraft.wiki/w/Minecraft_Wiki)'
+ - '[Official MineCraft Install Guide](http://minecraft.wiki/w/Tutorials/Setting_up_a_server#Debian)'
+ - '[Documentation on the World of Color Update](http://minecraft.wiki/w/1.12)'
 dedicated_cpu_link: true
 relations:
     platform:
@@ -194,11 +194,11 @@ eula=true
 To disconnect from the screen session without stopping the game server, press **CTRL+a** and then **d**. To resume the running screen session, use the command `screen -r`.
 {{< /note >}}
 
-1.  Optionally, you can take this opportunity to disconnect from the screen session and customize your game settings. When the `run.sh` script is executed, a world is created with the default variables. If you would like to create a new world with updated variables (like [world seeds](http://minecraft.gamepedia.com/Seed_(level_generation))), change the `level-name` directive in the `server.properties` file and modify other settings accordingly.
+1.  Optionally, you can take this opportunity to disconnect from the screen session and customize your game settings. When the `run.sh` script is executed, a world is created with the default variables. If you would like to create a new world with updated variables (like [world seeds](http://minecraft.wiki/w/Seed_(level_generation))), change the `level-name` directive in the `server.properties` file and modify other settings accordingly.
 
     After stopping and restarting the server script with the `level-name` changed, a new directory is created that contains your game data for that world.
 
-For more information on available settings and how to modify them, or how to run a Minecraft server upon startup of Ubuntu or Debian, refer to the [Minecraft Wiki settings page](http://minecraft.gamepedia.com/Server.properties).
+For more information on available settings and how to modify them, or how to run a Minecraft server upon startup of Ubuntu or Debian, refer to the [Minecraft Wiki settings page](http://minecraft.wiki/w/Server.properties).
 
 ## Connect to your Minecraft Server
 

--- a/docs/guides/game-servers/minecraft-on-linode-with-ubuntu-12-04/index.md
+++ b/docs/guides/game-servers/minecraft-on-linode-with-ubuntu-12-04/index.md
@@ -243,7 +243,7 @@ Once you’re ready to continue and have logged out of your server, log back in 
         2013-09-22 23:47:27 [INFO] Saving chunks for level 'world'/The End
         minecraft@li510-161:~$
 
-These next sections contain descriptions for certain files or directories in your `/minecraft` directory. These are not all the files that you may want to configure, nor are these complete descriptions. For more details, see the [Minecraft Wiki](http://minecraft.gamepedia.com/Minecraft_Wiki).
+These next sections contain descriptions for certain files or directories in your `/minecraft` directory. These are not all the files that you may want to configure, nor are these complete descriptions. For more details, see the [Minecraft Wiki](http://minecraft.wiki/w/Minecraft_Wiki).
 
 ### Edit the Configuration Files
 
@@ -279,14 +279,14 @@ Any time you modify these files while the game is running, you will need to stop
 -   `/world_nether`
 -   `/world_the_end`
 
-The directories `world`, `world_nether`, and `world-the-end` contain the map and player data for those realms in your game. We suggest [backing up](/docs/products/storage/backups/) these directories on a regular basis so that you can revert to previous versions in case of catastrophe or [griefing](http://www.minecraftwiki.net/wiki/Griefing). These directories may be in different locations, depending on which version of the Minecraft server you installed. Note that the directories for the *nether* and *the end* will not be created until a player goes to this area on the server.
+The directories `world`, `world_nether`, and `world-the-end` contain the map and player data for those realms in your game. We suggest [backing up](/docs/products/storage/backups/) these directories on a regular basis so that you can revert to previous versions in case of catastrophe or [griefing](http://minecraft.wiki/w/Griefing). These directories may be in different locations, depending on which version of the Minecraft server you installed. Note that the directories for the *nether* and *the end* will not be created until a player goes to this area on the server.
 
 ## More Information
 
 You may wish to consult the following resources for additional information on this topic. While these are provided in the hope that they will be useful, please note that we cannot vouch for the accuracy or timeliness of externally hosted materials.
 
 - [Official Minecraft Site](http://minecraft.net/)
-- [Minecraft Wiki](http://minecraft.gamepedia.com/Minecraft_Wiki)
+- [Minecraft Wiki](http://minecraft.wiki/w/Minecraft_Wiki)
 - [Official CraftBukkit Site](http://dl.bukkit.org/)
 - [Bukkit Plugins](http://dev.bukkit.org/bukkit-plugins/)
 

--- a/docs/guides/game-servers/minecraft-with-bungee-cord/index.md
+++ b/docs/guides/game-servers/minecraft-with-bungee-cord/index.md
@@ -6,7 +6,7 @@ tags: ["ubuntu", "debian"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
  - '[Minecraft.net](https://minecraft.net/)'
- - '[The Official Minecraft Wiki](http://minecraft.gamepedia.com/Minecraft_Wiki)'
+ - '[Minecraft Wiki](http://minecraft.wiki/w/Minecraft_Wiki)'
  - '[Official BungeeCord Site](https://www.spigotmc.org/wiki/bungeecord/)'
  - '[BungeeCord and Spigot Forums](https://www.spigotmc.org/)'
 published: 2015-09-09

--- a/docs/guides/game-servers/minecraft-with-spigot-ubuntu/index.md
+++ b/docs/guides/game-servers/minecraft-with-spigot-ubuntu/index.md
@@ -161,7 +161,7 @@ Customize the server by editing values in `/home/minecraft/server/server.propert
 
         pvp=true
 
--	**Other**: See the [Minecraft](http://minecraft.gamepedia.com/Server.properties) wiki for more details.
+-	**Other**: See the [Minecraft](http://minecraft.wiki/w/Server.properties) wiki for more details.
 
 ### Plugins
 

--- a/docs/products/tools/marketplace/guides/minecraft/index.md
+++ b/docs/products/tools/marketplace/guides/minecraft/index.md
@@ -44,7 +44,7 @@ With over 100 million users around the world, [Minecraft](https://www.minecraft.
 - **PvP Enabled:** Enables player versus player combat on the server. *Advanced Configuration*.
 - **Force Game Mode Enabled:** Forces players to join the server's default game mode. `false` allows players to join with their previous game mode. `true` forces the default game mode.
 - **World Type:** Type of world to generate. *Default* = standard, *flat* = featureless and flat, *largebiomes* = larger biomes, *amplified* = larger height limit. *Advanced Configuration*.
-- **World Seed:** A random value used by Minecraft's world generation algorithm to create a unique world. For example: `qazwsx123`. See [Minecraft's Gamepedia](https://minecraft.gamepedia.com/Seed_(level_generation)) entry on seeds for more information. *Advanced Configuration*.
+- **World Seed:** A random value used by Minecraft's world generation algorithm to create a unique world. For example: `qazwsx123`. See [Minecraft Wiki](https://minecraft.wiki/w/Seed_(level_generation)) entry on seeds for more information. *Advanced Configuration*.
 - **Spawn Animals Enabled:** Determines if animals (sheep, chickens, squid, etc.) spawn. *Advanced Configuration*.
 - **Spawn Monsters Enabled:** Determines if monsters (creepers, skeletons, spiders, etc.) spawn. *Advanced Configuration*.
 - **Spawn NPCs Enabled:** Determines if villagers spawn. *Advanced Configuration*.

--- a/docs/products/tools/marketplace/guides/minecraft/index.md
+++ b/docs/products/tools/marketplace/guides/minecraft/index.md
@@ -5,7 +5,7 @@ published: 2019-04-01
 modified: 2022-04-01
 title: "Deploy a Minecraft Server through the Linode Marketplace"
 external_resources:
-- '[Minecraft Wiki](https://minecraft.fandom.com/wiki/Server)'
+- '[Minecraft Wiki](https://minecraft.wiki/w/Server)'
 tags: ["linode platform","marketplace","cloud-manager"]
 aliases: ['/platform/marketplace/deploying-minecraft-with-marketplace-apps/', '/platform/one-click/deploying-minecraft-with-one-click-apps/', '/guides/deploying-minecraft-with-one-click-apps/', '/guides/deploying-minecraft-with-marketplace-apps/','/guides/deploy-minecraft-marketplace-app/','/guides/minecraft-marketplace-app/']
 image: deploy-a-minecraft-server-with-oneclick-apps.png


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the previous outdated wiki links accordingly.