### PR TITLE
Remove embedded YouTube videos within product docs

### DIFF
--- a/docs/products/networking/dns-manager/guides/common-dns-configurations/index.md
+++ b/docs/products/networking/dns-manager/guides/common-dns-configurations/index.md
@@ -9,8 +9,6 @@ tags: ["dns","networking","cloud manager","linode platform"]
 aliases: ['/networking/dns/common-dns-configurations/','/dns-guides/configuring-dns-with-the-linode-manager/','/networking/dns/common-dns-configurations-classic-manager/','/guides/common-dns-configurations/']
 ---
 
-{{< youtube Vb1JsfZlFLE >}}
-
 ## Set Up a Domain
 
 The most common DNS configuration is a single domain name on a single Linode. For this, you'll need to add *SOA* and *NS records* for all of your name servers, and *A/AAAA* records for your domain names. Use the screenshot below as a guide.

--- a/docs/products/storage/object-storage/get-started/index.md
+++ b/docs/products/storage/object-storage/get-started/index.md
@@ -7,8 +7,6 @@ tab_group_main:
 aliases: ['/platform/object-storage/how-to-use-object-storage/','/guides/how-to-use-object-storage/']
 ---
 
-{{< youtube q88OKsr5l6c >}}
-
 ## Enable Object Storage
 
 Object Storage is not enabled for a Linode account by default. All that is required to enable Object Storage is to create a bucket or an Object Storage access key. To cancel Object Storage, see the [Cancel Object Storage](/docs/products/storage/object-storage/guides/cancel/) guide.

--- a/docs/products/tools/marketplace/guides/counter-strike-go/index.md
+++ b/docs/products/tools/marketplace/guides/counter-strike-go/index.md
@@ -10,8 +10,6 @@ tags: ["linode platform","marketplace","cloud-manager"]
 aliases: ['/platform/marketplace/deploying-cs-go-with-marketplace-apps/', '/platform/one-click/deploying-cs-go-with-one-click-apps/','/guides/deploying-cs-go-with-one-click-apps/','/guides/deploying-cs-go-with-marketplace-apps/','/guides/counter-strike-go-marketplace-app/']
 ---
 
-{{< youtube aSivuBZxUgw >}}
-
 [Counter-Strike: Global Offensive](https://store.steampowered.com/app/730/CounterStrike_Global_Offensive/) (CS:GO) is a fast-paced first person shooter. Teams compete against each other to complete objectives or to eliminate the opposing team. A competitive match requires two teams of five players, but hosting your own server offers you control over team size and server location, so you and your friends can play with low latency. Up to 64 players can be hosted on a single server.
 
 This Marketplace App deploys the CS:GO server software through [LinuxGSM](https://linuxgsm.com/). While no additional license is required to run the server, each client needs to have a license for the game.

--- a/docs/products/tools/marketplace/guides/wireguard/index.md
+++ b/docs/products/tools/marketplace/guides/wireguard/index.md
@@ -12,7 +12,6 @@ external_resources:
 - '[WireGuard man page](https://manpages.debian.org/unstable/wireguard-tools/wg.8.en.html)'
 aliases: ['/platform/marketplace/deploy-wireguard-with-marketplace-apps/', '/platform/one-click/deploy-wireguard-with-one-click-apps/','/guides/deploy-wireguard-with-one-click-apps/','/guides/deploy-wireguard-with-marketplace-apps/','/guides/wireguard-marketplace-app/']
 ---
-<!-- {{< youtube Q1I6-clkQmQ >}} -->
 
 WireGuard&#174; is a simple, fast, and modern virtual private network (VPN) which utilizes state-of-the-art cryptography. It aims to be faster and leaner than other VPN protocols such as OpenVPN and IPSec, and it has a much smaller source code footprint.
 


### PR DESCRIPTION
This PR removes embedded youtube videos from all guides (4) within product documentation.