### PR TITLE
Remove links from various external resources sections

### DIFF
--- a/docs/guides/applications/containers/remove-docker-resources/index.md
+++ b/docs/guides/applications/containers/remove-docker-resources/index.md
@@ -9,7 +9,6 @@ keywords: ['docker remove image', 'docker remove container', 'docker remove volu
 tags: ['docker', 'container']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
-- '[DigitalOcean: How To Remove Docker Images, Containers, and Volumes](https://www.digitalocean.com/community/tutorials/how-to-remove-docker-images-containers-and-volumes)'
 - '[freeCodeCamp: How to Remove Images and Containers in Docker](https://www.freecodecamp.org/news/how-to-remove-images-in-docker/)'
 - '[Linuxize: How To Remove Docker Containers, Images, Volumes, and Networks](https://linuxize.com/post/how-to-remove-docker-images-containers-volumes-and-networks/)'
 - '[Docker Docs: docker image](https://docs.docker.com/engine/reference/commandline/image/)'

--- a/docs/guides/databases/concepts/what-is-database-sharding/index.md
+++ b/docs/guides/databases/concepts/what-is-database-sharding/index.md
@@ -8,7 +8,6 @@ published: 2022-06-21
 keywords: ['database sharding','database sharding vs partitioning','what is database sharding']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
-- '[DigitalOcean: Understanding Database Sharding](https://www.digitalocean.com/community/tutorials/understanding-database-sharding)'
 - '[MongoDB: Database Sharding — Concepts and Examples](https://www.mongodb.com/features/database-sharding-explained)'
 - '[Educative: What Is Database Sharding?](https://www.educative.io/edpresso/what-is-database-sharding)'
 - '[GeeksforGeeks: Database Sharding – System Design Interview Concept](https://www.geeksforgeeks.org/database-sharding-a-system-design-concept/)'

--- a/docs/guides/development/javascript/how-to-use-filter-method-javascript/index.md
+++ b/docs/guides/development/javascript/how-to-use-filter-method-javascript/index.md
@@ -1,14 +1,13 @@
 ---
 slug: how-to-use-filter-method-javascript
-title: "How to Use the filter() Method for Arrays in JavaScript"
-description: "Want to know what JavaScript’s filter() array method is and how to use it? This guide gives you everything you need to understand what filter() does and how to apply it in your JavaScript development."
+title: "How to Use the filter Method for Arrays in JavaScript"
+description: "Want to know what JavaScript’s filter array method is and how to use it? This guide gives you everything you need to understand what filter does and how to apply it in your JavaScript development."
 authors: ["Nathaniel Stickman"]
 contributors: ["Nathaniel Stickman"]
 published: 2022-03-13
 keywords: ['javascript filter array', 'javascript filter function', 'javascript filter method']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
-- '[DigitalOcean: How To Use the filter() Array Method in JavaScript](https://www.digitalocean.com/community/tutorials/js-filter-array-method)'
 - '[MDN Web Docs: Array.prototype.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)'
 ---
 

--- a/docs/guides/development/javascript/how-to-use-javascript-fetch-api/index.md
+++ b/docs/guides/development/javascript/how-to-use-javascript-fetch-api/index.md
@@ -9,7 +9,6 @@ keywords: ['javascript fetch', 'javascript fetch api', 'javascript fetch example
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[MDN Web Docs: Using the Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)'
-- '[DigitalOcean: How To Use the JavaScript Fetch API to Get Data](https://www.digitalocean.com/community/tutorials/how-to-use-the-javascript-fetch-api-to-get-data)'
 ---
 
 The JavaScript Filter API gives you a convenient and native way to make requests and handle responses for HTTP and other network APIs. It provides a built-in function for making `GET`, `POST`, and other HTTP requests in JavaScript.

--- a/docs/guides/tools-reference/tools/how-to-use-ack-command/index.md
+++ b/docs/guides/tools-reference/tools/how-to-use-ack-command/index.md
@@ -11,7 +11,7 @@ tags: ['linux']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[ack!: Documentation](https://beyondgrep.com/documentation/)'
-- '[DigitalOcean: How To Install and Use Ack, a Grep Replacement for Developers, on Ubuntu 14.04](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-ack-a-grep-replacement-for-developers-on-ubuntu-14-04)'
+how-to-install-and-use-ack-a-grep-replacement-for-developers-on-ubuntu-14-04)'
 - '[Linux Shell Tips: How to Install and Use Ack Command in Linux with Examples](https://www.linuxshelltips.com/ack-command-in-linux/)'
 ---
 

--- a/docs/guides/tools-reference/tools/how-to-use-ack-command/index.md
+++ b/docs/guides/tools-reference/tools/how-to-use-ack-command/index.md
@@ -11,7 +11,6 @@ tags: ['linux']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[ack!: Documentation](https://beyondgrep.com/documentation/)'
-how-to-install-and-use-ack-a-grep-replacement-for-developers-on-ubuntu-14-04)'
 - '[Linux Shell Tips: How to Install and Use Ack Command in Linux with Examples](https://www.linuxshelltips.com/ack-command-in-linux/)'
 ---
 

--- a/docs/guides/web-servers/nginx/using-openresty/index.md
+++ b/docs/guides/web-servers/nginx/using-openresty/index.md
@@ -9,7 +9,6 @@ keywords: ['what is openresty', 'openresty example', 'openresty vs nginx']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[OpenResty: Getting Started](https://openresty.org/en/getting-started.html)'
-- '[DigitalOcean: How to Use the OpenResty Web Framework for NGINX on Ubuntu 16.04](https://www.digitalocean.com/community/tutorials/how-to-use-the-openresty-web-framework-for-nginx-on-ubuntu-16-04)'
 - "[Ketzal's $HOME: Intro to Lua and Openresty, Part 1 - Hello World Examples](https://ketzacoatl.github.io/posts/2017-03-02-lua-and-openresty-hello-world-examples.html)"
 ---
 


### PR DESCRIPTION
In 5 guides, removed links from external resources:
- How to Remove Docker Images, Containers, and Volumes
- What Is Database Sharding?
- How to Use the JavaScript Fetch API
- How to Use the ack Command on Linux
- How to Use the OpenResty Web Server

Also removes parenthesis in title for: How to Use the filter Method for Arrays in JavaScript