### PR TITLE
[Updated] Deprecating 68 Guides

### DIFF
--- a/docs/guides/applications/big-data/how-to-install-and-configure-a-redis-cluster-on-ubuntu-1604/index.md
+++ b/docs/guides/applications/big-data/how-to-install-and-configure-a-redis-cluster-on-ubuntu-1604/index.md
@@ -13,6 +13,7 @@ aliases: ['/applications/big-data/redis-cluster/','/applications/big-data/how-to
 external_resources:
  - '[Redis Official Website](https://redis.io/)'
  - '[Install and Configure Redis on CentOS 7](/docs/guides/install-and-configure-redis-on-centos-7/)'
+deprecated: true
 ---
 
 ![How to Install and Configure a Redis Cluster on Ubuntu 16.04](Redis_Cluster.jpg)

--- a/docs/guides/applications/cloud-storage/access-google-drive-linode/index.md
+++ b/docs/guides/applications/cloud-storage/access-google-drive-linode/index.md
@@ -10,6 +10,7 @@ keywords: ["google", "drive", "console", "fuse", "apt", "ubuntu"]
 tags: ["ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/applications/cloud-storage/access-google-drive-linode/']
+deprecated: true
 ---
 
 If you've used Google Drive, you know that it can be an indispensable tool for remote file access. While one of the standard counter-arguments to remote storage is "just carry a flash drive," that only works until you need to add a file to your Linode. This guide will show you how to install and configure a great piece of free software to access your Google Drive from your Linode running Ubuntu version 14.04 or newer.

--- a/docs/guides/applications/cloud-storage/how-to-install-a-turtl-server-on-ubuntu/index.md
+++ b/docs/guides/applications/cloud-storage/how-to-install-a-turtl-server-on-ubuntu/index.md
@@ -11,6 +11,7 @@ tags: ["ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 
 aliases: ['/applications/cloud-storage/how-to-install-a-turtl-server-on-ubuntu/']
+deprecated: true
 ---
 
 ![Header image](Turtl.jpg)

--- a/docs/guides/applications/cloud-storage/how-to-use-zfs-on-ubuntu-16-04/index.md
+++ b/docs/guides/applications/cloud-storage/how-to-use-zfs-on-ubuntu-16-04/index.md
@@ -14,6 +14,7 @@ external_resources:
  - '[Ubuntu ZFS wiki](https://wiki.ubuntu.com/Kernel/Reference/ZFS)'
  - '[RAID levels Wikipedia](https://en.wikipedia.org/wiki/Standard_RAID_levels)'
 aliases: ['/applications/cloud-storage/how-to-use-zfs-on-ubuntu-16-04/']
+deprecated: true
 ---
 
 ![How to Use ZFS on Ubuntu 16.04](zfs-on-ubuntu-title.jpg "How to Use ZFS on Ubuntu 16.04 title graphic")

--- a/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-ubuntu-16-04/index.md
+++ b/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-ubuntu-16-04/index.md
@@ -18,6 +18,7 @@ relations:
         keywords:
             - distribution: Ubuntu 16.04
 aliases: ['/applications/cloud-storage/install-and-configure-owncloud-on-ubuntu-16-04/']
+deprecated: true
 ---
 
 OwnCloud is an open-source, cloud-based, file hosting service you can install on your Linode. OwnCloud offers a quick installation process, works out of the box, and has an extensive library of plugins available. Its cross-platform compatibility means you can access your files from most major operating systems, browsers, and mobile devices.

--- a/docs/guides/applications/cloud-storage/install-seafile-with-nginx-on-ubuntu-1604/index.md
+++ b/docs/guides/applications/cloud-storage/install-seafile-with-nginx-on-ubuntu-1604/index.md
@@ -12,6 +12,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
  - '[Seafile Server Manual](https://manual.seafile.com/)'
 aliases: ['/applications/cloud-storage/install-seafile-with-nginx-on-ubuntu-1604/']
+deprecated: true
 ---
 
 Seafile is a cross-platform file hosting tool with server applications for Linux and Windows, and GUI clients for Android, iOS, Linux, OS X and Windows. It supports file versioning and snapshots, two-factor authentication, WebDAV, and can be paired with NGINX or Apache to enable connections over HTTPS.

--- a/docs/guides/applications/cloud-storage/tahoe-lafs-on-debian-9/index.md
+++ b/docs/guides/applications/cloud-storage/tahoe-lafs-on-debian-9/index.md
@@ -14,6 +14,7 @@ external_resources:
 - '[Tahoe-LAFS Project Page](https://tahoe-lafs.org/)'
 - '[Tahoe-LAFS Documentation](http://tahoe-lafs.readthedocs.io)'
 aliases: ['/applications/cloud-storage/tahoe-lafs-on-debian-9/']
+deprecated: true
 ---
 
 ## What is Tahoe-LAFS?

--- a/docs/guides/applications/configuration-management/salt/use-salt-states-to-configure-a-lamp-stack-on-a-minion/index.md
+++ b/docs/guides/applications/configuration-management/salt/use-salt-states-to-configure-a-lamp-stack-on-a-minion/index.md
@@ -11,6 +11,7 @@ tags: ["automation","salt","debian","lamp","apache"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/applications/salt/salt-states-configuration-apache-mysql-php/','/applications/configuration-management/salt/use-salt-states-to-configure-a-lamp-stack-on-a-minion/','/applications/configuration-management/use-salt-states-to-configure-a-lamp-stack-on-a-minion/']
 image: UseSaltStatestoConfigureaLAMPStackonaMinion.png
+deprecated: true
 ---
 
 This tutorial will configure a Minion's LAMP stack with further use of Salt States. This tutorial is written for Debian 8 but can easily be adjusted for other Linux Distributions. You will need a working Salt master and minion configuration before starting this guide. If you need to set up that prerequisite, see our [Salt installation guide](/docs/guides/getting-started-with-salt-basic-installation-and-setup/) to get started.

--- a/docs/guides/applications/containers/how-to-install-openvz-on-debian-9/index.md
+++ b/docs/guides/applications/containers/how-to-install-openvz-on-debian-9/index.md
@@ -14,6 +14,7 @@ external_resources:
   - '[Basic OpenVZ Operations](https://openvz.org/Basic_operations_in_OpenVZ_environment)'
   - '[OpenVZ User Contributed Templates](https://openvz.org/Download/template/precreated)'
 aliases: ['/applications/containers/how-to-install-openvz-on-debian-9/']
+deprecated: true
 ---
 
 ## What is OpenVZ?

--- a/docs/guides/applications/containers/node-js-web-server-deployed-within-docker/index.md
+++ b/docs/guides/applications/containers/node-js-web-server-deployed-within-docker/index.md
@@ -15,6 +15,7 @@ external_resources:
 - '[Docker Docs](http://docs.docker.com/)'
 - '[Docker Try it Tutorial](https://www.docker.com/tryit/)'
 - '[Docker Hub](https://hub.docker.com/)'
+deprecated: true
 ---
 
 Node.js is a server-side, JavaScript package, often used for various cloud applications. Docker is a container platform. With Docker, users can download applications without the hassle of the installation and configuration process.

--- a/docs/guides/applications/messaging/installing-rocketchat-ubuntu-16-04/index.md
+++ b/docs/guides/applications/messaging/installing-rocketchat-ubuntu-16-04/index.md
@@ -15,6 +15,7 @@ external_resources:
  - '[Configuring SSL Reversae Proxy](https://rocket.chat/docs/installation/manual-installation/configuring-ssl-reverse-proxy/)'
  - '[Configuring HTTPS Servers](http://nginx.org/en/docs/http/configuring_https_servers.html)'
 aliases: ['/applications/messaging/installing-rocketchat-ubuntu-16-04/']
+deprecated: true
 ---
 
 **Rocket.Chat** is an open source chat software alternative to Slack that ships with the feature rich components users have come to expect for team productivity. Chat with team members, make video and audio calls with screen sharing, create channels and private groups, upload files and more. With Rocket.Chat's source code hosted on GitHub, you can develop new features and contribute back to the project.

--- a/docs/guides/applications/project-management/how-to-install-and-configure-redmine-on-ubuntu-16-04/index.md
+++ b/docs/guides/applications/project-management/how-to-install-and-configure-redmine-on-ubuntu-16-04/index.md
@@ -14,6 +14,7 @@ external_resources:
 - '[Redmine Users Guide](https://www.redmine.org/projects/redmine/wiki/Getting_Started)'
 - "[Andrew Hosch's Guide on Redmine](http://www.untrustedconnection.com/2016/04/redmine-passenger-and-nginx-on-ubuntu.html)"
 aliases: ['/applications/project-management/how-to-install-and-configure-redmine-on-ubuntu-16-04/']
+deprecated: true
 ---
 
 ![How to Install and Configure Redmine on Ubuntu](how-to-install-and-configure-redmine-on-ubuntu-smg.jpg)

--- a/docs/guides/applications/voip/install-and-configure-mumble-on-debian/index.md
+++ b/docs/guides/applications/voip/install-and-configure-mumble-on-debian/index.md
@@ -14,6 +14,7 @@ external_resources:
  - '[Mumble Wiki](http://wiki.mumble.info/wiki/Main_Page)'
 dedicated_cpu_link: true
 aliases: ['/applications/voip/install-and-configure-mumble-on-debian/']
+deprecated: true
 ---
 
 [Mumble](http://wiki.mumble.info/wiki/Main_Page) is an open-source VoIP client, designed for gamers, that requires a server for all clients to connect to. This guide instructs how to install and configure the Mumble server (also called Murmur) on Debian.

--- a/docs/guides/databases/cassandra/how-to-install-apache-cassandra-on-debian-9/index.md
+++ b/docs/guides/databases/cassandra/how-to-install-apache-cassandra-on-debian-9/index.md
@@ -22,6 +22,7 @@ relations:
             - distribution: Debian 9
 tags: ["debian","database","nosql"]
 aliases: ['/databases/cassandra/how-to-install-apache-cassandra-on-debian-9/']
+deprecated: true
 ---
 
 After completing this guide, you will have a single-node, production-ready installation of [Apache Cassandra](http://cassandra.apache.org/) hosted on your Linode running Debian 9. This tutorial will cover basic configuration options, as well as harden database security.

--- a/docs/guides/databases/elasticsearch/visualize-apache-web-server-logs-using-elastic-stack-on-debian-8/index.md
+++ b/docs/guides/databases/elasticsearch/visualize-apache-web-server-logs-using-elastic-stack-on-debian-8/index.md
@@ -20,6 +20,7 @@ relations:
         key: visualize-apache-logs-using-elastic-stack
         keywords:
             - distribution: Debian 8
+deprecated: true
 ---
 
 ![Visualize Apache Web Server Logs Using an Elastic Stack on Debian 8](elastic-stack-visualize-server-logs-title.jpg "Visualize Apache Web Server Logs Using an Elastic Stack on Debian 8")

--- a/docs/guides/databases/mariadb/how-to-install-mariadb-on-debian-9/index.md
+++ b/docs/guides/databases/mariadb/how-to-install-mariadb-on-debian-9/index.md
@@ -21,6 +21,7 @@ relations:
         keywords:
             - distribution: Debian 9
 tags: ["debian","mariadb","database"]
+deprecated: true
 ---
 
 MariaDB is a fork of the popular cross-platform MySQL database management system and is considered a full [drop-in replacement](https://mariadb.com/kb/en/mariadb/mariadb-vs-mysql-features/) for MySQL. MariaDB was created by one of MySQL's original developers in 2009 after MySQL was acquired by Oracle during the Sun Microsystems merger. Today MariaDB is maintained and developed by the [MariaDB Foundation](https://mariadb.org/en/foundation/) and community contributors with the intention of it remaining GNU GPL software.

--- a/docs/guides/databases/mongodb/install-mongodb-on-ubuntu-16-04/index.md
+++ b/docs/guides/databases/mongodb/install-mongodb-on-ubuntu-16-04/index.md
@@ -19,6 +19,7 @@ relations:
             - distribution: Ubuntu 16.04
 tags: ["ubuntu","database","nosql"]
 aliases: ['/databases/mongodb/install-mongodb-on-ubuntu-16-04/']
+deprecated: true
 ---
 
 In this MongoDB tutorial, we explain how to install the database on Ubuntu 16.04, and then provide a short guide on some basic features and functions.

--- a/docs/guides/databases/mysql/how-to-install-mysql-on-debian-8/index.md
+++ b/docs/guides/databases/mysql/how-to-install-mysql-on-debian-8/index.md
@@ -21,6 +21,7 @@ relations:
         keywords:
             - distribution: Debian 8
 tags: ["debian","database","mysql"]
+deprecated: true
 ---
 
 ![How to Install MySQL on Debian 8](how-to-install-mysql-on-debian-8.jpg "How to Install MySQL on Debian 8")

--- a/docs/guides/databases/mysql/install-and-configure-mysql-workbench-on-ubuntu/index.md
+++ b/docs/guides/databases/mysql/install-and-configure-mysql-workbench-on-ubuntu/index.md
@@ -12,6 +12,7 @@ external_resources:
  - '[MySQL Workbench Manual](https://dev.mysql.com/doc/workbench/en/)'
  - '[Deploy MySQL Workbench for Database Administration](/docs/guides/deploy-mysql-workbench-for-database-administration/)'
 tags: ["ubuntu","database","mysql"]
+deprecated: true
 ---
 
 MySQL Workbench is a feature-rich graphical tool used to model data, build SQL queries, manage MySQL servers, and more. This guide will show you how to install Workbench using the Ubuntu package manager.

--- a/docs/guides/databases/mysql/install-and-configure-phpmyadmin-on-debian-8/index.md
+++ b/docs/guides/databases/mysql/install-and-configure-phpmyadmin-on-debian-8/index.md
@@ -15,6 +15,7 @@ relations:
         keywords:
             - distribution: Debian 8
 tags: ["debian","database","mysql","php"]
+deprecated: true
 ---
 
 phpMyAdmin is a web application that provides a GUI to aid in MySQL database administration. It supports multiple MySQL servers and is a robust and easy alternative to using the MySQL command line client.

--- a/docs/guides/databases/postgresql/how-to-install-postgresql-on-ubuntu-16-04/index.md
+++ b/docs/guides/databases/postgresql/how-to-install-postgresql-on-ubuntu-16-04/index.md
@@ -19,6 +19,7 @@ relations:
         key: install-postrgesql-database
         keywords:
             - distribution: Ubuntu 16.04
+deprecated: true
 ---
 
 ![How to Install PostgreSQL on Ubuntu 16.04](how-to-install-postgresql-on-ubuntu-16-04.jpg "How to Install PostgreSQL on Ubuntu 16.04")

--- a/docs/guides/databases/redis/how-to-install-a-redis-server-on-ubuntu-or-debian8/index.md
+++ b/docs/guides/databases/redis/how-to-install-a-redis-server-on-ubuntu-or-debian8/index.md
@@ -21,6 +21,7 @@ relations:
         keywords:
             - distribution: Ubuntu/Debian
 tags: ["ubuntu","debian","database","nosql"]
+deprecated: true
 ---
 
 ![Redis Server on Ubuntu or Debian](install-redis-server-ubuntu-debian.png "Redis Server on Ubuntu or Debian")

--- a/docs/guides/development/java/install-java-on-debian/index.md
+++ b/docs/guides/development/java/install-java-on-debian/index.md
@@ -19,6 +19,7 @@ relations:
         key: install-java
         keywords:
             - distribution: Debian 8
+deprecated: true
 ---
 
 Java is a powerful programming language. Software written in Java can be compiled and run on any system. Unlike Python or C, Java does not come pre-installed on Linode distribution images. This guide installs the OpenJDK 7 runtime environment and development kit in Debian 8. OpenJDK is the free and open-source implementation of the Java SE Development Kit.

--- a/docs/guides/development/java/install-java-on-ubuntu-16-04/index.md
+++ b/docs/guides/development/java/install-java-on-ubuntu-16-04/index.md
@@ -21,6 +21,7 @@ relations:
         key: install-java
         keywords:
             - distribution: Ubuntu 16.04
+deprecated: true
 ---
 
 ![Java](Install_Oracle_Java.jpg)

--- a/docs/guides/development/ror/ruby-on-rails-apache-debian/index.md
+++ b/docs/guides/development/ror/ruby-on-rails-apache-debian/index.md
@@ -21,6 +21,7 @@ relations:
         key: ruby-on-rails-apache
         keywords:
             - distribution: Debian 9
+deprecated: true
 ---
 
 ![Ruby on Rails with Apache on Debian](ruby_on_rails_with_apache_debian.jpg "Ruby on Rails with Apache on Debian")

--- a/docs/guides/development/ror/ruby-on-rails-nginx-debian/index.md
+++ b/docs/guides/development/ror/ruby-on-rails-nginx-debian/index.md
@@ -27,6 +27,7 @@ relations:
         key: ruby-on-rails-nginx
         keywords:
             - distribution: Debian 9
+deprecated: true
 ---
 
 ![Ruby on Rails with nginx on Debian](ruby_on_rails_with_nginx_debian_8_smg.png "Ruby on Rails with nginx on Debian 8")

--- a/docs/guides/development/version-control/install-gogs-on-debian/index.md
+++ b/docs/guides/development/version-control/install-gogs-on-debian/index.md
@@ -20,6 +20,7 @@ relations:
         key: install-gogs
         keywords:
             - distribution: Debian 9
+deprecated: true
 ---
 
 [Gogs](http://gogs.io) is a self-hosted Git service, similar to GitLab. It is written in [Go](http://golang.org) and aims to be the easiest and most painless way to set up self-hosted Git service. Gogs is one of the best choices if you need to set up a private Git repository, but don't want to pay for the private plans on other Git services.

--- a/docs/guides/development/version-control/manage-distributed-version-control-with-mercurial/index.md
+++ b/docs/guides/development/version-control/manage-distributed-version-control-with-mercurial/index.md
@@ -13,6 +13,7 @@ external_resources:
  - '[HG Init, a Guide by Joel Spolsky](http://hginit.com/)'
 audiences: ["beginner"]
 tags: ["version control system"]
+deprecated: true
 ---
 
 [Mercurial](https://www.mercurial-scm.org/) is one of the leading distributed version control systems which allows software developers and teams of collaborators to work on a common code base without the need to rely on a centralized server or constant network connection. Mercurial runs on multiple platforms and can be used to manage code projects on many different operating systems.

--- a/docs/guides/email/clients/install-roundcube-on-ubuntu/index.md
+++ b/docs/guides/email/clients/install-roundcube-on-ubuntu/index.md
@@ -12,6 +12,7 @@ tags: ["ubuntu","postfix","email","lamp"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
   - '[Roundcube Homepage](https://roundcube.net/)'
+deprecated: true
 ---
 
 ![Install Roundcube on Ubuntu 16.04 LTS](Install_Roundcube_on_Ubuntu_16_04_smg.png "Install Roundcube on Ubuntu")

--- a/docs/guides/email/clients/install-squirrelmail-on-ubuntu-16-04-or-debian-8/index.md
+++ b/docs/guides/email/clients/install-squirrelmail-on-ubuntu-16-04-or-debian-8/index.md
@@ -17,6 +17,7 @@ relations:
         keywords:
             - distribution: Debian 8
 aliases: ['/email/clients/install-squirrelmail-on-ubuntu-16-04-or-debian-8/']
+deprecated: true
 ---
 
 ![Install SquirrelMail on Ubuntu or Debian](Install_SquirrelMail_smg.jpg)

--- a/docs/guides/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8/index.md
+++ b/docs/guides/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8/index.md
@@ -21,6 +21,7 @@ relations:
         keywords:
             - distribution: Debian 8
 aliases: ['/email/postfix/configure-spf-and-dkim-in-postfix-on-debian-8/']
+deprecated: true
 ---
 {{< note >}}
 We have created a [new version of this guide](/docs/guides/configure-spf-and-dkim-in-postfix-on-debian-9/) to run on Debian 9.

--- a/docs/guides/email/postfix/pflogsumm-for-postfix-monitoring-on-centos-6/index.md
+++ b/docs/guides/email/postfix/pflogsumm-for-postfix-monitoring-on-centos-6/index.md
@@ -11,6 +11,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/email/postfix/pflogsumm-for-postfix-monitoring-on-centos-6/','/email/postfix/pflogsumm-centos-6/']
 external_resources:
  - '[Pflogsumm](http://jimsun.linxnet.com/postfix_contrib.html)'
+deprecated: true
 ---
 
 ![Header image](Pflogsumm_or_Postfix_Monitoring_on_CentOS_smg.jpg "Pflogsumm for Postfix Monitoring on CentOS 6")

--- a/docs/guides/game-servers/deploy-just-cause-2-multiplayer-server-on-ubuntu/index.md
+++ b/docs/guides/game-servers/deploy-just-cause-2-multiplayer-server-on-ubuntu/index.md
@@ -11,6 +11,7 @@ tags: ["ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/applications/game-servers/deploy-just-cause-2-multiplayer-server-on-ubuntu/','/applications/game-servers/just-cause-2-multiplayer-on-ubuntu/','/game-servers/deploy-just-cause-2-multiplayer-server-on-ubuntu/']
 dedicated_cpu_link: true
+deprecated: true
 ---
 
 [Just Cause 2](http://www.justcause2.com/) is a single-player game published by Square Enix. Because it has no multiplayer mode, the modding community has created a multiplayer mod for the game that is quite popular. This guide will explain how to prepare your Linode, install SteamCMD and then install and configure Just Cause 2's multiplayer mod.

--- a/docs/guides/game-servers/host-a-terraria-server-on-your-linode/index.md
+++ b/docs/guides/game-servers/host-a-terraria-server-on-your-linode/index.md
@@ -14,6 +14,7 @@ external_resources:
  - '[Terraria Wiki: Setting up a Terraria Server](http://terraria.gamepedia.com/Guide:Setting_up_a_Terraria_server)'
 aliases: ['/game-servers/host-a-terraria-server-on-your-linode/','/applications/game-servers/host-a-terraria-server-on-your-linode/']
 dedicated_cpu_link: true
+deprecated: true
 ---
 
 ![Hosta a Terraria Server on Your Linode](terraria-server.png "Hosta a Terraria Server on Your Linode")

--- a/docs/guides/game-servers/install-dont-starve-together-game-server-on-ubuntu/index.md
+++ b/docs/guides/game-servers/install-dont-starve-together-game-server-on-ubuntu/index.md
@@ -11,6 +11,7 @@ tags: ["debian", "ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/applications/game-servers/dont-starve-together-on-ubuntu/','/game-servers/install-dont-starve-together-game-server-on-ubuntu/','/applications/game-servers/install-dont-starve-together-game-server-on-ubuntu/']
 dedicated_cpu_link: true
+deprecated: true
 ---
 
 ![Header image](Install_Dont_Starve_Together_Game_Server_on_Ubuntu_smg.jpg "Install Don't Starve Together Game Server on Ubuntu 14.04")

--- a/docs/guides/game-servers/pocketmine-server-on-debian-7/index.md
+++ b/docs/guides/game-servers/pocketmine-server-on-debian-7/index.md
@@ -14,6 +14,7 @@ external_resources:
  - '[PocketMine Documentation](http://pocketmine-mp.readthedocs.org/en/latest/)'
 aliases: ['/game-servers/pocketmine-server-on-debian-7/','/applications/game-servers/pocketmine-server-on-debian-7/']
 dedicated_cpu_link: true
+deprecated: true
 ---
 
 PocketMine is a third party server for the MineCraft - Pocket Edition game for [Android](https://play.google.com/store/apps/details?id=com.mojang.minecraftpe) and [iOS](https://itunes.apple.com/us/app/minecraft-pocket-edition/id479516143?mt=8). It features plugin support, allowing you to customize your gameplay with others. This guide details installing PocketMine on a Linode running Debian 7.

--- a/docs/guides/networking/nfs/how-to-mount-nfs-shares-on-debian-9/index.md
+++ b/docs/guides/networking/nfs/how-to-mount-nfs-shares-on-debian-9/index.md
@@ -11,6 +11,7 @@ keywords: ["NFS", "network file system"]
 aliases: ['/networking/how-to-mount-nfs-shares-on-debian-9/','/networking/how-to-mount-nfs-shares-on-debian-8/','/networking/nfs/how-to-mount-nfs-shares-on-debian-9/','/networking/basic-nfs-configuration-on-debian-7/','/networking/file-transfer/basic-nfs-debian/']
 tags: ["networking","debian"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+deprecated: true
 ---
 
 ![How to Mount NFS Shares on Debian 9](mount-nfs-shares-deb-9-title.jpg "How to Mount NFS Shares on Debian 9")

--- a/docs/guides/networking/vpn/set-up-a-hardened-openvpn-server/index.md
+++ b/docs/guides/networking/vpn/set-up-a-hardened-openvpn-server/index.md
@@ -12,6 +12,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/networking/vpn/set-up-a-hardened-openvpn-server-on-debian-8/','/networking/vpn/set-up-a-hardened-openvpn-server/']
 external_resources:
  - '[Official OpenVPN Documentation](https://openvpn.net/index.php/open-source/documentation/howto.html)'
+deprecated: true
 ---
 
 [OpenVPN](https://openvpn.net/) is a tool for creating network tunnels between groups of computers that are not on the same local network. This is useful to remotely access services on a network or computer without making those services publicly accessible. When integrated with OpenSSL, OpenVPN encrypts all VPN traffic providing a secure connection between machines.

--- a/docs/guides/security/security-patches/disabling-sslv3-for-poodle/index.md
+++ b/docs/guides/security/security-patches/disabling-sslv3-for-poodle/index.md
@@ -10,6 +10,7 @@ keywords: ["sslv3", "poodle", "security", "patch", "ubuntu", "debian", "centos",
 tags: ["web server","security","ssl"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/security/security-patches/disabling-sslv3-for-poodle/']
+deprecated: true
 ---
 
 ![Disabling_sslv3_for_poodle](Disabling_SSLv3_for_POODLE_smg.jpg)

--- a/docs/guides/security/security-patches/meltdown-and-spectre/index.md
+++ b/docs/guides/security/security-patches/meltdown-and-spectre/index.md
@@ -16,6 +16,7 @@ external_resources:
   - '[Reboot Survival Guide](/docs/guides/reboot-survival-guide/)'
   - '[Linode Blog: CPU Vulnerabilities: Meltdown & Spectre](https://blog.linode.com/2018/01/03/cpu-vulnerabilities-meltdown-spectre/)'
 tags: ["security"]
+deprecated: true
 ---
 
 ## Summary

--- a/docs/guides/security/security-patches/patching-bash-for-the-shellshock-vulnerability/index.md
+++ b/docs/guides/security/security-patches/patching-bash-for-the-shellshock-vulnerability/index.md
@@ -10,6 +10,7 @@ keywords: ["bash", "shellshock", "security", "patch", "ubuntu", "debian", "cento
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 tags: ["security"]
 aliases: ['/security/security-patches/patching-bash-for-the-shellshock-vulnerability/']
+deprecated: true
 ---
 
 Shellshock, or Bashdoor, is a vulnerability that was discovered on September 12th, 2014 and embargoed until September 24th when it was assigned the CVE identifier [CVE-2014-6271](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6271). The vulnerability pertains to Bash, which is a widely used Unix shell. This vulnerability affects all Linux distributions and allows remote execution of commands using environment variables.

--- a/docs/guides/security/security-patches/patching-glibc-for-the-ghost-vulnerability/index.md
+++ b/docs/guides/security/security-patches/patching-glibc-for-the-ghost-vulnerability/index.md
@@ -12,6 +12,7 @@ external_resources:
  - '[CVE-2015-0235](http://www.openwall.com/lists/oss-security/2015/01/27/9)'
 tags: ["security"]
 aliases: ['/security/security-patches/patching-glibc-for-the-ghost-vulnerability/']
+deprecated: true
 ---
 
 GHOST is a vulnerability that was announced on January 27th 2015, which affects the glibc library on Linux systems.  This vulnerability affects all Linux distributions running versions of glibc older than 2.18, and exploits a buffer overflow in the `__nss_hostname_digits_dots()` function. This guide will tell you how to safely upgrade your Linux distributions and secure your Linode against the GHOST vulnerability.

--- a/docs/guides/security/security-patches/patching-openssl-for-the-heartbleed-vulnerability/index.md
+++ b/docs/guides/security/security-patches/patching-openssl-for-the-heartbleed-vulnerability/index.md
@@ -12,6 +12,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/security/patching-openssl-for-the-heartbleed-vulnerability/','/security/security-patches/patching-openssl-for-the-heartbleed-vulnerability/','/security/openssl-heartbleed/']
 external_resources:
  - '[Heartbleed.com](http://heartbleed.com/)'
+deprecated: true
 ---
 
 ![Patching OpenSSL for the Heartbleed Vulnerability](Patching_OpenSSL_for_the_Heartbleed_Vulnerability_smg.png "Patching OpenSSL for the Heartbleed Vulnerability")

--- a/docs/guides/security/upgrading/upgrade-to-ubuntu-16-04/index.md
+++ b/docs/guides/security/upgrading/upgrade-to-ubuntu-16-04/index.md
@@ -15,6 +15,7 @@ relations:
         keywords:
             - distribution: Ubuntu 16.04
 aliases: ['/security/upgrading/upgrade-to-ubuntu-16-04/']
+deprecated: true
 ---
 
 ![Upgrade to Ubuntu 16.04](How_to_Upgrade_to_Ubuntu_smg.jpg)

--- a/docs/guides/uptime/monitoring/how-to-install-and-configure-graylog2-on-debian-9/index.md
+++ b/docs/guides/uptime/monitoring/how-to-install-and-configure-graylog2-on-debian-9/index.md
@@ -15,6 +15,7 @@ external_resources:
 - '[Elasticsearch](https://www.elastic.co/guide/index.html)'
 dedicated_cpu_link: true
 aliases: ['/uptime/monitoring/how-to-install-and-configure-graylog2-on-debian-9/']
+deprecated: true
 ---
 
 ## What is Graylog?

--- a/docs/guides/uptime/monitoring/install-icinga2-monitoring-on-debian-9/index.md
+++ b/docs/guides/uptime/monitoring/install-icinga2-monitoring-on-debian-9/index.md
@@ -12,6 +12,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
  - '[Official Icinga Documentation](https://www.icinga.com/docs/icinga2/latest/doc/01-about/)'
 aliases: ['/uptime/monitoring/install-icinga2-monitoring-on-debian-9/']
+deprecated: true
 ---
 
 ![Install Icinga 2 Monitoring on Debian 9](Icinga2.jpg "Install Icinga 2 Monitoring on Debian 9")

--- a/docs/guides/uptime/monitoring/install-nagios-4-on-ubuntu-debian-8/index.md
+++ b/docs/guides/uptime/monitoring/install-nagios-4-on-ubuntu-debian-8/index.md
@@ -17,6 +17,7 @@ relations:
         key: install-nagios-monitoring
         keywords:
             - distribution: Debian 8
+deprecated: true
 ---
 
 ![Install Nagios 4 on Ubuntu and Debian 8](Install_Nagios_4_smg.jpg)

--- a/docs/guides/web-servers/apache/apache-web-server-debian-8/index.md
+++ b/docs/guides/web-servers/apache/apache-web-server-debian-8/index.md
@@ -18,6 +18,7 @@ relations:
         key: install-apache-server
         keywords:
             - distribution: Debian 8
+deprecated: true
 ---
 
 ![How to Install and Configure Apache Web Server on Debian 8](Apache_Web_Server_on_Debian_8_Jessie_smg.jpg)

--- a/docs/guides/web-servers/apache/install-php-fpm-and-apache-on-debian-8/index.md
+++ b/docs/guides/web-servers/apache/install-php-fpm-and-apache-on-debian-8/index.md
@@ -13,6 +13,7 @@ aliases: ['/websites/apache/install-php-fpm-and-apache-on-debian-8/','/web-serve
 external_resources:
  - '[The PHP Homepage](http://php.net/)'
  - '[FastCGI Process Manager](http://php.net/manual/en/install.fpm.configuration.php)'
+deprecated: true
 ---
 
 PHP-FPM is an implementation of the FastCGI protocol for PHP. This guide covers installing PHP-FPM for Apache on Debian 8 (Jessie).

--- a/docs/guides/web-servers/lamp/lamp-on-debian-8-jessie/index.md
+++ b/docs/guides/web-servers/lamp/lamp-on-debian-8-jessie/index.md
@@ -20,6 +20,7 @@ relations:
         key: install-lamp-stack
         keywords:
             - distribution: Debian 8
+deprecated: true
 ---
 
 Setting up a LAMP (Linux, Apache, MySql, PHP) stack on your server will allow for the creation and hosting of websites and web applications. This guide shows you how to install a LAMP stack on Debian 8 (Jessie).

--- a/docs/guides/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-16-04/index.md
+++ b/docs/guides/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-16-04/index.md
@@ -15,6 +15,7 @@ relations:
         key: install-lemp-stack
         keywords:
             - distribution: Ubuntu 16.04
+deprecated: true
 ---
 
 ![LEMP Server on Ubuntu 16.04](lemp-server-on-ubuntu-1604.png "LEMP Server on Ubuntu 16.04")

--- a/docs/guides/web-servers/lemp/install-a-lemp-stack-on-debian/index.md
+++ b/docs/guides/web-servers/lemp/install-a-lemp-stack-on-debian/index.md
@@ -15,6 +15,7 @@ relations:
         key: install-lemp-stack
         keywords:
             - distribution: Debian 9
+deprecated: true
 ---
 
 ## What is a LEMP Stack?

--- a/docs/guides/web-servers/lighttpd/use-lighttpd-web-server-on-ubuntu-16-04/index.md
+++ b/docs/guides/web-servers/lighttpd/use-lighttpd-web-server-on-ubuntu-16-04/index.md
@@ -21,6 +21,7 @@ relations:
         key: install-lighttpd
         keywords:
             - distribution: Ubuntu 16.04
+deprecated: true
 ---
 
 Lighttpd provides a lightweight web server that is capable of serving large loads while using less memory than servers like Apache. It is commonly deployed on high traffic sites, including WhatsApp and xkcd.

--- a/docs/guides/websites/cms/drupal/managing-web-content-with-drupal-7/index.md
+++ b/docs/guides/websites/cms/drupal/managing-web-content-with-drupal-7/index.md
@@ -10,6 +10,7 @@ keywords: ["drupal", "cms", "web framework", "web application", "php", "content 
 tags: ["drupal","cms","lamp"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/websites/cms/drupal/managing-web-content-with-drupal-7/','/websites/cms/managing-web-content-with-drupal-7/']
+deprecated: true
 ---
 
 Drupal is an advanced and powerful content management framework, built on the PHP scripting language and supported by a [database](/docs/databases/) engine like [MySQL](/docs/databases/mysql/). Drupal provides a flexible system that can be used to manage websites of all different types and profiles. Drupal is capable of providing the tools necessary to create rich, interactive "community" websites with forums, user blogs, and private messaging. Drupal can also provide support for multifaceted personal publishing projects and can power podcasts, blogs, and knowledge-based systems, all within a single, unified platform.

--- a/docs/guides/websites/cms/ghost/how-to-install-ghost-cms-on-ubuntu-16-04/index.md
+++ b/docs/guides/websites/cms/ghost/how-to-install-ghost-cms-on-ubuntu-16-04/index.md
@@ -19,6 +19,7 @@ relations:
         key: how-to-install-ghost-cms
         keywords:
            - distribution: Ubuntu 16.04
+deprecated: true
 ---
 
 ![How to Install Ghost CMS on Ubuntu 16.04](ghost-blog-ubuntu-16-04-title-graphic.png "How to Install Ghost CMS on Ubuntu 16.04")

--- a/docs/guides/websites/cms/how-to-install-a-webmin-control-panel-and-modules/index.md
+++ b/docs/guides/websites/cms/how-to-install-a-webmin-control-panel-and-modules/index.md
@@ -16,6 +16,7 @@ external_resources:
  - '[Webmin Documentation](http://www.webmin.com/docs.html)'
  - '[Webmin Modules](http://www.webmin.com/standard.html)'
  - '[Webmin FAQ](http://www.webmin.com/faq.html)'
+deprecated: true
 ---
 
 ![How to Install a Webmin Control Panel and Modules on Ubuntu](Webmin_Control_Panel_smg.jpg)

--- a/docs/guides/websites/cms/solr/add-a-custom-search-to-your-site-with-solr/index.md
+++ b/docs/guides/websites/cms/solr/add-a-custom-search-to-your-site-with-solr/index.md
@@ -11,6 +11,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
   - '[Apache Solr Reference Guide](https://lucene.apache.org/solr/guide/6_6/)'
 aliases: ['/websites/cms/solr/add-a-custom-search-to-your-site-with-solr/','/websites/cms/add-a-custom-search-to-your-site-with-solr/']
+deprecated: true
 ---
 
 Apache Solr is an open source search platform that provides administrators with a customizable and scalable solution for managing online content. Solr can be configured to index all uploaded data, resulting in fast search results, whether used enterprise-wide or with a single website. In addition to a built-in web control interface, developers can also link access via a client API.

--- a/docs/guides/websites/cms/solr/turbocharge-wordpress-search-with-solr/index.md
+++ b/docs/guides/websites/cms/solr/turbocharge-wordpress-search-with-solr/index.md
@@ -9,6 +9,7 @@ keywords: ["wordpress", "search", "solr", "ubuntu", "debian"]
 tags: ["ubuntu","wordpress","cms","debian"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/websites/cms/solr/turbocharge-wordpress-search-with-solr/','/websites/cms/turbocharge-wordpress-search-with-solr/']
+deprecated: true
 ---
 
 The standard search that is built into WordPress does not provide the best search experience you can offer your visitors, given its inability to suggest search phrases, catch typos, understand word variations, organize and filter results, and index documents for search results. *Full text search engines* often offer these features and **Apache Solr** is a free, open-source option that does.

--- a/docs/guides/websites/cms/wordpress/how-to-install-wordprress-using-wp-cli-on-debian-9/index.md
+++ b/docs/guides/websites/cms/wordpress/how-to-install-wordprress-using-wp-cli-on-debian-9/index.md
@@ -20,6 +20,7 @@ relations:
         keywords:
            - distribution: Debian 9
 aliases: ['/websites/cms/wp-cli/how-to-install-wordprress-using-wp-cli-on-debian-9/','/websites/cms/wordpress/how-to-install-wordprress-using-wp-cli-on-debian-9/']
+deprecated: true
 ---
 
 WordPress is well-known for its rich content management feature set, ease of use, and quick installation time. The [WordPress command line interface (WP-CLI)](https://wp-cli.org/) provides useful commands and utilities to install, configure, and manage a WordPress site. This guide walks you through some common tasks you can complete using the WP-CLI.

--- a/docs/guides/websites/cms/wordpress/install-wordpress-on-ubuntu-16-04/index.md
+++ b/docs/guides/websites/cms/wordpress/install-wordpress-on-ubuntu-16-04/index.md
@@ -18,6 +18,7 @@ relations:
         keywords:
            - distribution: Ubuntu 16.04
 aliases: ['/websites/cms/install-wordpress-on-ubuntu-16-04/','/websites/cms/wordpress/install-wordpress-on-ubuntu-16-04/']
+deprecated: true
 ---
 
 In this guide, you'll learn to how to install WordPress on a Linode running Ubuntu 16.04. WordPress is a popular dynamic content management system focused on blogs. WordPress can be deployed on a LAMP or LEMP stack, and features an extensive plugin framework and theme system that allows site owners and developers to use its simple, yet powerful publishing tools.

--- a/docs/guides/websites/ecommerce/how-to-install-prestashop-on-ubuntu-16-04/index.md
+++ b/docs/guides/websites/ecommerce/how-to-install-prestashop-on-ubuntu-16-04/index.md
@@ -12,6 +12,7 @@ keywords: ["prestashop", "ecommerce", "cms"]
 tags: ["cms", "lamp", "ssl", "ubuntu"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/websites/ecommerce/how-to-install-prestashop-on-ubuntu-16-04/']
+deprecated: true
 ---
 
 ![How to Install PrestaShop of Ubuntu 16.04 LTS](PrestaShop.jpg)

--- a/docs/guides/websites/ecommerce/install-magento-on-ubuntu-16-04/index.md
+++ b/docs/guides/websites/ecommerce/install-magento-on-ubuntu-16-04/index.md
@@ -17,6 +17,7 @@ relations:
         keywords:
            - distribution: Ubuntu 16.04
 aliases: ['/websites/ecommerce/install-magento-on-ubuntu-16-04/']
+deprecated: true
 ---
 
 In this guide you'll learn how to install Magento on Ubuntu 16.04. Magento Community Edition (CE) is a free, open-source e-commerce platform. It's one of the most popular solutions for self-hosted online stores due to its simple yet powerful admin panel and large developer community.

--- a/docs/guides/websites/erp/install-an-odoo-11-stack-on-ubuntu-16-04/index.md
+++ b/docs/guides/websites/erp/install-an-odoo-11-stack-on-ubuntu-16-04/index.md
@@ -17,6 +17,7 @@ external_resources:
   - '[Install an SSL certificate with LetsEncrypt](/docs/guides/install-lets-encrypt-to-create-ssl-certificates/)'
   - '[How to Set up tinc, a Peer-to-Peer VPN](/docs/guides/how-to-set-up-tinc-peer-to-peer-vpn/)'
   - '[Using Terraform to Provision Linode Environments](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/)'
+deprecated: true
 ---
 
 ![Install an Odoo 11 Stack on Ubuntu 16.04 using Linode](install-an-odoo-11-stack-on-ubuntu-16-04-using-linode.png "Odoo 11 on Ubuntu 16.04 Title Graphic")

--- a/docs/guides/websites/erp/install-odoo-10-on-ubuntu-16-04/index.md
+++ b/docs/guides/websites/erp/install-odoo-10-on-ubuntu-16-04/index.md
@@ -13,6 +13,7 @@ aliases: ['/websites/cms/install-odoo-10-on-ubuntu-16-04/','/websites/erp/instal
 external_resources:
  - '[Odoo User Documentation](https://www.odoo.com/documentation/user/10.0/)'
  - '[Odoo Developer Documentation](https://www.odoo.com/documentation/10.0)'
+deprecated: true
 ---
 
 [Odoo](https://www.odoo.com/) (formerly known as OpenERP) is an open-source suite of business applications including customer relationship management (CRM), sales pipeline, project management, manufacturing, invoicing, accounting, eCommerce, and inventory tools, just to name a few. There are thirty-four main applications created by the Odoo team and more than 5,500 developed by community members, covering a wide range of business needs.

--- a/docs/guides/websites/erp/install-odoo-9-erp-on-ubuntu-14-04/index.md
+++ b/docs/guides/websites/erp/install-odoo-9-erp-on-ubuntu-14-04/index.md
@@ -12,6 +12,7 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/websites/erp/install-odoo-9-erp-on-ubuntu-14-04/','/websites/cms/install-odoo-9-erp-on-ubuntu-14-04/']
 external_resources:
  - '[Odoo User Documentation](https://doc.odoo.com/book/)'
+deprecated: true
 ---
 
 [Odoo](https://www.odoo.com/) (formerly known as OpenERP) is an open-source suite of business applications including: Customer Relationship Management, Sales Pipeline, Project Management, Manufacturing, Invoicing , Accounting, eCommerce and Inventory just to name a few. There are 31 main applications created by Odoo team and over 4,500+ developed by community members covering a wide range of business needs.

--- a/docs/guides/websites/forums/install-a-simple-machines-forum-on-your-website/index.md
+++ b/docs/guides/websites/forums/install-a-simple-machines-forum-on-your-website/index.md
@@ -15,7 +15,7 @@ external_resources:
  - '[Modifications, Styles, and Upgrades](http://custom.simplemachines.org/)'
  - '[Functions Database](http://support.simplemachines.org/function_db/)'
  - '[SMF Community Forum](http://www.simplemachines.org/community/index.php)'
-deprecated: false
+deprecated: true
 ---
 
 Simple Machines Forum (SMF) is a popular forum solution for small- to large-sized communities that offers a variety of features. With its modular design and flexibility, users can create their own plugins to modify the behavior of SMF in any way they wish.

--- a/docs/guides/websites/forums/install-and-run-askbot-on-ubuntu-16-04/index.md
+++ b/docs/guides/websites/forums/install-and-run-askbot-on-ubuntu-16-04/index.md
@@ -14,6 +14,7 @@ external_resources:
  - '[AskBot Official Q&A Forum](https://askbot.org)'
  - '[AskBot Official Website](https://askbot.com)'
 aliases: ['/websites/forums/install-and-run-askbot-on-ubuntu-16-04/']
+deprecated: true
 ---
 
 ![AskBot with Let's Encrypt on Ubuntu](AskBot.jpg)

--- a/docs/guides/websites/wikis/dokuwiki-engine/index.md
+++ b/docs/guides/websites/wikis/dokuwiki-engine/index.md
@@ -13,6 +13,7 @@ aliases: ['/web-applications/wikis/dokuwiki/','/websites/wikis/dokuwiki-engine/'
 external_resources:
  - '[The Doku Wiki Project Home Page](http://www.dokuwiki.org/dokuwiki)'
  - '[Doku Wiki Manual](http://www.dokuwiki.org/manual)'
+deprecated: true
 ---
 
 DokuWiki is a flexible and extensible wiki engine that aims to be easy to manage while providing a rich feature set to enable collaborative document editing and creation for users of all skill levels and technical inclinations. DokuWiki stores wiki pages in text files on the web-server rather than in a database management system, which increases data usability and portability for moderately sized wiki projects without requiring the system resources to power a relational database server.


### PR DESCRIPTION
Marking 68 guides deprecated as they are no longer maintained:

- How to Install Ghost CMS on Ubuntu 16.04
- Manage Distributed Version Control with Mercurial
- Install WordPress Using WP-CLI on Debian 9
- Installing Drupal 7
- DokuWiki Engine
- PocketMine Server on Debian 7
- Install a LEMP Stack on Ubuntu 16.04
- Install a LEMP Stack on Debian 9
- What You Need to Do to Mitigate Meltdown and Spectre
- Patching OpenSSL for the Heartbleed Vulnerability
- Install Magento on Ubuntu 16.04
- Deploy a Just Cause 2 Multiplayer Server on Ubuntu 14.04
- Install Apache Cassandra on Debian 9
- Install Seafile with NGINX on Ubuntu 16.04
- How to Install a Turtl Server on Ubuntu
- Installing MariaDB on Debian 9
- Use Salt States to Configure a LAMP Stack on a Minion
- Visualizing Apache Logs Using the Elastic Stack on Debian 8
- Add a Custom Search to your Site with Solr
- How to Use ZFS on Ubuntu 16.04
- Install Nagios 4 on Ubuntu and Debian 8
- Install Java on Debian 8
- Upgrading Bash for the Shellshock Vulnerability
- Turbocharge Your WordPress Search Using Solr
- Install Icinga 2 Monitoring on Debian 9
- Install an Odoo 11 Stack on Ubuntu 16.04
- Installing and Configuring ownCloud on Ubuntu 16.04
- LAMP on Debian 8 (Jessie)
- Upgrading glibc for the GHOST Vulnerability
- How to Install and Run AskBot with LetsEncrypt SSL on Ubuntu 16.04
- Access Google Drive from Linode with Ubuntu 14.04
- Keep Your Data Private in the Cloud with Tahoe-LAFS
- Installing a Simple Machines Discussion Forum (SMF) on Linux
- How to Install and Configure Graylog2 on Debian 9
- How to Install OpenVZ On Debian 9
- Installing Rocket.Chat on Ubuntu 16.04
- Disabling SSLv3 for POODLE
- Ruby on Rails with NGINX On Debian 9
- How to Install and Configure Redmine on Ubuntu 16.04
- Installing PrestaShop on Ubuntu 16.04
- Install Don't Starve Together Game Server on Ubuntu 14.04
- How to Install and Configure phpMyAdmin on Debian 8
- Installing MongoDB on Ubuntu 16.04 (Xenial)
- Install Gogs on Debian 9 with nginx and PostgreSQL
- Install WordPress on Ubuntu 16.04
- Installing PostgreSQL on Ubuntu 16.04
- Apache Web Server on Debian 8 (Jessie)
- Node.js Web Server Deployed within Docker
- Install PHP-FPM and Apache on Debian 8 (Jessie)
- Using lighttpd Web Server on Ubuntu 16.04 (Xenial Xerus)
- How to Install a Redis Server on Ubuntu or Debian 8
- Pflogsumm for Postfix Monitoring on CentOS 6
- Install Odoo 9 ERP on Ubuntu 14.04
- How to Install MySQL on Debian 8
- How to Install a Webmin Control Panel and Modules on Ubuntu 16.04
- Install and Configure MySQL Workbench on Ubuntu 16.04
- Install Ruby on Rails with Apache on Debian 9
- Install Roundcube on Ubuntu 16.04
- Installing and Configuring Mumble on Debian
- How to Mount NFS Shares on Debian 9
- Install Odoo 10 on Ubuntu 16.04
- Set up a Hardened OpenVPN Server on Debian 9
- Configure SPF and DKIM With Postfix on Debian 8
- Install Java on Ubuntu 16.04
- How to Setup a Terraria Linux Server
- Install SquirrelMail on Ubuntu 16.04 or Debian 8
- How to Install and Configure a Redis Cluster on Ubuntu 16.04
- How to Upgrade to Ubuntu 16.04 LTS