### PR TITLE
Use `mariadb` client instead of `mysql` in `docs/guides/how-to-install-mariadb-on-debian-10`

### DIFF
--- a/docs/guides/databases/mariadb/how-to-install-mariadb-on-debian-10/index.md
+++ b/docs/guides/databases/mariadb/how-to-install-mariadb-on-debian-10/index.md
@@ -55,13 +55,13 @@ Allowing unrestricted access to MariaDB on a public IP not advised but you may c
 
 ### MariaDB Client
 
-The standard tool for interacting with MariaDB is the `mariadb` client, which installs with the `mariadb-server` package. The MariaDB client is used through a terminal using the `mysql` command.
+The standard tool for interacting with MariaDB is the `mariadb` client, which installs with the `mariadb-server` package. The MariaDB client is used through a terminal using the `mariadb` command.
 
 ### Root Login
 
 1.  Log into MariaDB as the root user:
 
-        sudo mysql -u root -p
+        sudo mariadb -u root -p
 
 1.  When prompted for login credentials, hit enter. By default MariaDB will authenticate you via the **unix_socket plugin** and credentials are not required.
 
@@ -131,7 +131,7 @@ You will be given the choice to change the MariaDB root password, remove anonymo
 
 1.  Login to the database again. This time, if you set a password above, enter it at the prompt.
 
-        sudo mysql -u root -p
+        sudo mariadb -u root -p
 
 1. In the example below, `testdb` is the name of the database, `testuser` is the user, and `password` is the user's password. You should replace `password` with a secure password:
 
@@ -152,7 +152,7 @@ You will be given the choice to change the MariaDB root password, remove anonymo
 
 1.  Log back in as `testuser`, entering the password when prompted:
 
-        sudo mysql -u testuser -p
+        sudo mariadb -u testuser -p
 
 1.  Create a sample table called `customers`:
 
@@ -215,7 +215,7 @@ If you forget your root MariaDB password, it can be reset.
 
 1.  Login to the MariaDB server with the root account, this time without supplying a password:
 
-        sudo mysql -u root
+        sudo mariadb -u root
 
 1.  Use the following commands to reset root's password. Replace `password` with a strong password:
 
@@ -238,4 +238,4 @@ If you forget your root MariaDB password, it can be reset.
 
 1.  You should now be able to log into the database with your new root password:
 
-        sudo mysql -u root -p
+        sudo mariadb -u root -p

--- a/docs/guides/databases/mariadb/how-to-install-mariadb-on-debian-10/index.md
+++ b/docs/guides/databases/mariadb/how-to-install-mariadb-on-debian-10/index.md
@@ -6,6 +6,7 @@ description: "Want to replace MySQL? Read through this guide, which explains how
 authors: ["Ryan Syracuse"]
 contributors: ["Ryan Syracuse"]
 published: 2020-01-31
+modified: 2024-05-16
 keywords: ["mariadb", "Debian 10", "debian", "database", "mysql"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/databases/mariadb/how-to-install-mariadb-on-debian-10/','/databases/mariadb/mariadb-setup-debian-10/']
@@ -55,7 +56,7 @@ Allowing unrestricted access to MariaDB on a public IP not advised but you may c
 
 ### MariaDB Client
 
-The standard tool for interacting with MariaDB is the `mariadb` client, which installs with the `mariadb-server` package. The MariaDB client is used through a terminal using the `mariadb` command.
+The standard tool for interacting with MariaDB is the `mariadb` client, which installs with the `mariadb-server` package. The MariaDB client is used through a terminal using the `mariadb` command. Review the official [MariaDB Command-Line Client](https://mariadb.com/kb/en/mariadb-command-line-client/) guide for more details on this command.
 
 ### Root Login
 


### PR DESCRIPTION
## Reason for the change

- To align with the usage of `mariadb` client as it used by the official MariaDB website.
- This change helps remove confusion by using consistent terminology throughout the documentation.

## What Official MariaDB says?

Please [`check this article`](https://mariadb.com/docs/server/connect/clients/mariadb-client/#Client_10.3_and_Older) as it said:
```
Modern versions of MariaDB Client use client binary filename of mariadb

For MariaDB Client 10.3 and older, the client binary filename was mysql rather than mariadb.
```

Note that the LTS version of MariaDB is `10.11`!

## Testing

- I checked the page manually and confirmed it looks great