### PR TITLE
Added vale substitution warning for variations of "log into" -> "log in to" 

### DIFF
--- a/ci/vale/styles/Linode/SubstitutionWarning.yml
+++ b/ci/vale/styles/Linode/SubstitutionWarning.yml
@@ -21,3 +21,7 @@ swap:
   info: information
   repo: repository
   whitelist(?:ed|ing)?: allowlist
+  "[Ll]ogin to": log in to
+  "[Ll]og into": log in to
+  "[Ll]ogged into": logged in to
+  "[Ll]ogging into": logging in to

--- a/docs/guides/applications/configuration-management/puppet/getting-started-with-puppet-6-1-basic-installation-and-setup/index.md
+++ b/docs/guides/applications/configuration-management/puppet/getting-started-with-puppet-6-1-basic-installation-and-setup/index.md
@@ -490,7 +490,7 @@ Notice: Finished catalog run in 0.02 seconds
 
 ### Edit SSH Settings
 
-Although a new limited user has successfully been added to the Puppet master, it is still possible to login to the system as root. To properly secure your system, root access should be disabled.
+Although a new limited user has successfully been added to the Puppet master, it is still possible to log in to the system as root. To properly secure your system, root access should be disabled.
 
 {{< note >}}
 Because you are now logged in to the Puppet master as a limited user, you will need to execute commands and edit files with the user's sudo privileges.

--- a/docs/products/compute/compute-instances/faqs/_index.md
+++ b/docs/products/compute/compute-instances/faqs/_index.md
@@ -11,7 +11,7 @@ aliases: ['/beginners-guide/','/platform/linode-beginners-guide/','/platform/bil
 
 If you're relatively new to Linux system administration, or just new to our platform, this guide will help address some of the most common questions we receive. If you've just created your first Linode account, please first refer to our [Creating a Compute Instance](/docs/products/compute/compute-instances/guides/create/) guide and return here once your Compute Instance has been deployed.
 
-## How do I log into my Compute Instance?
+## How do I log in to my Compute Instance?
 
 All Compute Instances can be accessed through [Lish](/docs/products/compute/compute-instances/guides/lish/) and [SSH](/docs/guides/connect-to-server-over-ssh/) (if properly configured). Both methods provide you with command line access to your system. You can learn more about connecting to your Linode for the first time in the [connecting to your Linode with SSH](/docs/products/compute/compute-instances/guides/set-up-and-secure/#connect-to-the-instance) section of our [Setting Up and Securing a Compute Instance](/docs/products/compute/compute-instances/guides/set-up-and-secure/) guide.
 

--- a/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
+++ b/docs/products/compute/compute-instances/guides/rescue-and-rebuild/index.md
@@ -263,7 +263,7 @@ If you would like to mount or unmount additional disks on your system, repeat th
 
 ### Change Root
 
-*Changing root* is the process of changing your working root directory. When you change root (abbreviated as *chroot*) to your root disk, you are able to run commands as though you are logged into that system.
+*Changing root* is the process of changing your working root directory. When you change root (abbreviated as *chroot*) to your root disk, you are able to run commands as though you are logged in to that system.
 
 Chroot allows you to change user passwords, remove/install packages, and do other system maintenance and recovery tasks in your Compute Instance's normal Linux environment.
 

--- a/docs/products/compute/compute-instances/guides/set-up-and-secure/index.md
+++ b/docs/products/compute/compute-instances/guides/set-up-and-secure/index.md
@@ -510,7 +510,7 @@ Lastly, edit the SSH configuration file to disallow root login and disable passw
 
 ### Use Fail2Ban for SSH Login Protection
 
-[*Fail2Ban*](http://www.fail2ban.org/wiki/index.php/Main_Page) is an application that bans IP addresses from logging into your server after too many failed login attempts. Since legitimate logins usually take no more than three tries to succeed (and with SSH keys, no more than one), a server being spammed with unsuccessful logins indicates attempted malicious access.
+[*Fail2Ban*](http://www.fail2ban.org/wiki/index.php/Main_Page) is an application that bans IP addresses from logging in to your server after too many failed login attempts. Since legitimate logins usually take no more than three tries to succeed (and with SSH keys, no more than one), a server being spammed with unsuccessful logins indicates attempted malicious access.
 
 Fail2Ban can monitor a variety of protocols including SSH, HTTP, and SMTP. By default, Fail2Ban monitors SSH only, and is a helpful security deterrent for any server since the SSH daemon is usually configured to run constantly and listen for connections from any remote IP address.
 

--- a/docs/products/compute/compute-instances/guides/troubleshooting-firewall-issues/index.md
+++ b/docs/products/compute/compute-instances/guides/troubleshooting-firewall-issues/index.md
@@ -22,7 +22,7 @@ While a firewall is often responsible for cases of limited access, these issues 
 To learn about Lish in more detail, and for instructions on how to connect to your Compute Instance via Lish, review the [Using the Lish Console](/docs/products/compute/compute-instances/guides/lish/) guide. A fast and simple way to access Lish is by [the your web browser option](/docs/products/compute/compute-instances/guides/lish/#through-the-cloud-manager-weblish).
 
 {{< note >}}
-When using Lish, you can log into your Compute Instance with the `root` user, even if `root` user login is disabled by your system's SSH configuration file.
+When using Lish, you can log in to your Compute Instance with the `root` user, even if `root` user login is disabled by your system's SSH configuration file.
 {{< /note >}}
 
 ## Is the Compute Instance Powered On?

--- a/docs/products/compute/kubernetes/get-started/index.md
+++ b/docs/products/compute/kubernetes/get-started/index.md
@@ -69,7 +69,7 @@ Visit the [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/inst
 
 ### Access and Download your kubeconfig
 
-1. To access your cluster's kubeconfig, log into your Cloud Manager account and navigate to the **Kubernetes** section.
+1. To access your cluster's kubeconfig, log in to your Cloud Manager account and navigate to the **Kubernetes** section.
 
 1. From the Kubernetes listing page, click on your cluster's **more options ellipsis** and select **Download kubeconfig**. The file is saved to your computer's `Downloads` folder.
 

--- a/docs/products/compute/kubernetes/guides/kubectl/index.md
+++ b/docs/products/compute/kubernetes/guides/kubectl/index.md
@@ -48,7 +48,7 @@ current-context: lke1234-ctx
 
 This configuration file defines your cluster, users, and contexts.
 
-1. To access your cluster's kubeconfig, log into your Cloud Manager account and navigate to the **Kubernetes** section.
+1. To access your cluster's kubeconfig, log in to your Cloud Manager account and navigate to the **Kubernetes** section.
 
 1. From the Kubernetes listing page, click on your cluster's **more options ellipsis** and select **Download kubeconfig**. The file will be saved to your computer's `Downloads` folder.
 

--- a/docs/products/compute/kubernetes/guides/kubernetes-dashboard/index.md
+++ b/docs/products/compute/kubernetes/guides/kubernetes-dashboard/index.md
@@ -43,7 +43,7 @@ The Cluster Dashboard can be found at the top of the Cluster's [details page](/d
 
 ## Navigating the Cluster Dashboard
 
-Once logged into the Cluster dashboard, **Workloads** for the `default` namespace will appear. This page will include information on all [Workloads](https://kubernetes.io/docs/concepts/workloads/) as defined by Kubernetes, and provide a number of options to navigate the dashboard further.
+Once logged in to the Cluster dashboard, **Workloads** for the `default` namespace will appear. This page will include information on all [Workloads](https://kubernetes.io/docs/concepts/workloads/) as defined by Kubernetes, and provide a number of options to navigate the dashboard further.
 
 ![Dashboard Home](dashboard-home.png)
 

--- a/docs/products/platform/accounts/guides/parent-child-accounts/index.md
+++ b/docs/products/platform/accounts/guides/parent-child-accounts/index.md
@@ -10,7 +10,7 @@ promo_default: false
 
 ## Overview
 
-The parent and child accounts feature was designed with Akamai partners and their clients in mind. It allows partners to manage multiple end customers’ accounts with a single login to their company’s account.
+The parent and child accounts feature was designed with Akamai partners and their clients in mind. It allows partners to manage multiple end customers’ accounts with a single login for their company’s account.
 
 {{< note type="secondary" >}}
 This feature is only available for Akamai partners and their end customers with an Akamai Cloud Computing contract. To learn more about it, contact your Akamai representative.

--- a/docs/products/platform/accounts/guides/user-security-controls/index.md
+++ b/docs/products/platform/accounts/guides/user-security-controls/index.md
@@ -14,7 +14,7 @@ To protect your Linode user account against unauthorized access, there are sever
 
 2FA (*two-factor authentication*) increases the security of your Linode account by requiring two forms of authentication: your password and an expiring token, also called a one-time passcode (OTP) or 2FA code. This follows the security principle of authenticating with something you *know* (a password) and something you *have* (the device used to generate the token). This additional layer of security reduces the risk that an unauthorized individual can gain access to your Linode account.
 
-If you *do not* have 2FA enabled and have not logged into your account in 90 days, an OTP is sent to the email address associated with your user account. Should you not complete the login attempt within 60 minutes, the code expires and another login attempt is required to generate a new code.
+If you *do not* have 2FA enabled and have not logged in to your account in 90 days, an OTP is sent to the email address associated with your user account. Should you not complete the login attempt within 60 minutes, the code expires and another login attempt is required to generate a new code.
 
 **Linode highly recommends enabling 2FA**. See [Managing Two-Factor Authentication (2FA) on a User Account](/docs/guides/2fa/) to learn how to enable 2FA. To assist with account lockouts and recovery, you must first configure three [security questions](#security-questions) on your account before enabling 2FA.
 

--- a/docs/products/platform/accounts/resources/index.md
+++ b/docs/products/platform/accounts/resources/index.md
@@ -21,6 +21,6 @@ tab_group_main:
 
 - [How do I manage multiple accounts with the Linode CLI?](https://www.linode.com/community/questions/20161/how-do-i-manage-multiple-accounts-with-the-linode-cli)
 
-- [How do I re-generate 2FA backup codes for logging into cloud.linode.com?](https://www.linode.com/community/questions/21086/how-do-i-re-generate-2fa-backup-codes-for-logging-into-cloudlinodecom)
+- [How do I re-generate 2FA backup codes for logging in to cloud.linode.com?](https://www.linode.com/community/questions/21086/how-do-i-re-generate-2fa-backup-codes-for-logging-into-cloudlinodecom)
 
 - [Yubikey as 2FA option for Manager?](https://www.linode.com/community/questions/17374/yubikey-as-2fa-option-for-manager)

--- a/docs/products/storage/object-storage/get-started/index.md
+++ b/docs/products/storage/object-storage/get-started/index.md
@@ -41,7 +41,7 @@ Billing for Object Storage starts when it is enabled on your account, **regardle
 
 The Cloud Manager provides a web interface for creating buckets. To create a bucket:
 
-1.  If you have not already, log into the [Linode Cloud Manager](https://cloud.linode.com).
+1.  If you have not already, log in to the [Linode Cloud Manager](https://cloud.linode.com).
 
 1.  Click on the **Object Storage** link in the sidebar, and then click on **Create Bucket**.
 
@@ -61,7 +61,7 @@ The Cloud Manager provides a web interface for creating buckets. To create a buc
 
 ## Upload an Object to a Bucket
 
-1.  If you have not already, log into the [Linode Cloud Manager](https://cloud.linode.com).
+1.  If you have not already, log in to the [Linode Cloud Manager](https://cloud.linode.com).
 
 1.  Click on the **Object Storage** link in the sidebar. A list of all your buckets appears. Click on the bucket you'd like to begin uploading objects to.
 

--- a/docs/products/storage/object-storage/guides/acls/index.md
+++ b/docs/products/storage/object-storage/guides/acls/index.md
@@ -28,7 +28,7 @@ Access Control Lists (ACLs) are a method of defining access to Object Storage re
 Existing buckets and any new bucket created in the Cloud Manager have a default ACL permission setting of Private.
 {{< /note >}}
 
-1.  If you have not already, log into the [Linode Cloud Manager](https://cloud.linode.com).
+1.  If you have not already, log in to the [Linode Cloud Manager](https://cloud.linode.com).
 
 1.  Click the **Object Storage** link in the sidebar, and then click on the bucket you wish to edit the ACLs for.
 
@@ -62,7 +62,7 @@ Existing buckets and any new bucket created in the Cloud Manager have a default 
 Existing objects and any new objects created in the Cloud Manager have a default ACL permission setting of Private.
 {{< /note >}}
 
-1.  If you have not already, log into the [Linode Cloud Manager](https://cloud.linode.com).
+1.  If you have not already, log in to the [Linode Cloud Manager](https://cloud.linode.com).
 
 1.  Click the **Object Storage** link in the sidebar, and then click on the bucket that holds the objects that you wish to edit the ACLs for.
 

--- a/docs/products/tools/marketplace/guides/antmediaenterpriseserver/index.md
+++ b/docs/products/tools/marketplace/guides/antmediaenterpriseserver/index.md
@@ -34,7 +34,7 @@ The Enterprise Edition of Ant Media Server requires a valid license to use the s
 
 ### Ant Media Server Options
 
-- **Email address for the Ant Media Server Login & SSL Generation:** Enter the email address that should be used to log into the Ant Media Dashboard, and generate free Let's Encrypt SSL certificates.
+- **Email address for the Ant Media Server Login & SSL Generation:** Enter the email address that should be used to log in to the Ant Media Dashboard, and generate free Let's Encrypt SSL certificates.
 
 {{% content "marketplace-required-limited-user-fields-shortguide" %}}
 
@@ -65,7 +65,7 @@ The Ant Media Server will deploy with an administrator account preconfigured usi
 
 1.  Open your web browser and navigate to `https://[domain]:5443`, where *[domain]* can be replaced with the custom domain you entered during deployment or your Compute Instance's rDNS domain (such as `192-0-2-1.ip.linodeusercontent.com`). You can also use your IPv4 address. See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) guide for information on viewing IP addresses and rDNS.
 
-1.  Use the `Ant Media Server Username` and `Ant Media Server Password` from the `credentials` file to log into the Ant Media Dashboard.
+1.  Use the `Ant Media Server Username` and `Ant Media Server Password` from the `credentials` file to log in to the Ant Media Dashboard.
 
     ![Screenshot of Ant Media Login](ant-media-login.jpg)
 

--- a/docs/products/tools/marketplace/guides/antmediaserver/index.md
+++ b/docs/products/tools/marketplace/guides/antmediaserver/index.md
@@ -45,7 +45,7 @@ If you need adaptive streaming, cluster, load balancer, and hardware encoding, c
 
 ### Ant Media Server Options
 
-- **Email address for the Ant Media Server Login & SSL Generation:** Enter the email address that should be used to log into the Ant Media Dashboard, and generate free Let's Encrypt SSL certificates.
+- **Email address for the Ant Media Server Login & SSL Generation:** Enter the email address that should be used to log in to the Ant Media Dashboard, and generate free Let's Encrypt SSL certificates.
 
 {{% content "marketplace-required-limited-user-fields-shortguide" %}}
 
@@ -76,7 +76,7 @@ The Ant Media Server will deploy with an administrator account preconfigured usi
 
 1.  Open your web browser and navigate to `https://[domain]:5443`, where *[domain]* can be replaced with the custom domain you entered during deployment or your Compute Instance's rDNS domain (such as `192-0-2-1.ip.linodeusercontent.com`). You can also use your IPv4 address. See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) guide for information on viewing IP addresses and rDNS.
 
-1.  Use the `Ant Media Server Username` and `Ant Media Server Password` from the `credentials` file to log into the Ant Media Dashboard.
+1.  Use the `Ant Media Server Username` and `Ant Media Server Password` from the `credentials` file to log in to the Ant Media Dashboard.
 
     ![Screenshot of Ant Media Login](ant-media-login.jpg)
 

--- a/docs/products/tools/marketplace/guides/chevereto/index.md
+++ b/docs/products/tools/marketplace/guides/chevereto/index.md
@@ -36,11 +36,11 @@ Chevereto requires a valid license to use the software. To purchase a license, v
 
 ### Access your Chevereto App
 
-1.  After Chevereto has finished installing,log into your Linode via SSH, replacing `192.0.2.0` with your [Linode's IP address](/docs/guides/find-your-linodes-ip-address/), and entering your Linode's root password when prompted:
+1.  After Chevereto has finished installing, log in to your Linode via SSH, replacing `192.0.2.0` with your [Linode's IP address](/docs/guides/find-your-linodes-ip-address/), and entering your Linode's root password when prompted:
 
         ssh root@192.0.2.0
 
-1.  You should see the Chevereto welcome message when logging into the Linode. This includes instructions for accessing the Chevereto installation script in your web browser, along with the location of the credentials to the application. Replace `192.0.2.0` with your Linode’s IP address.
+1.  You should see the Chevereto welcome message when logging in to the Linode. This includes instructions for accessing the Chevereto installation script in your web browser, along with the location of the credentials to the application. Replace `192.0.2.0` with your Linode’s IP address.
 
     ![Chevereto Login Instruction](chevereto-login.png)
 

--- a/docs/products/tools/marketplace/guides/cyberpanel/index.md
+++ b/docs/products/tools/marketplace/guides/cyberpanel/index.md
@@ -34,13 +34,13 @@ aliases: ['/guides/deploy-cyberpanel-with-marketplace-apps/','/guides/cyberpanel
 
 ### Access your CyberPanel App
 
-1. When the installation completes, log into your Linode via SSH, replacing `192.0.2.1` with your [Linode's IP address](/docs/guides/find-your-linodes-ip-address/), and entering your Linode's root password when prompted:
+1. When the installation completes, log in to your Linode via SSH, replacing `192.0.2.1` with your [Linode's IP address](/docs/guides/find-your-linodes-ip-address/), and entering your Linode's root password when prompted:
 
     ```command
     ssh root@192.0.2.1
     ```
 
-1. You should see the CyberPanel welcome message when logging into the Linode. This will include instructions for accessing CyberPanel, phpMyAdmin, and RainLoop in your web browser. Replace `192.0.2.1` with your Linode's IP address.
+1. You should see the CyberPanel welcome message when logging in to the Linode. This will include instructions for accessing CyberPanel, phpMyAdmin, and RainLoop in your web browser. Replace `192.0.2.1` with your Linode's IP address.
 
     ```output
     Welcome to LiteSpeed One-Click CyberPanel Server.

--- a/docs/products/tools/marketplace/guides/gopaddle/index.md
+++ b/docs/products/tools/marketplace/guides/gopaddle/index.md
@@ -60,7 +60,7 @@ The gopaddle Marketplace App installs gopaddle lite, which is a free community e
 
 ### Containerize and Deploy
 
-Once the subscription is complete, you can login to the gopaddle console, using your email ID and the initial password.
+Once the subscription is complete, you can log in to the gopaddle console using your email ID and the initial password.
 
 In the main dashboard, the **Containerize and Deploy** Quickstart wizard helps to onboard a Source Code project from GitHub using the GitHub personal access token, build and push the generated container image to the Docker Registry. Once the build completes, gopaddle generates the necessary YAML files and deploys the docker image to the local microk8s cluster.
 

--- a/docs/products/tools/marketplace/guides/hashicorp-nomad-clients-cluster/index.md
+++ b/docs/products/tools/marketplace/guides/hashicorp-nomad-clients-cluster/index.md
@@ -51,7 +51,7 @@ Please be aware that each Compute Instance will appear on your invoice as a sepa
 
 ### Accessing the Nomad Web UI
 
-After deployment, you can confirm your clients have been successfully added to your cluster by logging into the Nomad Web UI and selecting **Clients** on the left sidebar. *Nomad clients are not interacted with directly*.
+After deployment, you can confirm your clients have been successfully added to your cluster by logging in to the Nomad Web UI and selecting **Clients** on the left sidebar. *Nomad clients are not interacted with directly*.
 
 ![Screenshot of Nomad Web UI Clients tab](NomadClientsTab.jpg)
 

--- a/docs/products/tools/marketplace/guides/mainconcept-ffmpeg-plugins-demo/index.md
+++ b/docs/products/tools/marketplace/guides/mainconcept-ffmpeg-plugins-demo/index.md
@@ -46,9 +46,9 @@ The versions of MainConcept Plugins for FFmpeg included in this deployment are f
 
 ### Logging In
 
-Once all packages have finished installing, you can login to your instance to access MainConcept's FFmpeg installation and plugins.
+Once all packages have finished installing, you can log in to your instance to access MainConcept's FFmpeg installation and plugins.
 
-1. Using the **limited sudo user** you created during deployment, login to your instance via SSH. Replace `LIMITED_USER` with your sudo user and `192.0.2.1` with the address of your Compute Instance:
+1. Using the **limited sudo user** you created during deployment, log in to your instance via SSH. Replace `LIMITED_USER` with your sudo user and `192.0.2.1` with the address of your Compute Instance:
     ```command
     ssh LIMITED_USER@192.0.2.1
     ```

--- a/docs/products/tools/marketplace/guides/mainconcept-live-encoder-demo/index.md
+++ b/docs/products/tools/marketplace/guides/mainconcept-live-encoder-demo/index.md
@@ -38,7 +38,7 @@ The version of MainConcept Live Encoder in this deployment is a free demo. It ad
 
 ## Getting Started after Deployment
 
-Once your MainConcept Live Encoder Marketplace App is deployed, you can log into the MainConcept Live Encoder Dashboard in your browser.
+Once your MainConcept Live Encoder Marketplace App is deployed, you can log in to the MainConcept Live Encoder Dashboard in your browser.
 
 1. Open a browser and navigate to the domain you created in the beginning of your deployment. If you did not use a domain, you can use your Compute Instance's rDNS, which may look like the example below:
 
@@ -53,7 +53,7 @@ Once your MainConcept Live Encoder Marketplace App is deployed, you can log into
     ![MainConcept Live Encoder Login](mainconcept-live-encoder-login.jpg "MainConcept Live Encoder Login")
 
     {{< note type="warning" title="Important">}}
-    Please ensure you change the default password after logging into your MainConcept Live Encoder instance. To change your password, select the **Users** tab, find your user named "admin", and click the **Op** option.
+    Please ensure you change the default password after logging in to your MainConcept Live Encoder instance. To change your password, select the **Users** tab, find your user named "admin", and click the **Op** option.
     {{< /note >}}
 
 ## Next Steps

--- a/docs/products/tools/marketplace/guides/peppermint/index.md
+++ b/docs/products/tools/marketplace/guides/peppermint/index.md
@@ -41,12 +41,12 @@ aliases: ['/guides/deploy-peppermint-with-marketplace-apps/','/guides/peppermint
 
     ![Peppermint login screen](peppermint.png)
 
-    The default credentials to login to your Peppermint Ticket Management Panel are:
+    The default credentials to log in to your Peppermint Ticket Management Panel are:
 
        Email: admin@admin.com
        Password: 1234
 
-1. Once you login to the Peppermint Ticket Management Panel, update the email and password you used to log in. To do this, click the Settings gear logo in the top right corner.
+1. Once you log in to the Peppermint Ticket Management Panel, update the email and password you used to log in. To do this, click the Settings gear logo in the top right corner.
 
 ![peppermint_settings.png](peppermint_settings.png)
 

--- a/docs/products/tools/marketplace/guides/rust/index.md
+++ b/docs/products/tools/marketplace/guides/rust/index.md
@@ -71,7 +71,7 @@ After the Rust Marketplace App has finished deploying to your Linode, you will b
 
     <!--![Rust developer's console log in process.](rust-marketplace-developers-console.png)-->
 
-    You will be logged into the server, and the game will load.
+    You will be logged in to the server, and the game will load.
 
 ## Software Included
 

--- a/docs/products/tools/marketplace/guides/simplex/index.md
+++ b/docs/products/tools/marketplace/guides/simplex/index.md
@@ -42,7 +42,7 @@ SimpleX Chat is a private messaging platform that uses temporary anonymous ident
 
 ## Getting Started after Deployment
 
-Once the SimpleX Server is up and running you can display your SMP and XFTP connection strings with the following command while logged into the server:
+Once the SimpleX Server is up and running you can display your SMP and XFTP connection strings with the following command while logged in to the server:
 
 ```command
 docker-compose --project-directory /etc/docker/compose/simplex logs grep 'Server address' | uniq

--- a/docs/products/tools/marketplace/guides/vscode/index.md
+++ b/docs/products/tools/marketplace/guides/vscode/index.md
@@ -30,7 +30,7 @@ Run a [Visual Studio Code Server](https://github.com/cdr/code-server) in the bro
 
 ### VS Code Options
 
-- **The password to login to the VS Code Web UI** *(required)*: Enter a *strong* password that can be used to access VS Code.
+- **The password used to log in to the VS Code Web UI** *(required)*: Enter a *strong* password that can be used to access VS Code.
 - **Email address** *(required)*: Enter the email address to use for generating the SSL certificates as well as configuring the server and DNS records.
 - **The version of VS Code Server you'd like installed** *(required)*: This is the version of VS Code Server that is installed during setup. The default at the time that this guide was written is 3.10.2. This field is filled in and it is recommended that you use this value. If you do not fill in this field, the latest version is used.
 

--- a/docs/products/tools/marketplace/guides/warpspeed/index.md
+++ b/docs/products/tools/marketplace/guides/warpspeed/index.md
@@ -30,8 +30,8 @@ WarpSpeed makes it easy for developers to access cloud infrastructure via the po
 
 ### WarpSpeed VPN Options
 
-- **Admin Email:** This is the admin user email to login to your WarpSpeed instance.
-- **Admin Password:** This is the admin user password to login to your WarpSpeed instance.
+- **Admin Email:** This is the admin user email to log in to your WarpSpeed instance.
+- **Admin Password:** This is the admin user password to log in to your WarpSpeed instance.
 - **DNS name:** This is the domain you will be using for your WarpSpeed instance.
 - **Data Directory:** This is the directory that your WarpSpeed data will be stored in, default will be `/wirespeed`.
 

--- a/docs/products/tools/marketplace/guides/zabbix/index.md
+++ b/docs/products/tools/marketplace/guides/zabbix/index.md
@@ -46,13 +46,13 @@ aliases: ['/platform/marketplace/deploy-zabbix-with-marketplace-apps/', '/platfo
 
 After Zabbix has finished installing, you must first obtain the login credentials. You can then use these credentials to log in to your Zabbix App via a web browser.
 
-1.  From your terminal, log into your new Compute Instance as the `root` user, or the `sudo` user created during deployment. Use the following command, replacing `192.0.2.1` with your instance's [IPv4 address](/docs/products/compute/compute-instances/guides/manage-ip-addresses/):
+1.  From your terminal, log in to your new Compute Instance as the `root` user, or the `sudo` user created during deployment. Use the following command, replacing `192.0.2.1` with your instance's [IPv4 address](/docs/products/compute/compute-instances/guides/manage-ip-addresses/):
 
     ```command
     ssh root@192.0.2.1
     ```
 
-1. Output the generated Zabbix credentials by using the following command, replacing `$USERNAME` with the `sudo` user created while deploying the Compute Instance.
+1.  Output the generated Zabbix credentials by using the following command, replacing `$USERNAME` with the `sudo` user created while deploying the Compute Instance.
 
     ```command
     cat /home/$USERNAME/.credentials
@@ -70,7 +70,7 @@ After Zabbix has finished installing, you must first obtain the login credential
 
     ![A screenshot of the Zabbix log in prompt](zabbix-login.png)
 
-1. Enter the username and password you obtained in a previous step and then click **Sign in** to access the Zabbix control panel.
+1.  Enter the username and password you obtained in a previous step and then click **Sign in** to access the Zabbix control panel.
 
     ![The Dashboard of the Zabbix Admin Panel](zabbix-admin.png)
 


### PR DESCRIPTION
This PR adds the following Vale substitution warnings:

- "[Ll]ogin to": log in to
- "[Ll]og into": log in to
- "[Ll]ogged into": logged in to
- "[Ll]ogging into": logging in to

Incorrect instances of these terms were fixed in the /docs/products/ section.