### PR TITLE
Updated support to Kubernetes 1.29.2

### DIFF
--- a/docs/release-notes/lke/v1.67.0.md
+++ b/docs/release-notes/lke/v1.67.0.md
@@ -6,4 +6,4 @@ version: 1.67.0
 
 ### Added
 
-- Kubernetes 1.29 support ([changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md)).
+- Kubernetes 1.29.2 support ([changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#v1292)).


### PR DESCRIPTION
Per @gaughan, we now support 1.29.2. Updated the 1.67 changelog.