### PR TITLE
[Update] Install and Configure the Linode CLI

### DIFF
--- a/docs/products/tools/cli/guides/install/index.md
+++ b/docs/products/tools/cli/guides/install/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Install and Configure the Linode CLI"
 description: "Learn how to install the Linode CLI on most common operating systems"
-modified: 2023-06-27
+modified: 2024-01-26
 authors: ["Linode"]
 ---
 
@@ -23,6 +23,13 @@ The [Linode CLI](https://github.com/linode/linode-cli) is officially managed thr
     ```command
     pip3 install linode-cli --upgrade
     ```
+
+    If you receive an error like the one in the output below, you will need to add your Python's bin folder to your system PATH environment variable. Instructions for adding a directory to PATH vary for each operating system.
+
+    ```output
+    WARNING: The script normalizer is installed in '/Users/{{< placeholder "USERNAME" >}}/Library/Python/3.9/bin' which is not on PATH.
+    Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+    ``````
 
 1.  Install the boto library if you intend to interact with Linode's Object Storage service.
 


### PR DESCRIPTION
If a user installs the Linode CLI through pip3 on a fresh macOS instance (and perhaps other operating systems), they may receive a warning that their system's Python bin directory isn't in their PATH environment variable. If the user takes no action and proceeds to run a `linode-cli` command, the command won't be found. To overcome this, they'll need to update PATH. Instructions for doing this vary, so none are provided at this time.