### PR TITLE
LKE releases for 2024H2

### DIFF
--- a/docs/release-notes/lke/v1.79.0.md
+++ b/docs/release-notes/lke/v1.79.0.md
@@ -1,0 +1,13 @@
+---
+title: Linode Kubernetes Engine v1.79.0
+date: 2024-08-07
+version: 1.79.0
+---
+
+### Changed
+
+- Upgraded clusters
+    * v1.28 to [v1.28.12](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.12)
+    * v1.29 to [v1.29.7](https://github.com/kubernetes/kubernetes/releases/tag/v1.29.7)
+    * v1.30 to [v1.30.3](https://github.com/kubernetes/kubernetes/releases/tag/v1.30.3)
+- Upgraded CCM to [v0.4.4](https://github.com/linode/linode-cloud-controller-manager/releases/tag/v0.4.4)

--- a/docs/release-notes/lke/v1.80.0.md
+++ b/docs/release-notes/lke/v1.80.0.md
@@ -6,4 +6,4 @@ version: 1.80.0
 
 ### Changed
 
-- Upgraded coredns to [v1.9.3](https://github.com/coredns/coredns/releases/tag/v1.9.3) to address a security issue
+- Upgraded CoreDNS to [v1.9.3](https://github.com/coredns/coredns/releases/tag/v1.9.3) to address a security issue

--- a/docs/release-notes/lke/v1.80.0.md
+++ b/docs/release-notes/lke/v1.80.0.md
@@ -1,0 +1,9 @@
+---
+title: Linode Kubernetes Engine v1.80.0
+date: 2024-08-20
+version: 1.80.0
+---
+
+### Changed
+
+- Upgraded coredns to [v1.9.3](https://github.com/coredns/coredns/releases/tag/v1.9.3) to address a security issue

--- a/docs/release-notes/lke/v1.82.0.md
+++ b/docs/release-notes/lke/v1.82.0.md
@@ -1,0 +1,12 @@
+---
+title: Linode Kubernetes Engine v1.82.0
+date: 2024-08-26
+version: 1.82.0
+---
+
+### Changed
+
+- Upgraded clusters
+    * v1.28 to [v1.28.13](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.13)
+    * v1.29 to [v1.29.8](https://github.com/kubernetes/kubernetes/releases/tag/v1.29.8)
+    * v1.30 to [v1.30.4](https://github.com/kubernetes/kubernetes/releases/tag/v1.30.4)

--- a/docs/release-notes/lke/v1.83.0.md
+++ b/docs/release-notes/lke/v1.83.0.md
@@ -1,0 +1,12 @@
+---
+title: Linode Kubernetes Engine v1.83.0
+date: 2024-09-13
+version: 1.83.0
+---
+
+### Changed
+
+- Upgraded clusters
+    * v1.28 to [v1.28.14](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.14)
+    * v1.29 to [v1.29.9](https://github.com/kubernetes/kubernetes/releases/tag/v1.29.9)
+    * v1.30 to [v1.30.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.30.5)

--- a/docs/release-notes/lke/v1.84.0.md
+++ b/docs/release-notes/lke/v1.84.0.md
@@ -1,0 +1,9 @@
+---
+title: Linode Kubernetes Engine v1.84.0
+date: 2024-10-02
+version: 1.84.0
+---
+
+### Changed
+
+- Upgraded linode-blockstorage-csi-driver to [v0.8.5](https://github.com/linode/linode-blockstorage-csi-driver/releases/tag/v0.8.5)

--- a/docs/release-notes/lke/v1.85.0.md
+++ b/docs/release-notes/lke/v1.85.0.md
@@ -1,0 +1,9 @@
+---
+title: Linode Kubernetes Engine v1.85.0
+date: 2024-10-08
+version: 1.85.0
+---
+
+### Changed
+
+- Upgraded CCM to [v0.4.15](https://github.com/linode/linode-cloud-controller-manager/releases/tag/v0.4.15)

--- a/docs/release-notes/lke/v1.87.0.md
+++ b/docs/release-notes/lke/v1.87.0.md
@@ -1,0 +1,12 @@
+---
+title: Linode Kubernetes Engine v1.87.0
+date: 2024-11-06
+version: 1.87.0
+---
+
+### Changed
+
+- Upgraded clusters
+    * v1.29 to [v1.29.10](https://github.com/kubernetes/kubernetes/releases/tag/v1.29.10)
+    * v1.30 to [v1.30.6](https://github.com/kubernetes/kubernetes/releases/tag/v1.30.6)
+    * v1.31 to [v1.31.2](https://github.com/kubernetes/kubernetes/releases/tag/v1.30.2)

--- a/docs/release-notes/lke/v1.88.0.md
+++ b/docs/release-notes/lke/v1.88.0.md
@@ -1,0 +1,9 @@
+---
+title: Linode Kubernetes Engine v1.88.0
+date: 2024-11-12
+version: 1.88.0
+---
+
+### Changed
+
+- Upgraded CCM to [v0.4.17](https://github.com/linode/linode-cloud-controller-manager/releases/tag/v0.4.17)


### PR DESCRIPTION
We have done a few releases without publishing these changelogs. Here they are backfilled for 08/2024 up until now.