### PR TITLE
[Updated] Terraform guides with steps for storing state on OBJ

### DIFF
--- a/docs/guides/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/index.md
@@ -5,7 +5,7 @@ description: 'This article gives you step-by-step instructions on how to use Ter
 authors: ["Damaso Sanoja"]
 contributors: ["Damaso Sanoja"]
 published: 2017-11-06
-modified: 2023-07-26
+modified: 2024-08-26
 keywords: ["terraform", "infrastructure", "IaC"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/','/applications/configuration-management/how-to-build-your-infrastructure-using-terraform-and-linode/','/platform/how-to-build-your-infrastructure-using-terraform-and-linode/']
@@ -677,3 +677,29 @@ Create a deployment for an imaginary client:
     terraform plan
     terraform apply
     ```
+
+### Use Linode Object Storage to Store State
+
+[State](https://developer.hashicorp.com/terraform/language/state) data files are stored on a [backend](https://developer.hashicorp.com/terraform/language/settings/backends/configuration) by Terraform to log and track metadata, map resources to a configuration, and improve performance. By default, state is stored locally in the `terraform.tfstate` file.
+
+Using the configuration below with the `backend` block, you can set up Terraform to use Linode Object Storage to store state remotely. This can be added to an existing module or added to your modules as a new file.
+
+Note that this module assumes an object storage bucket already exists on your account. Replace values with your bucket and key information:
+
+```file {title="obj-backend.tf"}
+# Backend Configuration
+backend "s3" {
+    bucket = "{{< placeholder "YOUR-BUCKET-NAME" >}}"   # The bucket name created on your account to which your access_key and secret_key can read and write
+    key = "tf/tfstate"  # The folder and object you want to write state to
+    region = "{{< placeholder "us-southeast-1" >}}"  # The region where your object storage bucket is at which is the same as the ClusterID Here https://techdocs.akamai.com/cloud-computing/docs/access-buckets-and-files-through-urls#cluster-url-s3-endpoint
+    access_key = "{{< placeholder "OBJ-ACCESS-KEY" >}}"  # You can put your value here inline or add it as an environment variable OBJ_ACCESS_KEY_ID  see more here https://developer.hashicorp.com/terraform/language/settings/backends/s3#credentials-and-shared-configuration
+    secret_key = "{{< placeholder "OBJ-SECRET-KEY" >}}"  # You can put your value here inline or add it as an environment variable OBJ_SECRET_ACCESS_KEY see more here https://developer.hashicorp.com/terraform/language/settings/backends/s3#credentials-and-shared-configuration
+    skip_region_validation = true  # All of these skip_* arguements are used since our object storage doesn't implement these additional endpoints
+    skip_credentials_validation = true
+    skip_requesting_account_id = true
+    skip_s3_checksum = true
+    endpoints = {
+      s3 = "{{< placeholder "https://us-southeast-1.linodeobjects.com" >}}"  # The endpoint for the s3 API based on the region your bucket is located https://techdocs.akamai.com/cloud-computing/docs/access-buckets-and-files-through-urls#cluster-url-s3-endpoint
+    }
+  }
+```

--- a/docs/guides/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/index.md
@@ -682,7 +682,7 @@ Create a deployment for an imaginary client:
 
 [State](https://developer.hashicorp.com/terraform/language/state) data files are stored on a [backend](https://developer.hashicorp.com/terraform/language/settings/backends/configuration) by Terraform to log and track metadata, map resources to a configuration, and improve performance. By default, state is stored locally in the `terraform.tfstate` file.
 
-Using the configuration below with the `backend` block, you can set up Terraform to use Linode Object Storage to store state remotely. This can be added to an existing module or added to your modules as a new file.
+Using the configuration below with the `backend` block, you can set up Terraform to use Linode Object Storage to store state remotely. The `backend` block should be nested within the `terraform` block as noted in [Hashicorp's official backend documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3). In this guide, the `terraform` block is located in the `main.tf` configuration file.
 
 Note that this module assumes an object storage bucket already exists on your account. Replace values with your bucket and key information:
 
@@ -692,8 +692,8 @@ backend "s3" {
     bucket = "{{< placeholder "YOUR-BUCKET-NAME" >}}"   # The bucket name created on your account to which your access_key and secret_key can read and write
     key = "{{< placeholder "tf/tfstate" >}}"  # The folder ({{< placeholder "tf" >}}) and object ({{< placeholder "tfstate" >}}) in your bucket where you want to write state to
     region = "{{< placeholder "us-southeast-1" >}}"  # The region where your object storage bucket is at which is the same as the ClusterID Here https://techdocs.akamai.com/cloud-computing/docs/access-buckets-and-files-through-urls#cluster-url-s3-endpoint
-    access_key = "{{< placeholder "OBJ-ACCESS-KEY" >}}"  # You can put your value here inline or add it as an environment variable OBJ_ACCESS_KEY_ID  see more here https://developer.hashicorp.com/terraform/language/settings/backends/s3#credentials-and-shared-configuration
-    secret_key = "{{< placeholder "OBJ-SECRET-KEY" >}}"  # You can put your value here inline or add it as an environment variable OBJ_SECRET_ACCESS_KEY see more here https://developer.hashicorp.com/terraform/language/settings/backends/s3#credentials-and-shared-configuration
+    access_key = "{{< placeholder "OBJ-ACCESS-KEY" >}}"  # You can put your value here inline or add it as an environment variable AWS_ACCESS_KEY_ID  see more here https://developer.hashicorp.com/terraform/language/settings/backends/s3#credentials-and-shared-configuration
+    secret_key = "{{< placeholder "OBJ-SECRET-KEY" >}}"  # You can put your value here inline or add it as an environment variable AWS_SECRET_ACCESS_KEY see more here https://developer.hashicorp.com/terraform/language/settings/backends/s3#credentials-and-shared-configuration
     skip_region_validation = true  # All of these skip_* arguements are used since our object storage doesn't implement these additional endpoints
     skip_credentials_validation = true
     skip_requesting_account_id = true

--- a/docs/guides/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/index.md
@@ -690,7 +690,7 @@ Note that this module assumes an object storage bucket already exists on your ac
 # Backend Configuration
 backend "s3" {
     bucket = "{{< placeholder "YOUR-BUCKET-NAME" >}}"   # The bucket name created on your account to which your access_key and secret_key can read and write
-    key = "tf/tfstate"  # The folder and object you want to write state to
+    key = "{{< placeholder "tf/tfstate" >}}"  # The folder ({{< placeholder "tf" >}}) and object ({{< placeholder "tfstate" >}}) in your bucket where you want to write state to
     region = "{{< placeholder "us-southeast-1" >}}"  # The region where your object storage bucket is at which is the same as the ClusterID Here https://techdocs.akamai.com/cloud-computing/docs/access-buckets-and-files-through-urls#cluster-url-s3-endpoint
     access_key = "{{< placeholder "OBJ-ACCESS-KEY" >}}"  # You can put your value here inline or add it as an environment variable OBJ_ACCESS_KEY_ID  see more here https://developer.hashicorp.com/terraform/language/settings/backends/s3#credentials-and-shared-configuration
     secret_key = "{{< placeholder "OBJ-SECRET-KEY" >}}"  # You can put your value here inline or add it as an environment variable OBJ_SECRET_ACCESS_KEY see more here https://developer.hashicorp.com/terraform/language/settings/backends/s3#credentials-and-shared-configuration

--- a/docs/guides/applications/configuration-management/terraform/how-to-use-terraform-with-linode-object-storage/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-use-terraform-with-linode-object-storage/index.md
@@ -6,7 +6,7 @@ description: 'This guide provides a brief introduction to Terraform, and explain
 authors: ["Jeff Novotny"]
 contributors: ["Jeff Novotny"]
 published: 2022-10-25
-modified: 2022-11-28
+modified: 2024-08-26
 keywords: ['Linode Terraform','Terraform Linode Object Storage','Install Terraform']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
@@ -464,6 +464,12 @@ To modify the contents of an object storage object, edit the `.tf` file containi
 terraform plan
 terraform apply
 ```
+
+## Configure Terraform to Store State on Linode Object Storage
+
+Terraform uses [state](https://developer.hashicorp.com/terraform/language/state) on a [backend](https://developer.hashicorp.com/terraform/language/settings/backends/configuration) to log and track resource information. By default, state is stored locally in a file named `terraform.tfstate`.
+
+For steps on how to use Linode Object Storage as a remote backend to store state, see our guide [Use Terraform to Provision Infrastructure on Linode](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/#use-linode-object-storage-to-store-state).
 
 ## Conclusion
 


### PR DESCRIPTION
Updated two guides with steps on how to configure Terraform to use Linode OBJ as a backend to write state:
- Use Terraform to Provision Infrastructure on Linode
- Use Terraform With Linode Object Storage (points to Terraform Provision guide)
