### PR TITLE
Updated guides for multiple deprecated Marketplace Apps

### DIFF
--- a/docs/guides/email/email-services/using-magicspam-email-authentication/index.md
+++ b/docs/guides/email/email-services/using-magicspam-email-authentication/index.md
@@ -3,7 +3,7 @@ slug: using-magicspam-email-authentication
 description: "Securing your email server with MagicSpam by using country authentication, IP authentication, source based authentication, and other restrictions."
 keywords: ["magicspam", "email authentication", "email server security"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-modified: 2021-12-29
+modified: 2024-01-22
 modified_by:
   name: Linode
 published: 2021-12-29
@@ -24,7 +24,7 @@ After a threat actor has compromised your email account, they can gain access to
 
 As an email end user, the consequences of having your email compromised can be very serious. After learning about your behaviors and relationships, threat actors can impersonate you. They can leverage the trust of your business partners,friends, and family. Influence them to transfer money, divulge private information, or even infect their machines with malware. Subsequently as the email administrator, the problems of your customers are your problems as well. Besides, dealing with angry customers with compromised accounts, the fallout from compromised accounts being used to send outbound spam effects your IP reputation negatively. This in turn creates more angry customers whose emails are rejected for delivery by other email servers and a whole new set of problems.
 
-Let’s learn how MagicSpam helps email administrators to avoid such a negative outcome and secure your email servers. If you do not yet have MagicSpam installed, you can deploy Linode's [MagicSpam Marketplace App](https://www.linode.com/marketplace/apps/magicspam/magicspam/).
+Let’s learn how MagicSpam helps email administrators to avoid such a negative outcome and secure your email servers.
 
 ## Country Authentication Restrictions
 

--- a/docs/guides/game-servers/create-an-ark-server-on-ubuntu/index.md
+++ b/docs/guides/game-servers/create-an-ark-server-on-ubuntu/index.md
@@ -6,7 +6,6 @@ keywords: ["ark survival evolved", "ubuntu", "server"]
 tags: ["ubuntu","game servers"]
 license: '[CC BY-ND 3.0](http://creativecommons.org/licenses/by-nd/3.0/us/)'
 external_resources:
- - '[Deploying an ARK Survival Evolved Server through the Linode Marketplace](/docs/products/tools/marketplace/guides/ark-survival-evolved/)'
  - '[The Official Ark Website](http://www.playark.com/)'
  - '[Dedicated Server Setup on the Official Ark: Survival Evolved Wiki](https://ark.wiki.gg/wiki/Dedicated_server_setup)'
  - '[Console commands on the Official Ark: Survival Evolved Wiki](https://ark.wiki.gg/wiki/Console_commands)'

--- a/docs/guides/game-servers/create-an-ark-server-on-ubuntu/index.md
+++ b/docs/guides/game-servers/create-an-ark-server-on-ubuntu/index.md
@@ -11,7 +11,7 @@ external_resources:
  - '[Dedicated Server Setup on the Official Ark: Survival Evolved Wiki](https://ark.wiki.gg/wiki/Dedicated_server_setup)'
  - '[Console commands on the Official Ark: Survival Evolved Wiki](https://ark.wiki.gg/wiki/Console_commands)'
  - '[Studio Wilpost on Epic Games and Steam crossplay](https://survivetheark.com/index.php?/forums/topic/539019-community-crunch-225-crystal-isles-anniversary-event-epic-games-store-and-more/)'
-modified: 2021-10-18
+modified: 2024-01-22
 modified_by:
   name: Linode
 published: 2016-12-28
@@ -24,11 +24,11 @@ authors: ["Nick Brewer"]
 
 This guide demonstrates how to set up a personal [ARK: Survival Evolved](http://www.playark.com/) server on a Linode Compute Instance running a modern Ubuntu distribution.
 
-{{< note respectIndent=false >}}
-Consider using the Linode Marketplace to quickly and automatically deploy an Ark server on our platform. See [Deploying an ARK Survival Evolved Server through the Linode Marketplace](/docs/products/tools/marketplace/guides/ark-survival-evolved/) for instructions.
-{{< /note >}}
-
 **Supported distributions:** Ubuntu 20.04 and 18.04. Recent non-LTS releases like Ubuntu 21.10, 21.04, and 20.10 should also be supported. Ubuntu 16.04 should still be supported, though that LTS release is no longer receiving free security patches or software updates.
+
+{{< note respectIndent=false title="You will need a PC client for Steam and Epic cross-play" >}}
+There is no cross-play between different platforms (Linux and Xbox, for example). For a PC-based server such as this, you will need the PC client from Steam or Epic Games (see more below about Steam and Epic cross-play).
+{{< /note >}}
 
 ![Create an ARK: Survival Evolved Server on Ubuntu](ark-survival-evolved.png)
 
@@ -39,10 +39,6 @@ Consider using the Linode Marketplace to quickly and automatically deploy an Ark
 1.  Ark will be installed through the Steam *command-line interface* (CLI). See our guide [Install SteamCMD for a Steam Game Server](/docs/guides/install-steamcmd-for-a-steam-game-server/) if you haven't installed Steam already.
 
 1.  To connect to your Ubuntu Ark server, you must have a copy of the [Ark: Survival Evolved](http://www.playark.com/) game client running on a local machine.
-
-{{< note respectIndent=false >}}
-There is no cross-play between different platforms (Linux and Xbox, for example). For a PC-based server such as this, you will need the PC client from Steam or Epic Games (see more below about Steam and Epic cross-play).
-{{< /note >}}
 
 {{< note respectIndent=false >}}
 The steps in this guide require root privileges unless otherwise noted. Be sure to run the steps below as `root` or with the `sudo` prefix. For more information on privileges, see our [Users and Groups](/docs/guides/linux-users-and-groups/) guide.

--- a/docs/products/compute/compute-instances/plans/dedicated-cpu/index.md
+++ b/docs/products/compute/compute-instances/plans/dedicated-cpu/index.md
@@ -75,11 +75,9 @@ In many cases, the CI/CD pipeline can become resource-intensive if many new code
 
 Depending on the intensity of demands they place on your Linode, [game servers](/docs/game-servers/) may benefit from a Dedicated CPU. Modern multiplayer games need to coordinate with a high number of clients, and require syncing entire game worlds for each player. If CPU resources are not available, then players will experience issues like stuttering and lag. Below is a short list of popular games that may benefit from a Dedicated CPU:
 
-- [ARK: Survival Evolved](/docs/products/tools/marketplace/guides/ark-survival-evolved/)
 - [Rust](/docs/products/tools/marketplace/guides/rust/)
 - [Minecraft](/docs/products/tools/marketplace/guides/minecraft/)
 - [CS:GO](/docs/products/tools/marketplace/guides/counter-strike-go/)
-- [Team Fortress 2](/docs/products/tools/marketplace/guides/team-fortress-2/)
 
 ### Audio and Video Transcoding
 

--- a/docs/products/tools/marketplace/guides/_index.md
+++ b/docs/products/tools/marketplace/guides/_index.md
@@ -26,7 +26,6 @@ See the [Marketplace](/docs/marketplace/) listing page for a full list of all Ma
 - [Ant Media Server Enterprise Edition](/docs/products/tools/marketplace/guides/antmediaenterpriseserver/)
 - [Apache Airflow](/docs/products/tools/marketplace/guides/apache-airflow/)
 - [Appwrite](/docs/products/tools/marketplace/guides/appwrite/)
-- [ARK Survival Evolved](/docs/products/tools/marketplace/guides/ark-survival-evolved/)
 - [AzuraCast](/docs/products/tools/marketplace/guides/azuracast/)
 - [BeEF](/docs/products/tools/marketplace/guides/beef/)
 - [Budibase](/docs/products/tools/marketplace/guides/budibase/)

--- a/docs/products/tools/marketplace/guides/_index.md
+++ b/docs/products/tools/marketplace/guides/_index.md
@@ -5,7 +5,7 @@ description: "A collection of guides to help you learn how to deploy each Market
 tab_group_main:
     weight: 30
 aliases: ['/products/tools/marketplace-one-click-apps/guides/']
-modified: 2023-06-26
+modified: 2024-01-22
 ---
 
 ## Basics
@@ -29,7 +29,6 @@ See the [Marketplace](/docs/marketplace/) listing page for a full list of all Ma
 - [ARK Survival Evolved](/docs/products/tools/marketplace/guides/ark-survival-evolved/)
 - [AzuraCast](/docs/products/tools/marketplace/guides/azuracast/)
 - [BeEF](/docs/products/tools/marketplace/guides/beef/)
-- [BitNinja](/docs/products/tools/marketplace/guides/bitninja/)
 - [Budibase](/docs/products/tools/marketplace/guides/budibase/)
 - [Chevereto](/docs/products/tools/marketplace/guides/chevereto/)
 - [Cloudron](/docs/products/tools/marketplace/guides/cloudron/)
@@ -68,13 +67,11 @@ See the [Marketplace](/docs/marketplace/) listing page for a full list of all Ma
 - [LEMP Stack](/docs/products/tools/marketplace/guides/lemp-stack/)
 - [LiteSpeed cPanel](/docs/products/tools/marketplace/guides/litespeed-cpanel/)
 - [LiveSwitch](/docs/products/tools/marketplace/guides/liveswitch/)
-- [MagicSpam](/docs/products/tools/marketplace/guides/magicspam/)
 - [Mastodon](/docs/products/tools/marketplace/guides/mastodon/)
 - [MEAN Stack](/docs/products/tools/marketplace/guides/mean-stack/)
 - [MERN Stack](/docs/products/tools/marketplace/guides/mern-stack/)
 - [Microweber](/docs/products/tools/marketplace/guides/microweber)
 - [Minecraft ](/docs/products/tools/marketplace/guides/minecraft/)
-- [Mist.io](/docs/products/tools/marketplace/guides/mistio/)
 - [Moodle](/docs/products/tools/marketplace/guides/moodle/)
 - [MySQL/MariaDB](/docs/products/tools/marketplace/guides/mysql/)
 - [Nextcloud](/docs/products/tools/marketplace/guides/nextcloud/)
@@ -91,7 +88,6 @@ See the [Marketplace](/docs/marketplace/) listing page for a full list of all Ma
 - [Owncloud Server](/docs/products/tools/marketplace/guides/owncloud/)
 - [Passky](/docs/products/tools/marketplace/guides/passky/)
 - [Peppermint](/docs/products/tools/marketplace/guides/peppermint/)
-- [Percona Monitoring and Management (PMM)](/docs/products/tools/marketplace/guides/percona-monitoring-management/)
 - [phpMyAdmin](/docs/products/tools/marketplace/guides/phpmyadmin/)
 - [Pi-hole](/docs/products/tools/marketplace/guides/pihole/)
 - [Plesk](/docs/products/tools/marketplace/guides/plesk/)
@@ -109,14 +105,12 @@ See the [Marketplace](/docs/marketplace/) listing page for a full list of all Ma
 - [Ruby on Rails](/docs/products/tools/marketplace/guides/ruby-on-rails/)
 - [Rust](/docs/products/tools/marketplace/guides/rust/)
 - [Saltcorn](/docs/products/tools/marketplace/guides/saltcorn/)
-- [Seatable](/docs/products/tools/marketplace/guides/seatable/)
+- [SeaTable](/docs/products/tools/marketplace/guides/seatable/)
 - [Secure Your Server](/docs/products/tools/marketplace/guides/secure-your-server/)
 - [ServerWand](/docs/products/tools/marketplace/guides/serverwand/)
 - [Shadowsocks](/docs/products/tools/marketplace/guides/shadowsocks/)
 - [Splunk](/docs/products/tools/marketplace/guides/splunk/)
 - [Superinsight](/docs/products/tools/marketplace/guides/superinsight/)
-- [Team Fortress 2](/docs/products/tools/marketplace/guides/team-fortress-2/)
-- [Terraria](/docs/products/tools/marketplace/guides/terraria/)
 - [Uptime Kuma](/docs/products/tools/marketplace/guides/uptime-kuma/)
 - [UTunnel VPN](/docs/products/tools/marketplace/guides/utunnel/)
 - [Valheim](/docs/products/tools/marketplace/guides/valheim/)

--- a/docs/products/tools/marketplace/guides/ark-survival-evolved/index.md
+++ b/docs/products/tools/marketplace/guides/ark-survival-evolved/index.md
@@ -18,7 +18,7 @@ deprecated: true
 
 ---
 {{< note type="warning" title="This app is no longer available for deployment" >}}
-ARK: Survival Evolved is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only. For information on how to deploy and set up ARK: Survival Evolved manually on a Compute Instance, see our [Creating a Dedicated ARK Server on Ubuntu](/docs/guides/create-an-ark-server-on-ubuntu) guide.
+ARK: Survival Evolved has been removed from the App Marketplace and can no longer be deployed. This guide has been retained for reference only. For information on how to deploy and set up ARK: Survival Evolved manually on a Compute Instance, see our [Creating a Dedicated ARK Server on Ubuntu](/docs/guides/create-an-ark-server-on-ubuntu) guide.
 {{< /note >}}
 
 [ARK: Survival Evolved](http://playark.com/ark-survival-evolved/) is a multiplayer action-survival game released in 2017. The game places you on a series of fictional islands inhabited by dinosaurs and other prehistoric animals. In ARK, the main objective is to survive. ARK is an ongoing battle where animals and other players have the ability to destroy you. To survive, you must build structures, farm resources, breed dinosaurs, and even set up trading hubs with neighboring tribes.

--- a/docs/products/tools/marketplace/guides/ark-survival-evolved/index.md
+++ b/docs/products/tools/marketplace/guides/ark-survival-evolved/index.md
@@ -2,7 +2,7 @@
 description: "Deploy a ARK: Survival Evolved Server on Linode using Marketplace Apps."
 keywords: ['ark','survival evolved','marketplace apps', 'server']
 published: 2019-04-03
-modified: 2022-05-17
+modified: 2024-01-22
 modified_by:
   name: Linode
 title: "Deploy an ARK Survival Evolved Server through the Linode Marketplace"
@@ -11,7 +11,15 @@ external_resources:
 tags: ["linode platform","marketplace","cloud-manager"]
 aliases: ['/platform/marketplace/deploying-ark-survival-evolved-with-marketplace-apps/', '/platform/one-click/deploying-ark-survival-evolved-with-one-click-apps/','/guides/deploying-ark-survival-evolved-with-one-click-apps/','/guides/deploying-ark-survival-evolved-with-marketplace-apps/','/guides/ark-survival-evolved-marketplace-app/']
 authors: ["Linode"]
+_build:
+  list: false
+noindex: true
+deprecated: true
+
 ---
+{{< note type="warning" title="This app is no longer available for deployment" >}}
+ARK: Survival Evolved is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only. For information on how to deploy and set up ARK: Survival Evolved manually on a Compute Instance, see our [Creating a Dedicated ARK Server on Ubuntu](/docs/guides/create-an-ark-server-on-ubuntu) guide.
+{{< /note >}}
 
 [ARK: Survival Evolved](http://playark.com/ark-survival-evolved/) is a multiplayer action-survival game released in 2017. The game places you on a series of fictional islands inhabited by dinosaurs and other prehistoric animals. In ARK, the main objective is to survive. ARK is an ongoing battle where animals and other players have the ability to destroy you. To survive, you must build structures, farm resources, breed dinosaurs, and even set up trading hubs with neighboring tribes.
 

--- a/docs/products/tools/marketplace/guides/bitninja/index.md
+++ b/docs/products/tools/marketplace/guides/bitninja/index.md
@@ -3,7 +3,7 @@ description: "Deploy BitNinja on a Linode Compute Instance. This provides you wi
 keywords: ['spam','security','waf']
 tags: ["marketplace", "linode platform", "cloud manager"]
 published: 2021-11-12
-modified: 2022-05-17
+modified: 2024-01-22
 modified_by:
   name: Linode
 title: "Deploy BitNinja through the Linode Marketplace"
@@ -11,7 +11,15 @@ external_resources:
 - '[BitNinja](https://bitninja.com/)'
 aliases: ['/guides/deploying-bitninja-marketplace-app/','/guides/bitninja-marketplace-app/']
 authors: ["Linode"]
+_build:
+  list: false
+noindex: true
+deprecated: true
+
 ---
+{{< note type="warning" title="This app is no longer available for deployment" >}}
+BitNinja is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only.
+{{< /note >}}
 
 [BitNinja](https://bitninja.com/) is a general purpose security-as-a-service server defense tool powered by a social defense system and many active defense modules. Its main purpose is to protect your server against hackers, botnets, attackers, and malicious activities, all with less effort and maintenance on your part. All BitNinja servers form a huge honey farm to collect and analyze attacks from different botnets and then use this knowledge to intelligently adapt to new threats.
 

--- a/docs/products/tools/marketplace/guides/bitninja/index.md
+++ b/docs/products/tools/marketplace/guides/bitninja/index.md
@@ -18,8 +18,9 @@ deprecated: true
 
 ---
 {{< note type="warning" title="This app is no longer available for deployment" >}}
-BitNinja is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only.
+BitNinja has been removed from the App Marketplace and can no longer be deployed. This guide has been retained for reference only.
 {{< /note >}}
+
 
 [BitNinja](https://bitninja.com/) is a general purpose security-as-a-service server defense tool powered by a social defense system and many active defense modules. Its main purpose is to protect your server against hackers, botnets, attackers, and malicious activities, all with less effort and maintenance on your part. All BitNinja servers form a huge honey farm to collect and analyze attacks from different botnets and then use this knowledge to intelligently adapt to new threats.
 

--- a/docs/products/tools/marketplace/guides/magicspam/index.md
+++ b/docs/products/tools/marketplace/guides/magicspam/index.md
@@ -3,7 +3,7 @@ description: "This guide shows you how to install and configure MagicSpam, a pow
 keywords: ['cPanel','Plesk','Email','Spam']
 tags: ["marketplace", "linode platform", "cloud manager"]
 published: 2021-08-13
-modified: 2022-03-08
+modified: 2024-01-22
 modified_by:
   name: Linode
 title: "Deploy MagicSpam through the Linode Marketplace"
@@ -11,7 +11,15 @@ aliases: ['/guides/deploying-magicspam-marketplace-app/','/guides/magicspam-mark
 external_resources:
 - '[MagicSpam](https://magicspam.com/)'
 authors: ["Linode"]
+_build:
+  list: false
+noindex: true
+deprecated: true
+
 ---
+{{< note type="warning" title="This app is no longer available for deployment" >}}
+MagicSpam is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only. For information on how to configure MagicSpam, see our [Using MagicSpam to Secure your Email Server](/docs/guides/using-magicspam-email-authentication) guide.
+{{< /note >}}
 
 [MagicSpam](https://magicspam.com/) is a powerful anti-spam and email security solution for Linux systems. It integrates directly with popular control panels, such as cPanel and Plesk. It's primary function is to stop inbound spam from entering your server right at the SMTP layer, which lowers bandwidth and overhead. It also secure mailboxes on your server from being compromised and used to send outbound spam.
 

--- a/docs/products/tools/marketplace/guides/magicspam/index.md
+++ b/docs/products/tools/marketplace/guides/magicspam/index.md
@@ -18,7 +18,7 @@ deprecated: true
 
 ---
 {{< note type="warning" title="This app is no longer available for deployment" >}}
-MagicSpam is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only. For information on how to configure MagicSpam, see our [Using MagicSpam to Secure your Email Server](/docs/guides/using-magicspam-email-authentication) guide.
+MagicSpam has been removed from the App Marketplace and can no longer be deployed. This guide has been retained for reference only. For information on how to configure MagicSpam, see our [Using MagicSpam to Secure your Email Server](/docs/guides/using-magicspam-email-authentication) guide.
 {{< /note >}}
 
 [MagicSpam](https://magicspam.com/) is a powerful anti-spam and email security solution for Linux systems. It integrates directly with popular control panels, such as cPanel and Plesk. It's primary function is to stop inbound spam from entering your server right at the SMTP layer, which lowers bandwidth and overhead. It also secure mailboxes on your server from being compromised and used to send outbound spam.

--- a/docs/products/tools/marketplace/guides/mistio/index.md
+++ b/docs/products/tools/marketplace/guides/mistio/index.md
@@ -18,7 +18,7 @@ deprecated: true
 
 ---
 {{< note type="warning" title="This app is no longer available for deployment" >}}
-Mist.io is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only.
+Mist.io has been removed from the App Marketplace and can no longer be deployed. This guide has been retained for reference only.
 {{< /note >}}
 
 [Mist.io](https://mist.io/) is an open source, multi-cloud management platform. Mist supports all popular infrastructure technologies including public clouds, private clouds, hypervisors, containers, and bare metal servers. It provides a unified interface for performing common management tasks like provisioning, orchestration, monitoring, automation, and cost analysis. It also comes with a RESTful API so you can easily integrate it in your existing workflows.

--- a/docs/products/tools/marketplace/guides/mistio/index.md
+++ b/docs/products/tools/marketplace/guides/mistio/index.md
@@ -3,7 +3,7 @@ description: "This guide shows how you can deploy Mist.io, an open-source, multi
 keywords: [ 'mist.io', 'marketplace', 'server']
 tags: ["cloud-manager", "linode platform", "marketplace"]
 published: 2020-03-18
-modified: 2022-03-08
+modified: 2024-01-22
 modified_by:
   name: Linode
 title: "Deploy Mist.io through the Linode Marketplace"
@@ -11,7 +11,15 @@ external_resources:
 - '[Mist.io Official](https://mist.io/)'
 aliases: ['/platform/marketplace/deploy-mistio-with-marketplace-apps/', '/platform/one-click/deploy-mistio-with-one-click-apps/','/guides/deploy-mistio-with-one-click-apps/','/guides/deploy-mistio-with-marketplace-apps/','/guides/mistio-marketplace-app/']
 authors: ["Linode"]
+_build:
+  list: false
+noindex: true
+deprecated: true
+
 ---
+{{< note type="warning" title="This app is no longer available for deployment" >}}
+Mist.io is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only.
+{{< /note >}}
 
 [Mist.io](https://mist.io/) is an open source, multi-cloud management platform. Mist supports all popular infrastructure technologies including public clouds, private clouds, hypervisors, containers, and bare metal servers. It provides a unified interface for performing common management tasks like provisioning, orchestration, monitoring, automation, and cost analysis. It also comes with a RESTful API so you can easily integrate it in your existing workflows.
 

--- a/docs/products/tools/marketplace/guides/percona-monitoring-management/index.md
+++ b/docs/products/tools/marketplace/guides/percona-monitoring-management/index.md
@@ -3,14 +3,22 @@ description: "Learn how to deploy Percona Monitoring & Management with Marketpla
 keywords: ['percona','marketplace apps','monitoring', 'database']
 tags: ["database","monitoring","cloud-manager","linode platform","marketplace"]
 published: 2020-06-11
-modified: 2022-03-08
+modified: 2024-01-22
 modified_by:
   name: Linode
 title: "Deploy Percona Monitoring and Management (PMM) through the Linode Marketplace"
 image: 'deploy-percona-marketplace.png'
 aliases: ['/platform/marketplace/how-to-deploy-percona-monitoring-management-with-marketplace-apps/', '/platform/one-click/how-to-deploy-percona-monitoring-management-with-one-click-apps/','/guides/how-to-deploy-percona-monitoring-management-with-one-click-apps/','/guides/how-to-deploy-percona-monitoring-management-with-marketplace-apps/','/guides/percona-marketplace-app/']
 authors: ["Linode"]
+_build:
+  list: false
+noindex: true
+deprecated: true
+
 ---
+{{< note type="warning" title="This app is no longer available for deployment" >}}
+Percona Monitorning and Management is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only.
+{{< /note >}}
 
 Percona Monitoring and Management (PMM) is an open-source tool which provides a GUI powered by [Grafana](https://grafana.com/) for monitoring and managing MySQL, MariaDB, PostgreSQL, and MongoDB databases. You can use PMM to easily observe important metrics, logging, and statistics related to your databases and the hosts they run on. Additionally, it includes a number of tools which can help to optimize your database's performance, manage all database instances, and track and identify potential security threats. Linode's Percona (PMM) Marketplace App deploys a Linode with PMM installed and ready for you to begin monitoring your databases.
 

--- a/docs/products/tools/marketplace/guides/percona-monitoring-management/index.md
+++ b/docs/products/tools/marketplace/guides/percona-monitoring-management/index.md
@@ -17,7 +17,7 @@ deprecated: true
 
 ---
 {{< note type="warning" title="This app is no longer available for deployment" >}}
-Percona Monitorning and Management is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only.
+Percona Monitoring and Management has been removed from the App Marketplace and can no longer be deployed. This guide has been retained for reference only.
 {{< /note >}}
 
 Percona Monitoring and Management (PMM) is an open-source tool which provides a GUI powered by [Grafana](https://grafana.com/) for monitoring and managing MySQL, MariaDB, PostgreSQL, and MongoDB databases. You can use PMM to easily observe important metrics, logging, and statistics related to your databases and the hosts they run on. Additionally, it includes a number of tools which can help to optimize your database's performance, manage all database instances, and track and identify potential security threats. Linode's Percona (PMM) Marketplace App deploys a Linode with PMM installed and ready for you to begin monitoring your databases.

--- a/docs/products/tools/marketplace/guides/team-fortress-2/index.md
+++ b/docs/products/tools/marketplace/guides/team-fortress-2/index.md
@@ -2,14 +2,22 @@
 description: "This guide provides you with instructions for deploying Team Fortress 2, a team-based multiplayer first-person shooter game, on a Linode using the Marketplace Apps."
 keywords: ['team fortress','marketplace', 'tf2', 'server']
 published: 2019-04-04
-modified: 2022-03-08
+modified: 2024-01-22
 modified_by:
   name: Linode
 title: "Deploy a Team Fortress 2 Server through the Linode Marketplace"
 tags: ["linode platform","marketplace","cloud-manager"]
 aliases: ['/platform/marketplace/deploying-team-fortress-2-with-marketplace-apps/', '/platform/one-click/deploying-team-fortress-2-with-one-click-apps/','/guides/deploying-team-fortress-2-with-one-click-apps/','/guides/deploying-team-fortress-2-with-marketplace-apps/','/guides/team-fortress-2-marketplace-app/']
 authors: ["Linode"]
+_build:
+  list: false
+noindex: true
+deprecated: true
+
 ---
+{{< note type="warning" title="This app is no longer available for deployment" >}}
+Team Fortress 2 is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only. For information on how to deploy and set up Team Fortress 2 manually on a Compute Instance, see our [Team Fortress 2 on Debian and Ubuntu](/docs/guides/team-fortress2-on-debian-and-ubuntu/) guide.
+{{< /note >}}
 
 Team Fortress 2 (TF2) is a team-based multiplayer first-person shooter game. In TF2, you and your team choose from 9 unique classes and play against an enemy team in a variety of game modes. These modes include capture the flag, king of the hill, and even a battle pitting your team against a robotic horde.
 

--- a/docs/products/tools/marketplace/guides/team-fortress-2/index.md
+++ b/docs/products/tools/marketplace/guides/team-fortress-2/index.md
@@ -16,7 +16,7 @@ deprecated: true
 
 ---
 {{< note type="warning" title="This app is no longer available for deployment" >}}
-Team Fortress 2 is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only. For information on how to deploy and set up Team Fortress 2 manually on a Compute Instance, see our [Team Fortress 2 on Debian and Ubuntu](/docs/guides/team-fortress2-on-debian-and-ubuntu/) guide.
+Team Fortress 2 has been removed from the App Marketplace and can no longer be deployed. This guide has been retained for reference only. For information on how to deploy and set up Team Fortress 2 manually on a Compute Instance, see our [Team Fortress 2 on Debian and Ubuntu](/docs/guides/team-fortress2-on-debian-and-ubuntu/) guide.
 {{< /note >}}
 
 Team Fortress 2 (TF2) is a team-based multiplayer first-person shooter game. In TF2, you and your team choose from 9 unique classes and play against an enemy team in a variety of game modes. These modes include capture the flag, king of the hill, and even a battle pitting your team against a robotic horde.

--- a/docs/products/tools/marketplace/guides/terraria/index.md
+++ b/docs/products/tools/marketplace/guides/terraria/index.md
@@ -18,7 +18,7 @@ deprecated: true
 
 ---
 {{< note type="warning" title="This app is no longer available for deployment" >}}
-Terraria is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only. For information on how to deploy and set up Terraria manually on a Compute Instance, see our [How to Setup a Terraria Linux Server](/docs/guides/host-a-terraria-server-on-your-linode/) guide.
+Terraria has been removed from the App Marketplace and can no longer be deployed. This guide has been retained for reference only. For information on how to deploy and set up Terraria manually on a Compute Instance, see our [How to Setup a Terraria Linux Server](/docs/guides/host-a-terraria-server-on-your-linode/) guide.
 {{< /note >}}
 
 Terraria is a two-dimensional sandbox game in which players explore the world, collect resources, build structures, and battle enemies in procedurally generated environments. In Terraria a player begins by digging for ore, and the further they dig the more adventure they find. Multiplayer mode can be either cooperative or PvP.

--- a/docs/products/tools/marketplace/guides/terraria/index.md
+++ b/docs/products/tools/marketplace/guides/terraria/index.md
@@ -2,7 +2,7 @@
 description: "This guide provides you with step-by-step instructions for deploying the two-dimensional sandbox survival game, Terraria, on a Linode using the One-Click Marketplace App."
 keywords: ['terraria','marketplace app', 'game server']
 published: 2019-04-05
-modified: 2022-05-10
+modified: 2024-01-22
 modified_by:
   name: Linode
 title: "Deploy Terraria through the Linode Marketplace"
@@ -11,7 +11,15 @@ external_resources:
 tags: ["linode platform","marketplace","cloud-manager"]
 aliases: ['/platform/marketplace/deploying-terraria-with-marketplace-apps/', '/platform/one-click/deploying-terraria-with-one-click-apps/','/guides/deploying-terraria-with-one-click-apps/','/guides/deploying-terraria-with-marketplace-apps/','/guides/terraria-marketplace-app/']
 authors: ["Linode"]
+_build:
+  list: false
+noindex: true
+deprecated: true
+
 ---
+{{< note type="warning" title="This app is no longer available for deployment" >}}
+Terraria is no longer a deployable app in the App Marketplace, and this guide is for referential purposes only. For information on how to deploy and set up Terraria manually on a Compute Instance, see our [How to Setup a Terraria Linux Server](/docs/guides/host-a-terraria-server-on-your-linode/) guide.
+{{< /note >}}
 
 Terraria is a two-dimensional sandbox game in which players explore the world, collect resources, build structures, and battle enemies in procedurally generated environments. In Terraria a player begins by digging for ore, and the further they dig the more adventure they find. Multiplayer mode can be either cooperative or PvP.
 


### PR DESCRIPTION
Updated the following guides for Marketplace App deprecation:
- Deploy Terraria through the Linode Marketplace (deprecated)
- Deploy a Team Fortress 2 Server through the Linode Marketplace (deprecated)
- Deploy an ARK Survival Evolved Server through the Linode Marketplace (deprecated)
- Creating a Dedicated ARK Server on Ubuntu: Removed note pointing to Marketplace deployment guide; updated cross-play note
- Deploy MagicSpam through the Linode Marketplace (deprecated)
- Using MagicSpam to Secure your Email Server: Removed text pointing to Marketplace deployment guide
- Deploy BitNinja through the Linode Marketplace (deprecated)
- Deploy Percona Monitoring and Management (PMM) through the Linode Marketplace (deprecated)
- Deploy Mist.io through the Linode Marketplace (deprecated)


