### PR TITLE
[Release] v1.318.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ To Install the latest Node.js LTS release on Windows, navigate to the [downloads
 
 ### Install Hugo
 
-The Linode documentation library is built using [Hugo](http://gohugo.io), an open-source static site generator. In order to preview your guide before submission, you need to install Hugo on your local computer. This site currently uses **Hugo v0.116.1**. To remain consistent in the testing and development process, it's recommended to install this version instead of using a newer version.
+The Linode documentation library is built using [Hugo](http://gohugo.io), an open-source static site generator. In order to preview your guide before submission, you need to install Hugo on your local computer. This site currently uses **Hugo v0.125.3**. To remain consistent in the testing and development process, it's recommended to install this version instead of using a newer version.
 
 Note: If you observe any issues on a newer version, please [file an issue](https://github.com/linode/docs/issues) in the docs GitHub repository.
 
@@ -78,10 +78,10 @@ Note: If you observe any issues on a newer version, please [file an issue](https
 
 To install Hugo, download the appropriate binary for your system, extract it, and move it to a directory within your PATH.
 
-1.  Download the file below that corresponds with the OS and platform on your local system. If you don't see your system on this list, you can find additional files on the [Hugo v0.116.1 GitHub release page](https://github.com/gohugoio/hugo/releases/tag/v0.116.1) under **Assets**.
+1.  Download the file below that corresponds with the OS and platform on your local system. If you don't see your system on this list, you can find additional files on the [Hugo v0.125.3 GitHub release page](https://github.com/gohugoio/hugo/releases/tag/v0.125.3) under **Assets**.
 
-    - **macOS:** https://github.com/gohugoio/hugo/releases/download/v0.116.1/hugo_extended_0.116.1_darwin-universal.tar.gz
-    - **Linux:** https://github.com/gohugoio/hugo/releases/download/v0.116.1/hugo_extended_0.116.1_Linux-64bit.tar.gz
+    - **macOS:** https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_darwin-universal.tar.gz
+    - **Linux:** https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_Linux-64bit.tar.gz
 
     You can download this file through a terminal using the curl command, replacing [url] with the URL for your platform:
 
@@ -115,7 +115,7 @@ To install Hugo, download the appropriate binary for your system, extract it, an
 
 While macOS and Linux are preferred by most of the core Linode Docs team, it's also possible to use Hugo on Windows.
 
-1.  Download the [hugo_extended_0.116.1_windows-amd64.zip](https://github.com/gohugoio/hugo/releases/download/v0.116.1/hugo_extended_0.116.1_windows-amd64.zip) file. Additional files for other operating systems can be found on the [Hugo v0.116.1 GitHub release page](https://github.com/gohugoio/hugo/releases/tag/v0.116.1) under **Assets**.
+1.  Download the [hugo_extended_0.125.3_windows-amd64.zip](https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_windows-amd64.zip) file. Additional files for other operating systems can be found on the [Hugo v0.125.3 GitHub release page](https://github.com/gohugoio/hugo/releases/tag/v0.125.3) under **Assets**.
 
 1.  Extract the file to the directory you'd like to install Hugo under, such as `C:\Hugo\bin`.
 
@@ -184,10 +184,10 @@ For more information about using Git, refer to the [official Git documentation](
 
 This section is only relevant to contributors who have previously worked on the docs repo prior to the Tailwind v3 upgrade (which occurred on July 6th, 2023 in docs release v1.252.0). After you merge in changes from this release (and onward), you will likely notice display issues when previewing the site locally. This is due to Tailwind v3 and the way it integrates with Hugo (and our theme). To complete the upgrade locally and fix any display issues, follow the steps below.
 
-1.  Upgrade Hugo to v0.116.1. On macOS, run the following commands in a temporary folder (not in your docs repo):
+1.  Upgrade Hugo to v0.125.3. On macOS, run the following commands in a temporary folder (not in your docs repo):
 
-        curl -OL https://github.com/gohugoio/hugo/releases/download/v0.116.1/hugo_extended_0.116.1_darwin-universal.tar.gz
-        tar -xvzf hugo_extended_0.116.1_darwin-universal.tar.gz
+        curl -OL https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_darwin-universal.tar.gz
+        tar -xvzf hugo_extended_0.125.3_darwin-universal.tar.gz
         mv hugo /usr/local/bin
 
     If you are using a different operating system, refer to the [Install Hugo](#install-hugo) section above.

--- a/_vendor/github.com/linode/linode-docs-theme/content/testpages/_index.md
+++ b/_vendor/github.com/linode/linode-docs-theme/content/testpages/_index.md
@@ -10,7 +10,7 @@ layout  = "content-only"
     [cascade._target]
         environment = "production"
     [cascade._build]
-        render           = "always"
+        render           = "never"
         list             = "never"
         publishResources = false
 +++

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/get-sections-meta.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/get-sections-meta.html
@@ -13,7 +13,7 @@
     {{- end -}}
   {{- end -}}
   {{- $objectID := (printf "%s" (replace .SectionsPath "/" " > ")) -}}
-  {{- $objectID =  $objectID | strings.TrimRight " >" -}}
+  {{- $objectID =  strings.Trim $objectID " >" -}}
   {{- $ordinal := 0 }}
   {{- with .Params.tab_group_main -}}
     {{/* This is set in products pages. */}}

--- a/_vendor/github.com/linode/linode-website-partials/footer.html
+++ b/_vendor/github.com/linode/linode-website-partials/footer.html
@@ -65,13 +65,7 @@
                 <a class="o-menu__link" href="https://www.linode.com/partners/"><span class="o-menu__title">Partners</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/company/careers/"><span class="o-menu__title">Careers</span></a>
-              </li>
-              <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/accessibility/"><span class="o-menu__title">Accessibility Commitment</span></a>
-              </li>
-              <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/company/press/"><span class="o-menu__title">Press Center</span></a>
               </li>
               <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/legal/"><span class="o-menu__title">Legal Center</span></a>
@@ -138,12 +132,6 @@
                 <a class="o-menu__link" href="https://www.linode.com/partners/"><span class="o-menu__title">Partners</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/company/press/"><span class="o-menu__title">Press Center</span></a>
-              </li>
-              <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/company/careers/"><span class="o-menu__title">Careers</span></a>
-              </li>
-              <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/legal/"><span class="o-menu__title">Legal</span></a>
               </li>
             </ul>
@@ -203,7 +191,7 @@
                 <a class="o-menu__link" href="https://www.linode.com/products/nodebalancers/"><span class="o-menu__title">NodeBalancers</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/products/private-networking/"><span class="o-menu__title">Private Networking</span></a>
+                <a class="o-menu__link" href="https://www.linode.com/products/vlan/"><span class="o-menu__title">VLAN</span></a>
               </li>
               <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/products/managed/"><span class="o-menu__title">Managed</span></a>
@@ -248,9 +236,6 @@
               </li>
               <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/managed-hosting-industry-solutions/"><span class="o-menu__title">Managed Hosting</span></a>
-              </li>
-              <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/managed-service-providers-industry-solutions/"><span class="o-menu__title">Managed Service Providers</span></a>
               </li>
               <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/video-streaming-solutions/"><span class="o-menu__title">Media</span></a>

--- a/_vendor/github.com/linode/linode-website-partials/header.html
+++ b/_vendor/github.com/linode/linode-website-partials/header.html
@@ -125,7 +125,7 @@
                 <a class="o-menu__link" href="https://www.linode.com/company/contact/"><span class="o-menu__title">Sales</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/company/careers/"><span class="o-menu__title">Careers</span></a>
+                <a class="o-menu__link" href="https://www.akamai.com/careers"><span class="o-menu__title">Careers</span></a>
               </li>
               <li class="o-menu__item">
                 <a class="o-menu__link" href="https://login.linode.com/login"><span class="o-menu__title">Log In</span></a>
@@ -313,7 +313,7 @@
                     <a class="o-menu__link" href="https://www.linode.com/products/nodebalancers/"><span class="o-menu__title">NodeBalancers</span></a>
                   </li>
                   <li class="o-menu__item">
-                    <a class="o-menu__link" href="https://www.linode.com/products/private-networking/"><span class="o-menu__title">Private Networking</span></a>
+                    <a class="o-menu__link" href="https://www.linode.com/products/vlan/"><span class="o-menu__title">VLAN</span></a>
                   </li>
                 </ul>
               </li>
@@ -413,9 +413,6 @@
                 <a class="o-menu__link" href="https://www.linode.com/managed-hosting-industry-solutions/"><span class="o-menu__title">Managed Hosting</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/managed-service-providers-industry-solutions/"><span class="o-menu__title">Managed Service Providers</span></a>
-              </li>
-              <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/video-streaming-solutions/"><span class="o-menu__title">Media</span></a>
               </li>
               <li class="o-menu__item">
@@ -499,10 +496,10 @@
                 <a class="o-menu__link" href="https://www.linode.com/company/about/"><span class="o-menu__title">About Us</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/company/press/"><span class="o-menu__title">Press Center</span></a>
+                <a class="o-menu__link" href="https://www.akamai.com/newsroom"><span class="o-menu__title">Newsroom</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/company/careers/"><span class="o-menu__title">Careers</span></a>
+                <a class="o-menu__link" href="https://www.akamai.com/careers"><span class="o-menu__title">Careers</span></a>
               </li>
               <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/legal/"><span class="o-menu__title">Legal</span></a>
@@ -732,7 +729,7 @@
                 <a class="o-menu__link" href="https://www.linode.com/products/nodebalancers/"><span class="o-menu__title">NodeBalancers</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/products/private-networking/"><span class="o-menu__title">Private Networking</span></a>
+                <a class="o-menu__link" href="https://www.linode.com/products/vlan/"><span class="o-menu__title">VLAN</span></a>
               </li>
             </ul>
           </nav>
@@ -873,9 +870,6 @@
                 <a class="o-menu__link" href="https://www.linode.com/managed-hosting-industry-solutions/"><span class="o-menu__title">Managed Hosting</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/managed-service-providers-industry-solutions/"><span class="o-menu__title">Managed Service Providers</span></a>
-              </li>
-              <li class="o-menu__item">
                 <a class="o-menu__link" href="https://www.linode.com/video-streaming-solutions/"><span class="o-menu__title">Media</span></a>
               </li>
               <li class="o-menu__item">
@@ -983,7 +977,7 @@
                 <a class="o-menu__link" href="https://www.linode.com/newsletter/"><span class="o-menu__title">Newsletter</span></a>
               </li>
               <li class="o-menu__item">
-                <a class="o-menu__link" href="https://www.linode.com/company/press/"><span class="o-menu__title">Press Center</span></a>
+                <a class="o-menu__link" href="https://www.akamai.com/newsroom"><span class="o-menu__title">Newsroom</span></a>
               </li>
               <li class="o-menu__item">
                 <a class="o-menu__link" href="https://partner-directory.linode.com/s/"><span class="o-menu__title">Find a Partner</span></a>

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,5 +1,5 @@
-# github.com/linode/linode-docs-theme v0.0.0-20240423165854-a2056513af25
-# github.com/linode/linode-website-partials v0.0.0-20240130163753-4a933fe77633
+# github.com/linode/linode-docs-theme v0.0.0-20240425164245-4aab9abf83f1
+# github.com/linode/linode-website-partials v0.0.0-20240424162657-dcb8464d17f3
 # github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.401.201
 # github.com/gohugoio/hugo-mod-jslibs/turbo/v7 v7.20300.20000
 # github.com/bep/turbo/v7 v7.20300.20000

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/hotwired/turbo v7.0.1+incompatible // indirect
 	github.com/linode/linode-api-docs/v4 v4.174.0 // indirect
-	github.com/linode/linode-docs-theme v0.0.0-20240423165854-a2056513af25 // indirect
+	github.com/linode/linode-docs-theme v0.0.0-20240425164245-4aab9abf83f1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/linode/linode-docs-theme v0.0.0-20240423162135-fcca3a0c8c89 h1:Q6uC3V
 github.com/linode/linode-docs-theme v0.0.0-20240423162135-fcca3a0c8c89/go.mod h1:pLFUnAD7hJW1C2wheL3HqtWIN6Xy0kywHHf33YyfUTI=
 github.com/linode/linode-docs-theme v0.0.0-20240423165854-a2056513af25 h1:XlGFuVQ3GighmP/S5CoLe09wbdPYYOUk9TmeTBZff4U=
 github.com/linode/linode-docs-theme v0.0.0-20240423165854-a2056513af25/go.mod h1:pLFUnAD7hJW1C2wheL3HqtWIN6Xy0kywHHf33YyfUTI=
+github.com/linode/linode-docs-theme v0.0.0-20240425164245-4aab9abf83f1 h1:rlOaJDaQDquw8LbE25+N18CeBI6fogH2e8pCofrYUsQ=
+github.com/linode/linode-docs-theme v0.0.0-20240425164245-4aab9abf83f1/go.mod h1:erpdkuemfqHLfK1HAJ2bOYgdgh0cOSSsazZ7p5qcc+U=
 github.com/linode/linode-website-partials v0.0.0-20221205205120-b6ea1aaa59fb/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
 github.com/linode/linode-website-partials v0.0.0-20221222200538-99862e429110/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
 github.com/linode/linode-website-partials v0.0.0-20230201145731-a8703d0a954a/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
@@ -274,3 +276,4 @@ github.com/linode/linode-website-partials v0.0.0-20230927181556-032071c7cd50/go.
 github.com/linode/linode-website-partials v0.0.0-20231004150321-3d3e65b490df/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
 github.com/linode/linode-website-partials v0.0.0-20231027173434-abbc557a5519/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
 github.com/linode/linode-website-partials v0.0.0-20240130163753-4a933fe77633/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
+github.com/linode/linode-website-partials v0.0.0-20240424162657-dcb8464d17f3/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,11 @@ publish = "public"
 command = "hugo version && hugo config && hugo --gc --minify -d public/docs;"
 
 [context.production.environment]
-HUGO_VERSION = "0.116.1"
+HUGO_VERSION = "0.125.3"
 HUGO_PARAMS_TESTENV="Netlify"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.116.1"
+HUGO_VERSION = "0.125.3"
 HUGO_PARAMS_TESTENV="Netlify"
 
 [[plugins]]


### PR DESCRIPTION
Theme updates:
- Compatibility fix for new Hugo version + Algolia search backend
- Hide some test typography pages in production
- Update header/footer
- Update to Hugo 0.125.3 in netlify config and contributing.md