### PR TITLE
fix: duplicate rate limit line

### DIFF
--- a/docs/products/storage/object-storage/_index.md
+++ b/docs/products/storage/object-storage/_index.md
@@ -73,7 +73,6 @@ The tables below outline Object Storage limits. Most of the limits apply **per r
 | Maximum number of buckets | 1,000 buckets |
 | Maximum file upload size | 5 GB (5 TB with multipart uploads) |
 | Rate limit (per bucket) | 750 requests per second |
-| Rate limit (per bucket) | 750 requests per second |
 
 
 | Data Center | Max Storage<br><small>per account, per region</small> | Max # of objects<br><small>per account, per region</small> |


### PR DESCRIPTION
As of right now, rate limits are still 750rps across all OBJ clusters (including ones in new regions). I believe a second line was accidentally added in https://github.com/linode/docs/pull/6550.
