### PR TITLE
Updated LKE 1.63.0 rel notes with new fix

### DIFF
--- a/docs/release-notes/lke/v1.63.0.md
+++ b/docs/release-notes/lke/v1.63.0.md
@@ -14,4 +14,4 @@ version: 1.63.0
 
 ### Fixed
 
-- CVE-2024-21626 has been mitigated for newly created LKE nodes. If you have an existing LKE, you need to recycle it to apply the mitigation.
+- [CVE-2024-21626](https://github.com/advisories/GHSA-xr7r-f8xq-vfvv) has been mitigated for newly created LKE nodes. If you have an existing LKE, you need to recycle it to apply the mitigation.

--- a/docs/release-notes/lke/v1.63.0.md
+++ b/docs/release-notes/lke/v1.63.0.md
@@ -7,10 +7,10 @@ version: 1.63.0
 ### Changed
 
 - Upgraded clusters using Kubernetes:
-  - 1.26 to patch version [1.26.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#v12613)
-  - 1.27 to patch version [1.27.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v12710)
-  - 1.28 to patch version [1.28.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1286)
-- Upgraded CSI driver to [v0.6.3](https://github.com/linode/linode-blockstorage-csi-driver/releases/tag/v0.6.3)
+  - 1.26 to patch version [1.26.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#v12613).
+  - 1.27 to patch version [1.27.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v12710).
+  - 1.28 to patch version [1.28.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1286).
+- Upgraded CSI driver to [v0.6.3](https://github.com/linode/linode-blockstorage-csi-driver/releases/tag/v0.6.3).
 - Upgraded LKE kernel version from v5.15 to [v6.1](https://kernelnewbies.org/Linux_6.1) for new LKE nodes.
 
 ### Fixed

--- a/docs/release-notes/lke/v1.63.0.md
+++ b/docs/release-notes/lke/v1.63.0.md
@@ -11,6 +11,7 @@ version: 1.63.0
   - 1.27 to patch version [1.27.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v12710)
   - 1.28 to patch version [1.28.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1286)
 - Upgraded CSI driver to [v0.6.3](https://github.com/linode/linode-blockstorage-csi-driver/releases/tag/v0.6.3)
+- Upgraded LKE kernel version from v5.15 to [v6.1](https://kernelnewbies.org/Linux_6.1) for new LKE nodes.
 
 ### Fixed
 

--- a/docs/release-notes/lke/v1.63.0.md
+++ b/docs/release-notes/lke/v1.63.0.md
@@ -11,3 +11,7 @@ version: 1.63.0
   - 1.27 to patch version [1.27.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v12710)
   - 1.28 to patch version [1.28.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1286)
 - Upgraded CSI driver to [v0.6.3](https://github.com/linode/linode-blockstorage-csi-driver/releases/tag/v0.6.3)
+
+### Fixed
+
+- CVE-2024-21626 has been mitigated for newly created LKE nodes. If you have an existing LKE, you need to recycle it to apply the mitigation.

--- a/docs/release-notes/lke/v1.63.0.md
+++ b/docs/release-notes/lke/v1.63.0.md
@@ -14,4 +14,4 @@ version: 1.63.0
 
 ### Fixed
 
-- [CVE-2024-21626](https://github.com/advisories/GHSA-xr7r-f8xq-vfvv) has been mitigated for newly created LKE nodes. If you have an existing LKE, you need to recycle it to apply the mitigation.
+- [CVE-2024-21626](https://github.com/advisories/GHSA-xr7r-f8xq-vfvv) has been mitigated for newly created LKE nodes. If you have an existing LKE node, you need to recycle it to apply the mitigation.


### PR DESCRIPTION
* Upgraded kernel version to 6.1 for new LKE nodes.
* Fix added to address CVE-2024-21626. 