### PR TITLE
[update] Deploying a 7 Days to Die Server on Linux

### DIFF
--- a/docs/guides/game-servers/deploy-7-days-to-die-linux-game-server/index.md
+++ b/docs/guides/game-servers/deploy-7-days-to-die-linux-game-server/index.md
@@ -34,7 +34,7 @@ The Linux Game Server manager ([LinuxGSM](https://linuxgsm.com/)) is a command-l
 
         sudo dpkg --add-architecture i386
         sudo apt update
-        sudo apt install curl wget file tar bzip2 gzip unzip bsdmainutils python util-linux ca-certificates binutils bc jq tmux netcat lib32gcc-s1 lib32stdc++6 steamcmd telnet expect
+        sudo apt install curl wget file tar bzip2 gzip unzip bsdmainutils python3 util-linux ca-certificates binutils bc jq tmux netcat-traditional lib32gcc-s1 lib32stdc++6 steamcmd telnet expect
 
     A prompt appears with the Steam EULA. To proceed, use your keyboard's **down arrow** key to read through the agreement. Then, use the **tab** key to select **<ok>**.
 


### PR DESCRIPTION
_ updated the packages that need to be installed
- fixes: https://github.com/linode/docs/issues/6613

Tested and validated that netcat-traditional is required.
```Do you want to continue? [Y/n] y
Get:1 http://mirrors.linode.com/ubuntu jammy/universe amd64 netcat-traditional amd64 1.10-47 [63.3 kB]
Fetched 63.3 kB in 1s (48.8 kB/s)             
Selecting previously unselected package netcat-traditional.
(Reading database ... 75240 files and directories currently installed.)
Preparing to unpack .../netcat-traditional_1.10-47_amd64.deb ...
Unpacking netcat-traditional (1.10-47) ...
Setting up netcat-traditional (1.10-47) ...
Processing triggers for man-db (2.10.2-1) ...
Scanning processes...                                                           
Scanning candidates...                                                          
Scanning linux images...                                                        

Running kernel seems to be up-to-date.

Restarting services...
```