### PR TITLE
[Release] v1.320.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ To Install the latest Node.js LTS release on Windows, navigate to the [downloads
 
 ### Install Hugo
 
-The Linode documentation library is built using [Hugo](http://gohugo.io), an open-source static site generator. In order to preview your guide before submission, you need to install Hugo on your local computer. This site currently uses **Hugo v0.125.3**. To remain consistent in the testing and development process, it's recommended to install this version instead of using a newer version.
+The Linode documentation library is built using [Hugo](http://gohugo.io), an open-source static site generator. In order to preview your guide before submission, you need to install Hugo on your local computer. This site currently uses **Hugo v0.116.1**. To remain consistent in the testing and development process, it's recommended to install this version instead of using a newer version.
 
 Note: If you observe any issues on a newer version, please [file an issue](https://github.com/linode/docs/issues) in the docs GitHub repository.
 
@@ -78,10 +78,10 @@ Note: If you observe any issues on a newer version, please [file an issue](https
 
 To install Hugo, download the appropriate binary for your system, extract it, and move it to a directory within your PATH.
 
-1.  Download the file below that corresponds with the OS and platform on your local system. If you don't see your system on this list, you can find additional files on the [Hugo v0.125.3 GitHub release page](https://github.com/gohugoio/hugo/releases/tag/v0.125.3) under **Assets**.
+1.  Download the file below that corresponds with the OS and platform on your local system. If you don't see your system on this list, you can find additional files on the [Hugo v0.116.1 GitHub release page](https://github.com/gohugoio/hugo/releases/tag/v0.116.1) under **Assets**.
 
-    - **macOS:** https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_darwin-universal.tar.gz
-    - **Linux:** https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_Linux-64bit.tar.gz
+    - **macOS:** https://github.com/gohugoio/hugo/releases/download/v0.116.1/hugo_extended_0.116.1_darwin-universal.tar.gz
+    - **Linux:** https://github.com/gohugoio/hugo/releases/download/v0.116.1/hugo_extended_0.116.1_Linux-64bit.tar.gz
 
     You can download this file through a terminal using the curl command, replacing [url] with the URL for your platform:
 
@@ -115,7 +115,7 @@ To install Hugo, download the appropriate binary for your system, extract it, an
 
 While macOS and Linux are preferred by most of the core Linode Docs team, it's also possible to use Hugo on Windows.
 
-1.  Download the [hugo_extended_0.125.3_windows-amd64.zip](https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_windows-amd64.zip) file. Additional files for other operating systems can be found on the [Hugo v0.125.3 GitHub release page](https://github.com/gohugoio/hugo/releases/tag/v0.125.3) under **Assets**.
+1.  Download the [hugo_extended_0.116.1_windows-amd64.zip](https://github.com/gohugoio/hugo/releases/download/v0.116.1/hugo_extended_0.116.1_windows-amd64.zip) file. Additional files for other operating systems can be found on the [Hugo v0.116.1 GitHub release page](https://github.com/gohugoio/hugo/releases/tag/v0.116.1) under **Assets**.
 
 1.  Extract the file to the directory you'd like to install Hugo under, such as `C:\Hugo\bin`.
 
@@ -184,10 +184,10 @@ For more information about using Git, refer to the [official Git documentation](
 
 This section is only relevant to contributors who have previously worked on the docs repo prior to the Tailwind v3 upgrade (which occurred on July 6th, 2023 in docs release v1.252.0). After you merge in changes from this release (and onward), you will likely notice display issues when previewing the site locally. This is due to Tailwind v3 and the way it integrates with Hugo (and our theme). To complete the upgrade locally and fix any display issues, follow the steps below.
 
-1.  Upgrade Hugo to v0.125.3. On macOS, run the following commands in a temporary folder (not in your docs repo):
+1.  Upgrade Hugo to v0.116.1. On macOS, run the following commands in a temporary folder (not in your docs repo):
 
-        curl -OL https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_darwin-universal.tar.gz
-        tar -xvzf hugo_extended_0.125.3_darwin-universal.tar.gz
+        curl -OL https://github.com/gohugoio/hugo/releases/download/v0.116.1/hugo_extended_0.116.1_darwin-universal.tar.gz
+        tar -xvzf hugo_extended_0.116.1_darwin-universal.tar.gz
         mv hugo /usr/local/bin
 
     If you are using a different operating system, refer to the [Install Hugo](#install-hugo) section above.

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/components/render-svg.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/components/render-svg.html
@@ -52,6 +52,7 @@
   <button
     type="button"
     {{ with .onclick }}@click.prevent.stop="{{ . }}"{{ end }}
+    @dblclick.prevent.stop=""
     class="{{ $rstyles }} relative inline-flex items-center bg-white px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10">
     <span class="sr-only">{{ .sronly }}</span>
     {{ with .iconhref }}

--- a/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/get-sections-meta.html
+++ b/_vendor/github.com/linode/linode-docs-theme/layouts/partials/sections/search/get-sections-meta.html
@@ -13,7 +13,7 @@
     {{- end -}}
   {{- end -}}
   {{- $objectID := (printf "%s" (replace .SectionsPath "/" " > ")) -}}
-  {{- $objectID =  strings.Trim $objectID " >" -}}
+  {{- $objectID =  $objectID | strings.TrimRight " >" -}}
   {{- $ordinal := 0 }}
   {{- with .Params.tab_group_main -}}
     {{/* This is set in products pages. */}}

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/linode/linode-docs-theme v0.0.0-20240429150342-36d65b1de62a
+# github.com/linode/linode-docs-theme v0.0.0-20240503183507-a183b1963316
 # github.com/linode/linode-website-partials v0.0.0-20240426140442-12b76ccbfefd
 # github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.401.201
 # github.com/gohugoio/hugo-mod-jslibs/turbo/v7 v7.20300.20000

--- a/docs/products/_index.md
+++ b/docs/products/_index.md
@@ -13,7 +13,7 @@ layout = "tabbed-section-layout"
 [cascade._target]
 # The section rendering for individual product pages uses the tabbed layout
 kind = "section"
-path = "/products/*/**"
+path = "/products/*/*/**"
 +++
 
  <!--more-->

--- a/docs/reference-architecture/_index.md
+++ b/docs/reference-architecture/_index.md
@@ -9,7 +9,7 @@ keywordsAlgolia = ["reference architecture"]
 [[cascade]]
 layout = "tabbed-section-layout"
 [cascade._target]
-path = "/reference-architecture/**"
+path = "/reference-architecture/*/**"
 +++
 
  <!--more-->

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/hotwired/turbo v7.0.1+incompatible // indirect
 	github.com/linode/linode-api-docs/v4 v4.175.0 // indirect
-	github.com/linode/linode-docs-theme v0.0.0-20240429150342-36d65b1de62a // indirect
+	github.com/linode/linode-docs-theme v0.0.0-20240503183507-a183b1963316 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,10 @@ github.com/linode/linode-docs-theme v0.0.0-20240425164245-4aab9abf83f1 h1:rlOaJD
 github.com/linode/linode-docs-theme v0.0.0-20240425164245-4aab9abf83f1/go.mod h1:erpdkuemfqHLfK1HAJ2bOYgdgh0cOSSsazZ7p5qcc+U=
 github.com/linode/linode-docs-theme v0.0.0-20240429150342-36d65b1de62a h1:xzyoqFvTImRXO92gOKRfweSLrmplOHlgHhXDgZvfavk=
 github.com/linode/linode-docs-theme v0.0.0-20240429150342-36d65b1de62a/go.mod h1:4bKPhuT/oYHgkQNryyd/F9NF5z98jBf19PYmSnDlUdM=
+github.com/linode/linode-docs-theme v0.0.0-20240503183252-c77f4f3e7a33 h1:xPjk1tDvP+aQ+Eivg2/3Fxnj1YZpaTZxVxhG6sdkn80=
+github.com/linode/linode-docs-theme v0.0.0-20240503183252-c77f4f3e7a33/go.mod h1:4bKPhuT/oYHgkQNryyd/F9NF5z98jBf19PYmSnDlUdM=
+github.com/linode/linode-docs-theme v0.0.0-20240503183507-a183b1963316 h1:cF+xtZZDuROvuLhY8de5Fa/fGdGkvNDOpeYT8Wby3NU=
+github.com/linode/linode-docs-theme v0.0.0-20240503183507-a183b1963316/go.mod h1:4bKPhuT/oYHgkQNryyd/F9NF5z98jBf19PYmSnDlUdM=
 github.com/linode/linode-website-partials v0.0.0-20221205205120-b6ea1aaa59fb/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
 github.com/linode/linode-website-partials v0.0.0-20221222200538-99862e429110/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=
 github.com/linode/linode-website-partials v0.0.0-20230201145731-a8703d0a954a/go.mod h1:K1Em3lwb16JiCwNVftAFwWGhyB9Zkl/nXhxjBBUC1Ao=

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,11 @@ publish = "public"
 command = "hugo version && hugo config && hugo --gc --minify -d public/docs;"
 
 [context.production.environment]
-HUGO_VERSION = "0.125.3"
+HUGO_VERSION = "0.116.1"
 HUGO_PARAMS_TESTENV="Netlify"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.125.3"
+HUGO_VERSION = "0.116.1"
 HUGO_PARAMS_TESTENV="Netlify"
 
 [[plugins]]


### PR DESCRIPTION
Theme updates:
- Revert theme update for Hugo 0.125.3 upgrade
- Revert contributing.md, netlify.toml, and section page configurations for Hugo 0.125.3 upgrade
- Fix for double-click recognizer interacting with pan/zoom buttons on SVG diagrams