### PR TITLE
[update] Deploy Focalboard through the Linode Marketplace

### DIFF
--- a/docs/products/tools/marketplace/guides/focalboard/index.md
+++ b/docs/products/tools/marketplace/guides/focalboard/index.md
@@ -3,7 +3,7 @@ description: "Deploy Focalboard on a Linode Compute Instance. This provides you 
 keywords: ['focalboard','project','productivity','kanban']
 tags: ["marketplace", "linode platform", "cloud manager"]
 published: 2022-02-22
-modified: 2022-03-08
+modified: 2023-10-27
 modified_by:
   name: Linode
 title: "Deploy Focalboard through the Linode Marketplace"
@@ -13,7 +13,7 @@ aliases: ['/guides/focalboard-marketplace-app/']
 authors: ["Linode"]
 ---
 
-[Focalboard](https://www.focalboard.com/) is an open source alternative to tools like Asana, Trello, and Notion. It helps teams, individuals, and developers stay aligned and organized on their everyday tasks. With Focalboard, you can reach milestones, keep track of project notes, and achieve goals.
+[Focalboard](https://www.focalboard.com/) is an open source alternative to project management tools such as Asana, Trello, and Notion. It helps teams, individuals, and developers stay aligned and organized on their everyday tasks. With Focalboard, you can reach milestones, keep track of project notes, and achieve goals.
 
 ## Deploying a Marketplace App
 
@@ -44,7 +44,7 @@ authors: ["Linode"]
 
 ### Accessing the Focalboard App
 
-1.  Open your web browser and navigate to `https://[domain]/`, where *[domain]* can be replaced with the custom domain you entered during deployment or your Compute Instance's rDNS domain (such as `192-0-2-1.ip.linodeusercontent.com`). See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) guide for information on viewing rDNS.
+1.  Open your web browser and navigate to `https://DOMAIN/`, where *DOMAIN* can be replaced with the custom domain you entered during deployment or your Compute Instance's rDNS domain (such as `192-0-2-1.ip.linodeusercontent.com`). See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) guide for information on viewing rDNS.
 
     ![Screenshot of the URL bar](focalboard-url.png)
 

--- a/docs/products/tools/marketplace/guides/focalboard/index.md
+++ b/docs/products/tools/marketplace/guides/focalboard/index.md
@@ -27,7 +27,7 @@ authors: ["Linode"]
 
 ## Configuration Options
 
-- **Supported distributions:** Ubuntu 20.04 LTS, Debian 11
+- **Supported distributions:** Ubuntu 22.04 LTS
 - **Recommended plan:** All plan types and sizes can be used.
 
 ### Focalboard Options
@@ -44,7 +44,7 @@ authors: ["Linode"]
 
 ### Accessing the Focalboard App
 
-1.  Open your web browser and navigate to `http://[domain]/`, where *[domain]* can be replaced with the custom domain you entered during deployment or your Compute Instance's rDNS domain (such as `192-0-2-1.ip.linodeusercontent.com`). See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) guide for information on viewing rDNS.
+1.  Open your web browser and navigate to `https://[domain]/`, where *[domain]* can be replaced with the custom domain you entered during deployment or your Compute Instance's rDNS domain (such as `192-0-2-1.ip.linodeusercontent.com`). See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) guide for information on viewing rDNS.
 
     ![Screenshot of the URL bar](focalboard-url.png)
 
@@ -59,8 +59,6 @@ authors: ["Linode"]
 1.  You are automatically logged in and the **Create Board** screen should display.
 
     ![The Focalboard Create a Board page](focalboard-create-board.png)
-
-
 
 
 Now that you’ve accessed your dashboard, check out [the official Focalboard documentation](https://www.focalboard.com/guide/user/) to learn how to further utilize your Focalboard instance.


### PR DESCRIPTION
Updated supported distros

New focalboard script: https://github.com/akamai-compute-marketplace/marketplace-apps/blob/main/deployment_scripts/linode-marketplace-focalboard/focalboard-deploy.sh

Once Merged, please notify the Marketplace team so we can update the live application