### PR TITLE
[UPDATE] Limited Beta for Akamai's New Data Centers

### DIFF
--- a/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
+++ b/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
@@ -10,7 +10,7 @@ noindex: true
 aliases: ['/products/platform/get-started/guides/iad/']
 ---
 
-Akamai is expanding its services to new data centers across the globe. Each new data center will undergo a beta period, where a limited number of interested customers can deploy services in these regions. Premium plans and upgraded Object Storage clusters are only available in these new data centers. As a beta participant, please review this guide for additional specifications and details you may need when configuring your workloads in the one of these data centers.
+Akamai is expanding its services to new data centers across the globe. Each new data center will undergo a beta period, where a limited number of interested customers can deploy services in these regions. Premium plans are available in new data centers. As a beta participant, please review this guide for additional specifications and details you may need when configuring your workloads in the one of these data centers.
 
 {{< note type="warning" >}}
 Capacity in beta data centers may be limited as we continue to scale up resources. Additionally, the beta environment is subject to change. We strongly suggest that participants do not run production workloads during the beta.
@@ -20,7 +20,8 @@ Capacity in beta data centers may be limited as we continue to scale up resource
 
 | Data Center | Status | Region ID |
 | -- | -- | -- |
-| London, England | **Now available to all customers** | `gb-lon` |
+| London, England | **Limited Availability** | `gb-lon` |
+| Melbourne, Australia | **Limited Availability** | `au-mel`
 
 ## Deploy Services in a Beta Data Center
 
@@ -44,11 +45,11 @@ Each data center in this beta is slated to have most of Akamai’s cloud computi
 
 ### Object Storage
 
-The London, England (gb-lon) data center does not support Object Storage during the Beta period.
+The London(gb-lon) and Melbourne (au-mel) data centers do not support Object Storage during the Beta period.
 
 ### Premium Plans
 
-[Premium tier](/docs/products/compute/compute-instances/plans/premium/) Dedicated CPU Compute Instance plans are available only in the new data centers. These plans are in addition to our standard tier Dedicated CPU, Shared CPU, and High Memory instance types. These Premium instances guarantee a baseline hardware class that includes new AMD EPYC™ CPUs. These Premium offerings are built for applications with critical performance needs such as enterprise video encoding, AI, CI/CD, build servers, and data analysis.
+[Premium tier](/docs/products/compute/compute-instances/plans/premium/) Dedicated CPU Compute Instance plans are available only in newer data centers, including those in Beta. These plans are in addition to our standard tier Dedicated CPU, Shared CPU, and High Memory instance types. These Premium instances guarantee a baseline hardware class that includes new AMD EPYC™ CPUs. These Premium offerings are built for applications with critical performance needs such as enterprise video encoding, AI, CI/CD, build servers, and data analysis.
 
 The table below outlines the default pricing and hardware specifications for Premium tier Dedicated CPU Instances. [Pricing](https://www.linode.com/pricing/) may vary by region:
 
@@ -91,6 +92,7 @@ Beta data centers support IP sharing and BGP-based failover, which can be config
 | Data Center | IP Sharing Support | Failover Method | Software | ID |
 | --- | --- | --- | --- | --- |
 | London, England | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 44 |
+| Melbourne, Australia | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 45 |
 
 ### Lish Gateways
 
@@ -102,10 +104,24 @@ Lish and Glish provide direct access to your Compute Instances, bypassing the ne
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
-    RSA 3072 SHA256:/y+83+sA3JdDGkv/KLnIAIXqfgqWfgp5RZ+DCx1T4yU lish-nl-ams.linode.com
-    ECDSA 256 SHA256:iR/He+teo+c7jqr8LzaTikbTlMDdIkIERhJBXdIjO8w lish-nl-ams.linode.com
+    RSA 3072 SHA256:EIKjJlF0nmpuj795Y4DhwYjIMCDa2yodWKk9rKxg67o lish-gb-lon.linode.com
+    ECDSA 256 SHA256:MvMwule197MvqJIjvJq7vjnxlvX0XveAocRPDs5jbMA lish-gb-lon.linode.com
     ED25519 256 SHA256:4IUSmmru/F/Q4nHVZjBZUzSol7XLaE33i8hLPD8VJ2o lish-gb-lon.linode.com
     ```
     {{< /note >}}
 
 -   **Weblish/Glish Gateway:** `gb-lon.webconsole.linode.com`
+
+#### Melbourne, Australia
+
+-   **Lish SSH Gateway:** `lish-au-mel.linode.com`
+
+    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
+    ```command
+    RSA 3072 SHA256:JX2eVSdHIJzb3iDJFpTtHVGQq1paEh53D9cnsEPNvvU lish-au-mel.linode.com
+    ECDSA 256 SHA256:88mN/wieI4kG1rkuohob3ZyqhvCMiMWiCTVN1XECvLU lish-au-mel.linode.com
+    ED25519 256 SHA256:e8xMMpHXjDRi9vSiNliiMEHtsKzAjGdG0WkeFS3W1RU lish-au-mel.linode.com
+    ```
+    {{< /note >}}
+
+-   **Weblish/Glish Gateway:** `au-mel.webconsole.linode.com`

--- a/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
+++ b/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
@@ -45,11 +45,11 @@ Each data center in this beta is slated to have most of Akamai’s cloud computi
 
 ### Object Storage
 
-The London(gb-lon) and Melbourne (au-mel) data centers do not support Object Storage during the Beta period.
+The London (gb-lon) and Melbourne (au-mel) data centers do not support Object Storage during the beta period.
 
 ### Premium Plans
 
-[Premium tier](/docs/products/compute/compute-instances/plans/premium/) Dedicated CPU Compute Instance plans are available only in newer data centers, including those in Beta. These plans are in addition to our standard tier Dedicated CPU, Shared CPU, and High Memory instance types. These Premium instances guarantee a baseline hardware class that includes new AMD EPYC™ CPUs. These Premium offerings are built for applications with critical performance needs such as enterprise video encoding, AI, CI/CD, build servers, and data analysis.
+[Premium tier](/docs/products/compute/compute-instances/plans/premium/) Dedicated CPU Compute Instance plans are available only in newer data centers, including those in beta. These plans are in addition to our standard tier Dedicated CPU, Shared CPU, and High Memory instance types. These Premium instances guarantee a baseline hardware class that includes new AMD EPYC™ CPUs. These Premium offerings are built for applications with critical performance needs such as enterprise video encoding, AI, CI/CD, build servers, and data analysis.
 
 The table below outlines the default pricing and hardware specifications for Premium tier Dedicated CPU Instances. [Pricing](https://www.linode.com/pricing/) may vary by region:
 

--- a/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
+++ b/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
@@ -2,7 +2,7 @@
 title: "Limited Beta for Akamai's New Data Centers"
 description: "This document provides details for the limited availability beta of Akamai Cloud Compute's latest data centers."
 published: 2023-04-17
-modified: 2024-06-23
+modified: 2024-07-05
 tags: ["linode platform"]
 _build:
   list: false

--- a/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
+++ b/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
@@ -21,7 +21,7 @@ Capacity in beta data centers may be limited as we continue to scale up resource
 | Data Center | Status | Region ID |
 | -- | -- | -- |
 | London, England | **Limited Availability** | `gb-lon` |
-| Melbourne, Australia | **Limited Availability** | `au-mel`
+| Melbourne, Australia | **Limited Availability** | `au-mel` |
 
 ## Deploy Services in a Beta Data Center
 

--- a/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
+++ b/docs/products/platform/get-started/guides/beta-for-new-data-centers/index.md
@@ -2,7 +2,7 @@
 title: "Limited Beta for Akamai's New Data Centers"
 description: "This document provides details for the limited availability beta of Akamai Cloud Compute's latest data centers."
 published: 2023-04-17
-modified: 2024-02-14
+modified: 2024-06-23
 tags: ["linode platform"]
 _build:
   list: false
@@ -10,30 +10,17 @@ noindex: true
 aliases: ['/products/platform/get-started/guides/iad/']
 ---
 
-Akamai is expanding its services to new data centers across the globe. Each new data center will undergo a beta period, where a limited number of interested customers can deploy services in these regions. All Akamai cloud computing services are fully operational in these data centers. In addition, Premium plans and upgraded Object Storage clusters are only available in these new data centers. As a beta participant, please review this guide for additional specifications and details you may need when configuring your workloads in the one of these data centers.
+Akamai is expanding its services to new data centers across the globe. Each new data center will undergo a beta period, where a limited number of interested customers can deploy services in these regions. Premium plans and upgraded Object Storage clusters are only available in these new data centers. As a beta participant, please review this guide for additional specifications and details you may need when configuring your workloads in the one of these data centers.
 
 {{< note type="warning" >}}
 Capacity in beta data centers may be limited as we continue to scale up resources. Additionally, the beta environment is subject to change. We strongly suggest that participants do not run production workloads during the beta.
 {{< /note >}}
 
-## List of New Data Centers
+## List of Beta Data Centers
 
 | Data Center | Status | Region ID |
 | -- | -- | -- |
-| Amsterdam, Netherlands | **Now available to all customers** | `nl-ams` |
-| Chennai, India | **Now available to all customers** | `in-maa` |
-| Chicago, IL, USA | **Now available to all customers** | `us-ord` |
-| Jakarta, Indonesia | **Now available to all customers** | `id-cgk` |
-| Los Angeles, CA, USA | **Now available to all customers** | `us-lax` |
-| Madrid, Spain | **Now available to all customers** | `es-mad` |
-| Miami, FL, USA | **Now available to all customers** | `us-mia` |
-| Milan, Italy | **Now available to all customers** | `it-mil` |
-| Osaka, Japan | **Now available to all customers** | `jp-osa` |
-| Paris, France | **Now available to all customers** | `fr-par` |
-| São Paulo, Brazil | **Now available to all customers** | `br-gru` |
-| Seattle, WA, USA | **Now available to all customers** | `us-sea` |
-| Stockholm, Sweden | **Now available to all customers** | `se-sto` |
-| Washington, DC, USA | **Now available to all customers** | `us-iad` |
+| London, England | **Now available to all customers** | `gb-lon` |
 
 ## Deploy Services in a Beta Data Center
 
@@ -41,12 +28,10 @@ Follow the instructions below to target one of the new data centers when deployi
 
 -   **Cloud Manager:** Select the name of the data center you wish to use in the region dropdown menu.
 
-    ![Screenshot of the Cloud Manager region selection dropdown menu](select-washington-dc-cloud-manager.png)
-
 -   **Linode CLI and Linode API:** If a command or request requires a region ID, use the one that corresponds to your desired data center in the [table above](#list-of-new-data-centers).
 
 {{< note type="warning" noTitle=true >}}
-You must enrolled in the beta to select one of the beta data centers when deploying services. If you are a beta participant but are not able to target one of these data centers, please contact the [Support team](https://www.linode.com/support/) for assistance. You need to request access to *each* data center you wish to use during the beta period.
+You must be enrolled in the beta to select a beta data center when deploying services. If you are a beta participant but are not able to target a beta data center, please contact the [Support team](https://www.linode.com/support/) for assistance. You need to request access to *each* data center you wish to use during the beta period.
 {{< /note >}}
 
 ## Pricing
@@ -59,33 +44,11 @@ Each data center in this beta is slated to have most of Akamai’s cloud computi
 
 ### Object Storage
 
-The new data centers feature enhanced Object Storage, which improves upon the consistency and reliability of the existing service and offers increased capacity (outlined below). Review the [Availability](/docs/products/storage/object-storage/#availability) and [Specifications](/docs/products/storage/object-storage/#specifications) section of the Object Storage documentation for more details.
-
-- **Max storage** (*per region, per account*): 100 TB (up to 1,000 TB by request)
-- **Max # of objects** (*per region, per account*): 100 million (up to 1 billion by request)
-
-The following table includes the IDs and URLs of each new Object Storage cluster:
-
-| Data Center | Cluster ID | Cluster URL |
-| --| -- | -- |
-| Amsterdam, Netherlands | `nl-ams-1` | `https://nl-ams-1.linodeobjects.com` |
-| Chennai, India | `in-maa-1` | `https://in-maa-1.linodeobjects.com` |
-| Chicago, IL, USA | `us-ord-1` | `https://us-ord-1.linodeobjects.com` |
-| Jakarta, Indonesia | `id-cgk-1` | `https://id-cgk-1.linodeobjects.com` |
-| Los Angeles, CA, USA | `us-lax-1` | `https://us-lax-1.linodeobjects.com` |
-| Madrid, Spain | `es-mad-1` | `https://es-mad-1.linodeobjects.com` |
-| Miami, FL, USA | `us-mia-1` | `https://us-mia-1.linodeobjects.com` |
-| Milan, Italy | `it-mil-1` | `https://it-mil-1.linodeobjects.com` |
-| Osaka, Japan | `jp-osa-1	` | `https://jp-osa-1.linodeobjects.com` |
-| Paris, France | `fr-par-1` | `https://fr-par-1.linodeobjects.com` |
-| São Paulo, Brazil | `br-gru-1` | `https://br-gru-1.linodeobjects.com` |
-| Seattle, WA, USA | `us-sea-1` | `https://us-sea-1.linodeobjects.com` |
-| Stockholm, Sweden | `se-sto-1` | `https://se-sto-1.linodeobjects.com	` |
-| Washington, DC, USA | `us-iad-1` | `https://us-iad-1.linodeobjects.com` |
+The London, England (gb-lon) data center does not support Object Storage during the Beta period.
 
 ### Premium Plans
 
-A new [Premium tier](/docs/products/compute/compute-instances/plans/premium/) Dedicated CPU Compute Instance plan is available only in the new data centers. This is in addition to our standard tier Dedicated CPU, Shared CPU, and High Memory instance types. These Premium tier instances guarantee a baseline hardware class that includes new AMD EPYC™ CPUs. These Premium offerings are built for applications with critical performance needs such as enterprise video encoding, AI, CI/CD, build servers, and data analysis.
+[Premium tier](/docs/products/compute/compute-instances/plans/premium/) Dedicated CPU Compute Instance plans are available only in the new data centers. These plans are in addition to our standard tier Dedicated CPU, Shared CPU, and High Memory instance types. These Premium instances guarantee a baseline hardware class that includes new AMD EPYC™ CPUs. These Premium offerings are built for applications with critical performance needs such as enterprise video encoding, AI, CI/CD, build servers, and data analysis.
 
 The table below outlines the default pricing and hardware specifications for Premium tier Dedicated CPU Instances. [Pricing](https://www.linode.com/pricing/) may vary by region:
 
@@ -101,9 +64,9 @@ The table below outlines the default pricing and hardware specifications for Pre
 | Premium 256 GB | $2,765/mo ($4.15/hr) | 256 | 56 | 5,000 | 11 | 40/11 |
 | Premium 512 GB | $5,530/mo ($8.29/hr) | 512 | 64 | 7,200 | 12 | 40/12 |
 
-The new Premium plans can also be deployed as worker nodes in Linode Kubernetes Engine (LKE) clusters. There is no additional cost for Premium plan LKE worker nodes beyond the price listed in the Premium pricing table above.
+Premium CPU plans can also be deployed as worker nodes in Linode Kubernetes Engine (LKE) clusters. There is no additional cost for Premium plan LKE worker nodes beyond the price listed in the Premium pricing table above.
 
-{{< note isCollapsible=true title="Details of the Backup service for Premium Plans" >}}
+{{< note isCollapsible=true title="Details of the Backup service for Premium CPU Plans" >}}
 Optionally, you can also add the [Backup](/docs/products/storage/backups/) service to a Premium instance. The default prices for this service are outlined below. [Pricing](https://www.linode.com/pricing/) may vary by region:
 
 | <div class="w-40">Plan</div> | Price for the Backup service |
@@ -123,221 +86,26 @@ Optionally, you can also add the [Backup](/docs/products/storage/backups/) servi
 
 ### IP Sharing and Failover
 
-All new data centers support IP sharing and BGP-based failover, which can be configured on IPv4 addresses (public and private) and addresses from IPv6 routed ranges (/64 and /56). To configure failover, you can use [lelastic](https://github.com/linode/lelastic), Linode's own software, or software like FRR, BIRD, or GoBGP. For more information on failover, consult our [failover documentation](/docs/products/compute/compute-instances/guides/failover/).
+Beta data centers support IP sharing and BGP-based failover, which can be configured on IPv4 addresses (public and private) and addresses from IPv6 routed ranges (/64 and /56). To configure failover, you can use [lelastic](https://github.com/linode/lelastic), Linode's own software, or software like FRR, BIRD, or GoBGP. For more information on failover, consult our [failover documentation](/docs/products/compute/compute-instances/guides/failover/).
 
 | Data Center | IP Sharing Support | Failover Method | Software | ID |
 | --- | --- | --- | --- | --- |
-| Amsterdam, Netherlands | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 22 |
-| Chennai, India | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 25 |
-| Chicago, IL, USA | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 18 |
-| Jakarta, Indonesia | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 29 |
-| Los Angeles, CA, USA | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 30 |
-| Madrid, Spain | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 24 |
-| Miami, FL, USA | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 28 |
-| Milan, Italy | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 27 |
-| Osaka, Japan | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 26 |
-| Paris, France | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 19 |
-| São Paulo, Brazil | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 21 |
-| Seattle, WA, USA | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 20 |
-| Stockholm, Sweden | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 23 |
-| Washington, DC, USA | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 17 |
+| London, England | Supported | BGP-based (new) | [lelastic](/docs/products/compute/compute-instances/guides/failover/#configure-failover) / [FRR](/docs/products/compute/compute-instances/guides/failover-bgp-frr/) | 44 |
 
 ### Lish Gateways
 
 Lish and Glish provide direct access to your Compute Instances, bypassing the need for SSH or a VNC. For more information on Lish, consult our guide on how to [Access Your System Console Using Lish](/docs/products/compute/compute-instances/guides/lish/).
 
-#### Amsterdam, Netherlands
+#### London, England
 
--   **Lish SSH Gateway:** `lish-nl-ams.linode.com`
+-   **Lish SSH Gateway:** `lish-gb-lon.linode.com`
 
     {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
     ```command
     RSA 3072 SHA256:/y+83+sA3JdDGkv/KLnIAIXqfgqWfgp5RZ+DCx1T4yU lish-nl-ams.linode.com
     ECDSA 256 SHA256:iR/He+teo+c7jqr8LzaTikbTlMDdIkIERhJBXdIjO8w lish-nl-ams.linode.com
-    ED25519 256 SHA256:vxF9arB2lYBVP45ZA7t1JEE9w/vthPmzU3a2oOR8O7Y lish-nl-ams.linode.com
+    ED25519 256 SHA256:4IUSmmru/F/Q4nHVZjBZUzSol7XLaE33i8hLPD8VJ2o lish-gb-lon.linode.com
     ```
     {{< /note >}}
 
--   **Weblish/Glish Gateway:** `nl-ams.webconsole.linode.com`
-
-#### Chennai, India
-
--   **Lish SSH Gateway:** `lish-in-maa.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:kXCaKnn1nVlVEC5SCuez6FApcXr/2UUiaSANUy0rlLI lish-in-maa.linode.com
-    ECDSA 256 SHA256:Jj+pb1AkDdKs77o6ozgkOk83rg7auLSOQrnebE8n91o lish-in-maa.linode.com
-    ED25519 256 SHA256:v1KaIB0togivalP7OVvlrLpu/y80qsm5cj50qclTWc0 lish-in-maa.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `in-maa.webconsole.linode.com`
-
-#### Chicago, IL, USA
-
--   **Lish SSH Gateway:** `lish-us-ord.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:rRwktOKfSApeffa+YOVxXXL70Ba1CpTYp/oFywEH2Pc lish-us-ord.linode.com
-    ECDSA 256 SHA256:SV9A/24Jdb++ns/+6Gx7WqZCyN4+0y4ICFsaqK3Rm8s lish-us-ord.linode.com
-    ED25519 256 SHA256:J+yN8rjhr9j27M4zLSF6OX9XmIoipWbPP/J1AGRlRYc lish-us-ord.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `us-ord.webconsole.linode.com`
-
-#### Jakarta, Indonesia
-
--   **Lish SSH Gateway:** `lish-id-cgk.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:n+f2JBMBYvvJUw11nYafKrX1nU3gdohnWfj9qdTXU+I lish-id-cgk.linode.com
-    ECDSA 256 SHA256:CwM8d4D9yU0Mw/Odu4bxs6OWpfzJHSrSUUgtkZNRvsk lish-id-cgk.linode.com
-    ED25519 256 SHA256:RvdTsLHAWcjmXU2h5JD821Xk4x40FcHLzpX2/ppMLh0 lish-id-cgk.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `id-cgk.webconsole.linode.com`
-
-#### Los Angeles, CA, USA
-
--   **Lish SSH Gateway:** `lish-us-lax.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:TVyXe3i1iJF9rU+j/t57wpdRB2h56Kh2tnZsUra30kA lish-us-lax.linode.com
-    ECDSA 256 SHA256:Yh+jEgxiGIgETrC9uz4wUqnKvi7yPrlqgmpxsa65QDI lish-us-lax.linode.com
-    ED25519 256 SHA256:kFi+ignk5bxYxnk/F3Lehk0HoM98BuUzEGhlEzhHo9I lish-us-lax.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `us-lax.webconsole.linode.com`
-
-#### Madrid, Spain
-
--   **Lish SSH Gateway:** `lish-es-mad.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:sIYL6fvcNZVz3pXa6fp6YNS4ITfcCTu918pH0dxmaL0 lish-es-mad.linode.com
-    ECDSA 256 SHA256:eSqy+KAkPlzqRxYnPzGKJXuVd6D5APZsM/qWAWVk5xs lish-es-mad.linode.com
-    ED25519 256 SHA256:Sm20p3dsXSoqdRF8RwehfHn2sJszSuP/Z454glxohbc lish-es-mad.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `es-mad.webconsole.linode.com`
-
-#### Miami, FL, USA
-
--   **Lish SSH Gateway:** `lish-us-mia.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:kfwzGjXR+WV1JxvufbsZTv4qzVUI5Nkmh3Z3/XhpAT8 lish-us-mia.linode.com
-    ECDSA 256 SHA256:cZVK7bB8cwci3sXJJNIaBlX9Z3DlBj3hAL5J8Hc+vr0 lish-us-mia.linode.com
-    ED25519 256 SHA256:+sBLV01KzOiVJw4OJGmO71+NUm2cE7ndpj1aqW2tNLg lish-us-mia.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `us-mia.webconsole.linode.com`
-
-#### Milan, Italy
-
--   **Lish SSH Gateway:** `lish-it-mil.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:toVfir7U8Ixg0wELAx0qCC91ld+HIxmTwggUP/+itkU lish-it-mil.linode.com
-    ECDSA 256 SHA256:XQDX+diXFBAT8OjpN+zwZN5sukTAQwtqe+i89Kh6gXQ lish-it-mil.linode.com
-    ED25519 256 SHA256:Uxw1KbWQVz5QYHHfUzFJcZM+HLbdu6vJ/R3ksEv2k3M lish-it-mil.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `it-mil.webconsole.linode.com`
-
-#### Osaka, Japan
-
--   **Lish SSH Gateway:** `lish-jp-osa.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:VXDxZ8+0b1Q54Bzvt7a6A4bvvKAI5OHxBYxwIC4OsDQ lish-jp-osa.linode.com
-    ECDSA 256 SHA256:qM6cfmK2/Vrho1exDZ9qe4cLWVdp5U0dv5MJ22K+lwE lish-jp-osa.linode.com
-    ED25519 256 SHA256:1CJ7P/i5XUP6XWizukQ7XIEiQ5rlIM+06N6qF2WfDMc lish-jp-osa.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `jp-osa.webconsole.linode.com`
-
-#### Paris, France
-
--   **Lish SSH Gateway:** `lish-fr-par.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:qTliFB86axo9n07H0hUP/z5nm7Fbkzlf8eKnmtXBhZU lish-fr-par.linode.com
-    ECDSA 256 SHA256:NU4UctBefhWIR3mpCrh+r2p5lNmtwFFoeelZspjMNYM lish-fr-par.linode.com
-    ED25519 256 SHA256:GYNvVuHJqGIdCiU6yTPbkJmMgj+ZYBGRVGDqnrtJoQc lish-fr-par.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `fr-par.webconsole.linode.com`
-
-#### São Paulo, Brazil
-
--   **Lish SSH Gateway:** `lish-br-gru.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:lmtONyLfe0tiLEdNrbEUd8j10A/o/Ss1HaUYJDgc8ks lish-br-gru.linode.com
-    ECDSA 256 SHA256:ftl4kIcxzeGUsT9FPQ49GF7afel1yrOQgclJN7/8kuk lish-br-gru.linode.com
-    ED25519 256 SHA256:EKqBawVESQnL4oQOMskpBAtrEiOlE+qD9M6WLiFbCyU lish-br-gru.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `br-gru.webconsole.linode.com`
-
-#### Seattle, WA, USA
-
--   **Lish SSH Gateway:** `lish-us-sea.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:XqkskcFrRzZbMU/XeR1diiNM6zCsWs2wL4pmTvBLNII lish-us-sea.linode.com
-    ECDSA 256 SHA256:FEqVGwuv/BgbLtNkcfFg7Lgm0R6KQVUnPY+wIoimrrA lish-us-sea.linode.com
-    ED25519 256 SHA256:6R7iWvSe7OQSDcVmhwrH/EJiE51+ntiub3CPXfzupDA lish-us-sea.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `us-sea.webconsole.linode.com`
-
-#### Stockholm, Sweden
-
--   **Lish SSH Gateway:** `lish-se-sto.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:oC6WZwUMm+S/myz7aEBP6YsAUXss7csmWzJRlwDfpyw lish-se-sto.linode.com
-    ECDSA 256 SHA256:lr6m6BKQBqFW/iw/WDq2QQqh5kUlMjidawEEKv9lNRg lish-se-sto.linode.com
-    ED25519 256 SHA256:phubC9JMR6DNal0BIvu2ESvmDfs2rSquBrhKdr0IbmU lish-se-sto.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `se-sto.webconsole.linode.com`
-
-#### Washington, DC, USA
-
--   **Lish SSH Gateway:** `lish-us-iad.linode.com`
-
-    {{< note type="secondary" title="Lish SSH Gateway Fingerprints" isCollapsible=true >}}
-    ```command
-    RSA 3072 SHA256:mzFtMaMVX6CsLXsYWn6c8BXnXk0XHfoOXGExDUEH2OI lish-us-iad.linode.com
-    ECDSA 256 SHA256:of9osuoFwh7g5ZiO0G3ZGYi/8JcCw3BA/ZdkpaKQlT0 lish-us-iad.linode.com
-    ED25519 256 SHA256:oFoUJn/xXV/+b7EJIcIt6G6hV5jXzjM/pOsoceDDOaA lish-us-iad.linode.com
-    ```
-    {{< /note >}}
-
--   **Weblish/Glish Gateway:** `us-iad.webconsole.linode.com`
+-   **Weblish/Glish Gateway:** `gb-lon.webconsole.linode.com`


### PR DESCRIPTION
Updated to remove data centers now in GA and add new London (gb-lon) and Melbourne (au-mel) DCs

Full preview link is: https://deploy-preview-7016--nostalgic-ptolemy-b01ab8.netlify.app/docs/products/platform/get-started/guides/beta-for-new-data-centers/
.