### PR TITLE
Remove Content-Security-Policy from the Hugo server config

### DIFF
--- a/config/development/server.toml
+++ b/config/development/server.toml
@@ -6,7 +6,6 @@ X-Frame-Options = "DENY"
 X-XSS-Protection = "1; mode=block"
 X-Content-Type-Options = "nosniff"
 Referrer-Policy = "no-referrer"
-Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.adobedtm.com *.trustarc.com *.weglot.com *.disqus.com 'unsafe-eval' 'unsafe-inline'"
 
 [[headers]]
 for = "/**.{css,jpg,js}"


### PR DESCRIPTION
Note that this is the `hugo server` only; it's getting out of date (re. consent manager), so instead of spending time maintaining it, just remove it.

