### PR TITLE
Adds placeholder shortcode to formatting guide

### DIFF
--- a/docs/guides/linode-writers-formatting-guide/index.md
+++ b/docs/guides/linode-writers-formatting-guide/index.md
@@ -5,7 +5,7 @@ keywords: ["style guide", "format", "formatting", "how to write", "write for us"
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/linode-writers-formatting-guide/','/linode-writers-guide/','/style-guide/']
 published: 2014-01-15
-modified: 2023-09-11
+modified: 2023-11-28
 modified_by:
   name: Linode
 title: Linode Writer's Formatting Guide
@@ -276,6 +276,8 @@ Example IPs should use the documentation address blocks given in [IETF RFC 5737]
 - 192.0.2.0/24
 - 198.51.100.0/24
 - 203.0.113.0/24
+
+In general, use these address blocks in order. Use the first block (`192.0.2.0/24`) for the first example IP address that is needed. If another IP address is needed, pull from the next block. If the example text is referencing the IP address of a Compute Instance, do not use 0 or 1 as the last segment of the IP address as they are not used for Compute Instances. For instance, `192.0.2.17` is acceptable but `192.0.2.0` and `192.0.2.1` are not.
 
 ### External Resources/More Information
 
@@ -786,6 +788,46 @@ This content appears within the first list item but does not respect its indenta
 | 1-10 | Greater than 10 |
 | -- | -- |
 | Use words (one, two, three, etc.)  | Use numerical digits (11, 22, 33). |
+
+### Placeholders
+
+The placeholder shortcode applies special formatting to highlight the user-replaceable portion of a command or file. It can also be used within a paragraph as a way to reference what the user should replace.
+
+- **Syntax:** `{{</* placeholder "VARIABLE_NAME" */>}}`</br>
+- **Output:** {{< placeholder "VARIABLE_NAME" >}}
+
+When creating a placeholder, you can either use a descriptive variable name (as shown above) or example text.
+
+- **Placeholder example text:** A generic example that represents the expected user input. For instance, example IP addresses (`192.0.2.17`) and example domain names (`example.com`). This should be in the same case as the surrounding text, using whatever formatting is appropriate for the example text.
+- **Placeholder variable:** A short string descriptive variable name that the user should replace. This should be formatted in uppercase with an underscore (`_`) used instead of spaces. For instance, `REGION_ID` and `FILE_NAME`.
+
+The following example demonstrates a common use case for the placeholder shortcode.
+
+-   **Markdown syntax:**
+
+    ````
+    Within the default NGINX configuration file, replace {{</* placeholder "example.com" */>}} with your website's domain.
+
+    ```file {title="/etc/nginx/sites-available/default"}
+    server {
+        listen  80;
+        listen [::]:80;
+        server_name {{</* placeholder "example.com" */>}};
+    }
+    ```
+    ````
+
+-   **Output:**
+
+    Within the default NGINX configuration file, replace {{< placeholder "example.com" >}} with your website's domain.
+
+    ```file {title="/etc/nginx/sites-available/default"}
+    server {
+        listen  80;
+        listen [::]:80;
+        server_name {{< placeholder "example.com" >}};
+    }
+    ```
 
 ### Sentence Spacing
 

--- a/docs/guides/linode-writers-formatting-guide/index.md
+++ b/docs/guides/linode-writers-formatting-guide/index.md
@@ -271,13 +271,17 @@ Update your system by running `yum update`.
 
 ### Example IP Addresses
 
-Example IPs should use the documentation address blocks given in [IETF RFC 5737](https://tools.ietf.org/html/rfc5737). These are:
+When referencing IP address in the documentation, any real address should be obscured unless it is intended for the user to access that IP address. When possible, use the documentation address blocks given in [IETF RFC 5737](https://tools.ietf.org/html/rfc5737) and [IETF RFC 3849](https://datatracker.ietf.org/doc/html/rfc3849).
 
-- 192.0.2.0/24
-- 198.51.100.0/24
-- 203.0.113.0/24
+-   **IPv4:** 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
 
-In general, use these address blocks in order. Use the first block (`192.0.2.0/24`) for the first example IP address that is needed. If another IP address is needed, pull from the next block. If the example text is referencing the IP address of a Compute Instance, do not use 0 or 1 as the last segment of the IP address as they are not used for Compute Instances. For instance, `192.0.2.17` is acceptable but `192.0.2.0` and `192.0.2.1` are not.
+    *Examples:* 192.0.2.84, 192.0.2.142, 198.51.100.65, 198.51.100.231, 203.0.113.2, 203.0.113.97
+
+    In general, use these address blocks in order. Use the first block (`192.0.2.0/24`) for the first example IP address that is needed. If another IP address is needed, pull from the next block. If the example text is referencing the IPv4 address of a Compute Instance, do not use 0 or 1 as the last segment of the IP address as they are not used for Compute Instances. For instance, `192.0.2.17` is acceptable but `192.0.2.0` and `192.0.2.1` are not.
+
+-   **IPv6:** 2001:DB8::/32
+
+    *Examples:* 2001:db8:1:1:1:1:1:1, 2001:db8::f03c:485f:b84e:6534
 
 ### External Resources/More Information
 

--- a/docs/guides/linode-writers-formatting-guide/index.md
+++ b/docs/guides/linode-writers-formatting-guide/index.md
@@ -802,8 +802,8 @@ The placeholder shortcode applies special formatting to highlight the user-repla
 
 When creating a placeholder, you can either use a descriptive variable name (as shown above) or example text.
 
-- **Placeholder example text:** A generic example that represents the expected user input. For instance, example IP addresses (`192.0.2.17`) and example domain names (`example.com`). This should be in the same case as the surrounding text, using whatever formatting is appropriate for the example text.
-- **Placeholder variable:** A short string descriptive variable name that the user should replace. This should be formatted in uppercase with an underscore (`_`) used instead of spaces. For instance, `REGION_ID` and `FILE_NAME`.
+- **Placeholder example text:** A generic example that represents the expected user input. For instance, example IP addresses (`192.0.2.17`) and example domain names (`example.com`). This should be in the same case as the surrounding text, using whatever formatting is appropriate for the example text. For IP addresses, review the [Example IP Addresses](#example-ip-addresses) section.
+- **Placeholder variable:** A short descriptive variable name. This should be formatted in uppercase with an underscore (`_`) used instead of spaces. For instance, `REGION_ID` and `FILE_NAME`.
 
 The following example demonstrates a common use case for the placeholder shortcode.
 


### PR DESCRIPTION
This PR adds the new placeholder shortcode to the Linode Writer's Formatting guide. It also clarifies preferred usage of example IP addresses, adds examples, and adds IPv6 documentation range.