### PR TITLE
Fix tab formatting in Longview guides

### DIFF
--- a/docs/products/tools/longview/get-started/index.md
+++ b/docs/products/tools/longview/get-started/index.md
@@ -84,7 +84,7 @@ If the [automatic installation](#automatic-installation) instructions failed, yo
 1. Add a configuration file to store the repository information for the Longview agent:
 
     {{< tabs >}}
-    {{% tab "Debian and Ubuntu" %}}
+    {{< tab "Debian and Ubuntu" >}}
 Find the codename of the distribution running on your Linode.
 
 ```command
@@ -100,8 +100,8 @@ Using the text editor of your choice, like [nano](/docs/guides/use-nano-to-edit-
 ```file {title="/etc/apt/sources.list.d/longview.list" lang="config"}
 deb http://apt-longview.linode.com/ stretch main
 ```
-    {{% /tab %}}
-    {{% tab "CentOS" %}}
+    {{< /tab >}}
+    {{< tab "CentOS" >}}
 Using the text editor of your choice, like [nano](/docs/guides/use-nano-to-edit-files-in-linux/), create a `.repo` file and copy the contents of the example file below. Replace `REV` in the repository URL with your CentOS version (e.g., 7). If unsure, you can find your CentOS version number with `cat /etc/redhat-release`.
 
 ```file {title="/etc/yum.repos.d/longview.repo" lang="config"}
@@ -111,24 +111,24 @@ baseurl=https://yum-longview.linode.com/centos/REV/noarch/
 enabled=1
 gpgcheck=1
 ```
-    {{% /tab %}}
+    {{< /tab >}}
     {{< /tabs >}}
 
 1. Download the repository's GPG key and import or move it to the correct location:
 
     {{< tabs >}}
-    {{% tab "Debian and Ubuntu" %}}
+    {{< tab "Debian and Ubuntu" >}}
 ```command
 sudo curl -O https://apt-longview.linode.com/linode.gpg
 sudo mv linode.gpg /etc/apt/trusted.gpg.d/linode.gpg
 ```
-    {{% /tab %}}
-    {{% tab "CentOS" %}}
+    {{< /tab >}}
+    {{< tab "CentOS" >}}
 ```command
 sudo curl -O https://yum-longview.linode.com/linode.key
 sudo rpm --import linode.key
 ```
-    {{% /tab %}}
+    {{< /tab >}}
     {{< /tabs >}}
 
 1. Create a directory for the API key:
@@ -146,17 +146,17 @@ sudo rpm --import linode.key
 1. Install Longview:
 
     {{< tabs >}}
-    {{% tab "Debian and Ubuntu" %}}
+    {{< tab "Debian and Ubuntu" >}}
 ```command
 sudo apt update
 sudo apt install linode-longview
 ```
-    {{% /tab %}}
-    {{% tab "CentOS" %}}
+    {{< /tab >}}
+    {{< tab "CentOS" >}}
 ```command
 sudo yum install linode-longview
 ```
-    {{% /tab %}}
+    {{< /tab >}}
     {{< /tabs >}}
 
 ## Start the Longview Agent {#start-agent}
@@ -170,7 +170,7 @@ sudo systemctl status longview
 You should see a similar output:
 
 {{< tabs >}}
-{{% tab "Debian and Ubuntu" %}}
+{{< tab "Debian and Ubuntu" >}}
 ```output
 ● longview.service - LSB: Longview Monitoring Agent
 Loaded: loaded (/etc/init.d/longview; generated; vendor preset: enabled)
@@ -181,8 +181,8 @@ Process: 2997 ExecStart=/etc/init.d/longview start (code=exited, status=0/SUCCES
 CGroup: /system.slice/longview.service
         └─3001 linode-longview
 ```
-{{% /tab %}}
-{{% tab "CentOS" %}}
+{{< /tab >}}
+{{< tab "CentOS" >}}
 ```output
 ● longview.service - SYSV: Longview statistics gathering
   Loaded: loaded (/etc/rc.d/init.d/longview; bad; vendor preset: disabled)
@@ -195,7 +195,7 @@ Dec 10 22:35:11 203-0-113-0.ip.linodeusercontent.com systemd[1]: Starting SYSV: 
 Dec 10 22:35:11 203-0-113-0.ip.linodeusercontent.com longview[12198]: Starting longview: [  OK  ]
 Dec 10 22:35:11 203-0-113-0.ip.linodeusercontent.com systemd[1]: Started SYSV: Longview statistics gathering.
 ```
-{{% /tab %}}
+{{< /tab >}}
 {{< /tabs >}}
 
 If the Longview agent is not running, start it with the following command:

--- a/docs/products/tools/longview/get-started/index.md
+++ b/docs/products/tools/longview/get-started/index.md
@@ -85,32 +85,32 @@ If the [automatic installation](#automatic-installation) instructions failed, yo
 
     {{< tabs >}}
     {{< tab "Debian and Ubuntu" >}}
-Find the codename of the distribution running on your Linode.
+    Find the codename of the distribution running on your Linode.
 
-```command
-root@localhost:~# lsb_release -sc
-```
+    ```command
+    root@localhost:~# lsb_release -sc
+    ```
 
-```output
-stretch
-```
+    ```output
+    stretch
+    ```
 
-Using the text editor of your choice, like [nano](/docs/guides/use-nano-to-edit-files-in-linux/), create a custom sources file that includes Longview's Debian repository and the Debian distribution codename. In the command below, replace *stretch* with the output of the previous step.
+    Using the text editor of your choice, like [nano](/docs/guides/use-nano-to-edit-files-in-linux/), create a custom sources file that includes Longview's Debian repository and the Debian distribution codename. In the command below, replace *stretch* with the output of the previous step.
 
-```file {title="/etc/apt/sources.list.d/longview.list" lang="config"}
-deb http://apt-longview.linode.com/ stretch main
-```
+    ```file {title="/etc/apt/sources.list.d/longview.list" lang="config"}
+    deb http://apt-longview.linode.com/ stretch main
+    ```
     {{< /tab >}}
     {{< tab "CentOS" >}}
-Using the text editor of your choice, like [nano](/docs/guides/use-nano-to-edit-files-in-linux/), create a `.repo` file and copy the contents of the example file below. Replace `REV` in the repository URL with your CentOS version (e.g., 7). If unsure, you can find your CentOS version number with `cat /etc/redhat-release`.
+    Using the text editor of your choice, like [nano](/docs/guides/use-nano-to-edit-files-in-linux/), create a `.repo` file and copy the contents of the example file below. Replace `REV` in the repository URL with your CentOS version (e.g., 7). If unsure, you can find your CentOS version number with `cat /etc/redhat-release`.
 
-```file {title="/etc/yum.repos.d/longview.repo" lang="config"}
-[longview]
-name=Longview Repo
-baseurl=https://yum-longview.linode.com/centos/REV/noarch/
-enabled=1
-gpgcheck=1
-```
+    ```file {title="/etc/yum.repos.d/longview.repo" lang="config"}
+    [longview]
+    name=Longview Repo
+    baseurl=https://yum-longview.linode.com/centos/REV/noarch/
+    enabled=1
+    gpgcheck=1
+    ```
     {{< /tab >}}
     {{< /tabs >}}
 
@@ -118,16 +118,16 @@ gpgcheck=1
 
     {{< tabs >}}
     {{< tab "Debian and Ubuntu" >}}
-```command
-sudo curl -O https://apt-longview.linode.com/linode.gpg
-sudo mv linode.gpg /etc/apt/trusted.gpg.d/linode.gpg
-```
+    ```command
+    sudo curl -O https://apt-longview.linode.com/linode.gpg
+    sudo mv linode.gpg /etc/apt/trusted.gpg.d/linode.gpg
+    ```
     {{< /tab >}}
     {{< tab "CentOS" >}}
-```command
-sudo curl -O https://yum-longview.linode.com/linode.key
-sudo rpm --import linode.key
-```
+    ```command
+    sudo curl -O https://yum-longview.linode.com/linode.key
+    sudo rpm --import linode.key
+    ```
     {{< /tab >}}
     {{< /tabs >}}
 
@@ -147,15 +147,15 @@ sudo rpm --import linode.key
 
     {{< tabs >}}
     {{< tab "Debian and Ubuntu" >}}
-```command
-sudo apt update
-sudo apt install linode-longview
-```
+    ```command
+    sudo apt update
+    sudo apt install linode-longview
+    ```
     {{< /tab >}}
     {{< tab "CentOS" >}}
-```command
-sudo yum install linode-longview
-```
+    ```command
+    sudo yum install linode-longview
+    ```
     {{< /tab >}}
     {{< /tabs >}}
 

--- a/docs/products/tools/longview/guides/apache/index.md
+++ b/docs/products/tools/longview/guides/apache/index.md
@@ -75,21 +75,21 @@ To enable the Apache Longview integration manually, follow these steps on your s
 
     {{< tabs >}}
     {{< tab "Debian and Ubuntu" >}}
-```command
-sudo a2enmod status
-```
+    ```command
+    sudo a2enmod status
+    ```
     {{< /tab >}}
     {{< tab "CentOS" >}}
-```command
-sudo yum install links
-httpd -M | grep status
-```
+    ```command
+    sudo yum install links
+    httpd -M | grep status
+    ```
 
-The output should be similar to:
+    The output should be similar to:
 
-```output
-status_module (shared)
-```
+    ```output
+    status_module (shared)
+    ```
     {{< /tab >}}
     {{< /tabs >}}
 
@@ -119,14 +119,14 @@ status_module (shared)
 
     {{< tabs >}}
     {{< tab "Debian and Ubuntu" >}}
-```command
-sudo systemctl restart apache2
-```
+    ```command
+    sudo systemctl restart apache2
+    ```
     {{< /tab >}}
     {{< tab "CentOS" >}}
-```command
-sudo systemctl restart httpd
-```
+    ```command
+    sudo systemctl restart httpd
+    ```
     {{< /tab >}}
     {{< /tabs >}}
 

--- a/docs/products/tools/longview/guides/apache/index.md
+++ b/docs/products/tools/longview/guides/apache/index.md
@@ -74,12 +74,12 @@ To enable the Apache Longview integration manually, follow these steps on your s
 1.  Verify that **mod\_status** is enabled for Apache (it should be by default). For more information, see the [Apache Module mod\_status](https://httpd.apache.org/docs/2.4/mod/mod_status.html) documentation.
 
     {{< tabs >}}
-    {{% tab "Debian and Ubuntu" %}}
+    {{< tab "Debian and Ubuntu" >}}
 ```command
 sudo a2enmod status
 ```
-    {{% /tab %}}
-    {{% tab "CentOS" %}}
+    {{< /tab >}}
+    {{< tab "CentOS" >}}
 ```command
 sudo yum install links
 httpd -M | grep status
@@ -90,7 +90,7 @@ The output should be similar to:
 ```output
 status_module (shared)
 ```
-    {{% /tab %}}
+    {{< /tab >}}
     {{< /tabs >}}
 
 1.  Update your Apache configuration file to include the block in the example file below. Depending on your Linux distribution and version, your Apache configuration file may be stored in one of the following locations:
@@ -118,16 +118,16 @@ status_module (shared)
 1.  Restart Apache:
 
     {{< tabs >}}
-    {{% tab "Debian and Ubuntu" %}}
+    {{< tab "Debian and Ubuntu" >}}
 ```command
 sudo systemctl restart apache2
 ```
-    {{% /tab %}}
-    {{% tab "CentOS" %}}
+    {{< /tab >}}
+    {{< tab "CentOS" >}}
 ```command
 sudo systemctl restart httpd
 ```
-    {{% /tab %}}
+    {{< /tab >}}
     {{< /tabs >}}
 
 1.  Restart Longview:
@@ -348,16 +348,16 @@ ExtendedStatus On
 When you've finished modifying the configuration file, restart Apache:
 
 {{< tabs >}}
-{{% tab "Debian and Ubuntu" %}}
+{{< tab "Debian and Ubuntu" >}}
 ```command
 sudo systemctl restart apache2
 ```
-{{% /tab %}}
-{{% tab "CentOS" %}}
+{{< /tab >}}
+{{< tab "CentOS" >}}
 ```command
 sudo systemctl restart httpd
 ```
-{{% /tab %}}
+{{< /tab >}}
 {{< /tabs >}}
 
 ### Apache Tab is Missing

--- a/docs/products/tools/longview/guides/manage/index.md
+++ b/docs/products/tools/longview/guides/manage/index.md
@@ -45,19 +45,19 @@ To start capturing metrics for one of your Compute Instances (or other Linux sys
 5.  Uninstall the Longview Agent by removing the `linode-longview` package.
 
     {{< tabs >}}
-    {{% tab "Debian and Ubuntu" %}}
+    {{< tab "Debian and Ubuntu" >}}
 ```command
 sudo apt-get remove linode-longview
 ```
-    {{% /tab %}}
-    {{% tab "CentOS" %}}
+    {{< /tab >}}
+    {{< tab "CentOS" >}}
 ```command
 sudo yum remove linode-longview
 ```
-    {{% /tab %}}
-    {{% tab "Other Distributions" %}}
+    {{< /tab >}}
+    {{< tab "Other Distributions" >}}
 ```command
 sudo rm -rf /opt/linode/longview
 ```
-    {{% /tab %}}
+    {{< /tab >}}
     {{< /tabs >}}

--- a/docs/products/tools/longview/guides/manage/index.md
+++ b/docs/products/tools/longview/guides/manage/index.md
@@ -46,18 +46,18 @@ To start capturing metrics for one of your Compute Instances (or other Linux sys
 
     {{< tabs >}}
     {{< tab "Debian and Ubuntu" >}}
-```command
-sudo apt-get remove linode-longview
-```
+    ```command
+    sudo apt-get remove linode-longview
+    ```
     {{< /tab >}}
     {{< tab "CentOS" >}}
-```command
-sudo yum remove linode-longview
-```
+    ```command
+    sudo yum remove linode-longview
+    ```
     {{< /tab >}}
     {{< tab "Other Distributions" >}}
-```command
-sudo rm -rf /opt/linode/longview
-```
+    ```command
+    sudo rm -rf /opt/linode/longview
+    ```
     {{< /tab >}}
     {{< /tabs >}}


### PR DESCRIPTION
This PR fixes an display issue introduced in the latest Hugo upgrade (based on looking at recent Netlify previews). The issue only affected some Longview pages as they were one of the first to introduce tab functionality and used an older syntax.

- [Live site](https://www.linode.com/docs/products/tools/longview/get-started/#start-agent) (broken formatting)
- [Netlify preview](https://deploy-preview-6967--nostalgic-ptolemy-b01ab8.netlify.app/docs/products/tools/longview/get-started/#start-agent) (fixed formatting)