### PR TITLE
[Release] v1.296.0

### DIFF
--- a/_vendor/github.com/linode/linode-api-docs/v4/openapi.yaml
+++ b/_vendor/github.com/linode/linode-api-docs/v4/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  version: 4.170.0
+  version: 4.170.2
   title: Linode API
   license:
     name: Apache 2.0
@@ -8960,6 +8960,21 @@ paths:
                     will not be performed.
                   example: false
                   default: false
+                type:
+                  type: string
+                  enum:
+                  - warm
+                  - cold
+                  description: |
+                    Type of migration used in moving to a new host or Linode type.
+
+                    `warm`: the Linode will not power down until the migration is complete.
+                    Warm migrations are not available for DC migrations.
+
+                    `cold`: the Linode will be powered down and migrated. When the migration
+                    is complete, the Linode will be powered on.
+                  example: warm
+                  default: cold
       responses:
         '200':
           description: Scheduled migration started
@@ -9451,6 +9466,21 @@ paths:
                     data must fit within the smaller disk size.
                   example: true
                   default: true
+                migration_type:
+                  type: string
+                  enum:
+                  - warm
+                  - cold
+                  description: |
+                    Type of migration used in moving to a new host or Linode type.
+
+                    `warm`: the Linode will not power down until the migration is complete.
+                    Warm migrations are not available for DC migrations.
+
+                    `cold`: the Linode will be powered down and migrated. When the migration
+                    is complete, the Linode will be powered on.
+                  example: warm
+                  default: cold
       responses:
         '200':
           description: Resize started.
@@ -13779,7 +13809,7 @@ paths:
         * A Firewall can be assigned during Linode creation by utilizing the `firewall_id` [Linode Create Request](/docs/api/linode-instances/#linode-create__request-body-schema) property.
 
         * A service can have one active, assigned Firewall at a time.
-        
+
         Additional disabled Firewalls can be assigned to a service, but they cannot be enabled if another active Firewall is already assigned to the same service.
 
         * Firewalls apply to all of a Linode's non-`vlan` purpose Configuration Profile Interfaces.

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -5,4 +5,4 @@
 # github.com/bep/turbo/v7 v7.20300.20000
 # github.com/gohugoio/hugo-mod-jslibs/instantpage v0.5.1
 # github.com/instantpage/instant.page v5.1.1+incompatible
-# github.com/linode/linode-api-docs/v4 v4.170.0
+# github.com/linode/linode-api-docs/v4 v4.170.2

--- a/docs/release-notes/api/v4.170.2.md
+++ b/docs/release-notes/api/v4.170.2.md
@@ -1,0 +1,17 @@
+---
+title: API v4.170.2
+date: 2024-01-12
+version: 4.170.2
+---
+
+### Added
+
+-   **Linode Resize** ([POST /linode/instances/{linodeId}/resize](/docs/api/linode-instances/#linode-resize))
+  - Added `type` property with two values:
+    - `warm`: the Linode remains powered on until the migration is complete.
+    - `cold`: the Linode is powered down and migrated. When the migration is complete, the Linode is powered on.
+
+-   **Linode Migrate** ([POST /linode/instances/{linodeId}/migrate](/docs/api/linode-instances/#dc-migrationpending-host-migration-initiate))
+  - Added `migration_type` property with two values:
+    - `warm`: the Linode remains powered on until the migration is complete.
+    - `cold`: the Linode is powered down and migrated. When the migration is complete, the Linode is powered on.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/hotwired/turbo v7.0.1+incompatible // indirect
-	github.com/linode/linode-api-docs/v4 v4.170.0 // indirect
+	github.com/linode/linode-api-docs/v4 v4.170.2 // indirect
 	github.com/linode/linode-docs-theme v0.0.0-20231206150915-b245bac51c82 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/linode/linode-api-docs/v4 v4.169.1 h1:FSexBWg4XMBnC3mkg94f6tiBg3L4qub
 github.com/linode/linode-api-docs/v4 v4.169.1/go.mod h1:JRT7kOTjArLJngT4KkAnxWNGszYSP+zlQg2OHQ407RI=
 github.com/linode/linode-api-docs/v4 v4.170.0 h1:tec83RXRsvUrmhPO/hMqhHP6pQ1CdjKdefVWsOOXYoQ=
 github.com/linode/linode-api-docs/v4 v4.170.0/go.mod h1:JRT7kOTjArLJngT4KkAnxWNGszYSP+zlQg2OHQ407RI=
+github.com/linode/linode-api-docs/v4 v4.170.2 h1:sinJqcS08nq2EZz0h/1J13zNZYJ3kt9NOUR0YSAkMEQ=
+github.com/linode/linode-api-docs/v4 v4.170.2/go.mod h1:JRT7kOTjArLJngT4KkAnxWNGszYSP+zlQg2OHQ407RI=
 github.com/linode/linode-docs-theme v0.0.0-20220622135843-166f108e1933 h1:QchGQS6xESuyjdlNJEjvq2ftGX0sCTAhPhD5hAOJVMI=
 github.com/linode/linode-docs-theme v0.0.0-20220622135843-166f108e1933/go.mod h1:6kYeZt+rMvJFZ9Wbnm4CDSn8Sg1MuYjr2Kx6W/awiQM=
 github.com/linode/linode-docs-theme v0.0.0-20220718150422-ea48dbf69943 h1:BE3OgPTfmSdYeNUxcC1clIpJZhdMmYByCCCap0njwyY=


### PR DESCRIPTION
API Updates (v4.170.2):
-   **Linode Resize** ([POST /linode/instances/{linodeId}/resize](/docs/api/linode-instances/#linode-resize))
    - Added `type` property with two values:
        - `warm`: the Linode remains powered on until the migration is complete.
        - `cold`: the Linode is powered down and migrated. When the migration is complete, the Linode is powered on.

-   **Linode Migrate** ([POST /linode/instances/{linodeId}/migrate](/docs/api/linode-instances/#dc-migrationpending-host-migration-initiate))
    - Added `migration_type` property with two values:
        - `warm`: the Linode remains powered on until the migration is complete.
        - `cold`: the Linode is powered down and migrated. When the migration is complete, the Linode is powered on.