### PR TITLE
Fix mistyped "manager" in various documentation.

### DIFF
--- a/docs/guides/development/python/installing-and-importing-modules-in-python-3/index.md
+++ b/docs/guides/development/python/installing-and-importing-modules-in-python-3/index.md
@@ -61,7 +61,7 @@ These instructions are geared toward Ubuntu users but are generally applicable f
 
 ### Install Modules with pip
 
-1. Ensure the `pip` module is already installed. `pip` can be installed using the [APT package manger](/docs/guides/apt-package-manager/).
+1. Ensure the `pip` module is already installed. `pip` can be installed using the [APT package manager](/docs/guides/apt-package-manager/).
 
         sudo apt install python3-pip
 

--- a/docs/guides/kubernetes/how-to-setup-a-private-docker-registry-with-lke-and-object-storage/index.md
+++ b/docs/guides/kubernetes/how-to-setup-a-private-docker-registry-with-lke-and-object-storage/index.md
@@ -274,7 +274,7 @@ You will now complete the steps to deploy your Docker Registry to your Kubernete
 
 To enabled basic access restriction for your Docker registry, you will use the `htpasswd` utility. This utility allows you to use a file to store usernames and passwords for basic HTTP authentication. This will require you to log into your Docker registry prior to being able to push or pull images from and to it.
 
-1.  Install the `htpasswd` utility. This example is for an Ubuntu 18.04 instance, but you can use your system's package manger to install it.
+1.  Install the `htpasswd` utility. This example is for an Ubuntu 18.04 instance, but you can use your system's package manager to install it.
 
     ```command
     sudo apt install apache2-utils -y

--- a/docs/guides/platform/migrate-to-linode/migrating-a-server-to-your-linode/index.md
+++ b/docs/guides/platform/migrate-to-linode/migrating-a-server-to-your-linode/index.md
@@ -133,7 +133,7 @@ After the network copy is complete and the files from the existing server have b
 
     The entire mounted filesystem will be recursively searched for any instances of your old IP address. Note that this replacement operation can take a while to complete.
 
-3.  You can find your IP information in the Linode Cloud Manger under the **Networking** tab. You'll need your public IP, gateway, and DNS server. On the Linode, open the relevant network configuration files for your distribution and adjust them accordingly.
+3.  You can find your IP information in the Linode Cloud Manager under the **Networking** tab. You'll need your public IP, gateway, and DNS server. On the Linode, open the relevant network configuration files for your distribution and adjust them accordingly.
 
 ### Configuring Mount Points
 

--- a/docs/guides/tools-reference/linux-package-management/linux-package-management-overview/index.md
+++ b/docs/guides/tools-reference/linux-package-management/linux-package-management-overview/index.md
@@ -79,7 +79,7 @@ There are lots of package managers in Linux, each working a bit differently. Her
 - **Underlying package management tool:** [RPM](https://linux.die.net/man/8/rpm) (*RPM Package Manager*)
 - **Package file format:** `.rpm`
 
-*Yellowdog Updater, Modified*, more commonly known as [YUM](http://yum.baseurl.org/), is a package management tool for a variety of older RHEL-based distributions (such as CentOS 7) and older versions of Fedora. It provides an easy-to-use interface on top of the low-level functions available in the RPM Package Manger (RPM). It has largely been replaced by it successor *Dandified YUM*, also called DNF, on most newer RPM-based distributions.
+*Yellowdog Updater, Modified*, more commonly known as [YUM](http://yum.baseurl.org/), is a package management tool for a variety of older RHEL-based distributions (such as CentOS 7) and older versions of Fedora. It provides an easy-to-use interface on top of the low-level functions available in the RPM Package Manager (RPM). It has largely been replaced by it successor *Dandified YUM*, also called DNF, on most newer RPM-based distributions.
 
 ### Zypper
 
@@ -90,7 +90,7 @@ There are lots of package managers in Linux, each working a bit differently. Her
 - **Underlying package management tool:** ZYpp (also called [libzypp](https://doc.opensuse.org/projects/libzypp/HEAD/))
 - **Package file format:** `.rpm`
 
-[Zypper](https://en.opensuse.org/Portal:Zypper) is the CLI tool used for managing packages on openSUSE Linux distributions. Just like DNF and YUM, packages are stored in the `.rpm` file format, though Zypper interfaces with the ZYpp (libzypp) library instead of RPM. Some users report that Zypper is faster than other package mangers and, unlike many others, has the ability to add repositories directly from its own CLI. See the [Zypper manual](https://en.opensuse.org/SDB:Zypper_manual) for more usage details.
+[Zypper](https://en.opensuse.org/Portal:Zypper) is the CLI tool used for managing packages on openSUSE Linux distributions. Just like DNF and YUM, packages are stored in the `.rpm` file format, though Zypper interfaces with the ZYpp (libzypp) library instead of RPM. Some users report that Zypper is faster than other package managers and, unlike many others, has the ability to add repositories directly from its own CLI. See the [Zypper manual](https://en.opensuse.org/SDB:Zypper_manual) for more usage details.
 
 ### Pacman
 

--- a/docs/guides/websites/hosting/host-a-website-with-high-availability/index.md
+++ b/docs/guides/websites/hosting/host-a-website-with-high-availability/index.md
@@ -103,7 +103,7 @@ Run the following commands on each Linode in your GlusterFS cluster.
     ```
 
     {{< note >}}
-    In the Linode Manger, you may notice that the netmask for your private IP addresses is `/17`. Firewalld does not recognize this, so a `/32` prefix should be used instead.
+    In the Linode Manager, you may notice that the netmask for your private IP addresses is `/17`. Firewalld does not recognize this, so a `/32` prefix should be used instead.
     {{< /note >}}
 
 1.  Reload your firewall configuration:
@@ -264,7 +264,7 @@ Run the following commands on each database node.
     ```
 
     {{< note >}}
-    In the Linode Manger, you may notice that the netmask for your private IP addresses is `/17`. Firewalld does not recognize this, so a `/32` prefix should be used instead.
+    In the Linode Manager, you may notice that the netmask for your private IP addresses is `/17`. Firewalld does not recognize this, so a `/32` prefix should be used instead.
     {{< /note >}}
 
 1.  Reload your firewall configuration and enable the `firewalld` service to start automatically on boot:

--- a/docs/products/compute/compute-instances/guides/manage-ip-addresses/index.md
+++ b/docs/products/compute/compute-instances/guides/manage-ip-addresses/index.md
@@ -126,7 +126,7 @@ This process only transfers IPv4 addresses and IPv6 ranges, not IPv6 SLAAC addre
     - **Move To:** moves the IP address to another Compute Instance. When choosing this option, select the destination Compute Instance in the next dropdown menu that appears. If you are moving a public IPv4 address, there needs to be at least one remaining public IPv4 address on the source Compute Instance.
     - **Swap With:** swaps the IP addresses of two Compute Instances. When choosing this option, select the destination Compute Instance in the next dropdown menu that appears. Then select the IP address (belonging to the destination Compute Instance) you would like to swap with the originally selected IP address.
 
-    ![The IP Transfer menu in the Cloud Manger](remote_access_ip_transfer.png)
+    ![The IP Transfer menu in the Cloud Manager](remote_access_ip_transfer.png)
 
     {{< note >}}
     The *IP Transfer* form only displays Compute Instances hosted in the same data center as the current Instance.

--- a/docs/products/compute/compute-instances/guides/resize/index.md
+++ b/docs/products/compute/compute-instances/guides/resize/index.md
@@ -10,7 +10,7 @@ image: resizing_a_linode.png
 aliases: ['/platform/disk-images/resizing-a-linode-classic-manager/','/resizing/','/platform/disk-images/resizing-a-linode/','/migrate-to-linode/disk-images/resizing-a-linode/','/guides/resizing-a-linode/']
 ---
 
-You can easily change a Compute Instance's plan using Cloud Manger. Are you expecting a temporary burst of traffic to your website? Or, are you using your plan's resource allotment less than you thought? To accommodate, you can upgrade to a larger plan or downgrade to a smaller one, respectively. You can also change to a different plan type, such as switching from a Shared CPU plan to a Dedicated CPU plan.
+You can easily change a Compute Instance's plan using Cloud Manager. Are you expecting a temporary burst of traffic to your website? Or, are you using your plan's resource allotment less than you thought? To accommodate, you can upgrade to a larger plan or downgrade to a smaller one, respectively. You can also change to a different plan type, such as switching from a Shared CPU plan to a Dedicated CPU plan.
 
 ## Before you begin
 


### PR DESCRIPTION
This change does a pass through the documentation for misuse of "manger" instead of "manager".