### PR TITLE
[update] : update ccm install docs

### DIFF
--- a/docs/guides/kubernetes/install-the-linode-ccm-on-unmanaged-kubernetes/index.md
+++ b/docs/guides/kubernetes/install-the-linode-ccm-on-unmanaged-kubernetes/index.md
@@ -22,9 +22,9 @@ This guide will show you how to manually install the Linode CCM on an unmanaged 
 
 If you would like to use Kubernetes for production scenarios and make use of Linode NodeBalancers to expose your cluster's resources, it is recommended that you [use the Linode Kubernetes Engine to deploy your cluster](/docs/products/compute/kubernetes/). An LKE cluster's control plane has the Linode CCM preinstalled and does not require any of the steps included in this guide.
 
-Similarly, if you would like to deploy an unmanaged Kubernetes cluster on Linode, the best way to accomplish that is using [Terraform and the Linode K8s module](/docs/guides/how-to-provision-an-unmanaged-kubernetes-cluster-using-terraform/). The Linode K8s module will also include the Linode CCM preinstalled on the Kubernetes master's control plane and does not require any of the steps included in this guide.
+Another option for deploying unmanaged kubernetes clusters on Linode is to use [Cluster API Provider Linode (CAPL)](https://linode.github.io/cluster-api-provider-linode/). It provisions a management k8s cluster which can then be used to provision and manage multiple child k8s clusters on Linode. It installs CCM by default and supports provisioning k8s clusters using kubeadm, rke2 and k3s.
 
-If you have used the Linode Kubernetes Engine (LKE) or the Linode Terraform K8s module to deploy your cluster, you should instead refer to the [Getting Started with Load Balancing on a Linode Kubernetes Engine (LKE) Cluster](/docs/products/compute/kubernetes/guides/load-balancing/) guide for steps on adding and configuring NodeBalancers on your Kubernetes cluster.
+If you have used the Linode Kubernetes Engine (LKE) or Cluster API Provider Linode (CAPL) to deploy your cluster, you should instead refer to the [Getting Started with Load Balancing on a Linode Kubernetes Engine (LKE) Cluster](/docs/products/compute/kubernetes/guides/load-balancing/) guide for steps on adding and configuring NodeBalancers on your Kubernetes cluster.
 {{< /note >}}
 
 ## In this Guide
@@ -49,6 +49,8 @@ You will manually install the Linode CCM on your unmanaged Kubernetes cluster. T
 
 1. Generate a [Linode APIv4 token](/docs/products/tools/api/get-started/#get-an-access-token).
 
+1. [Install helm](https://helm.sh/docs/intro/install/)
+
 ## Running the Linode Cloud Controller Manager
 
 ### Update Your Cluster Configuration
@@ -60,7 +62,28 @@ In order to run the Linode Cloud Controller Manager:
 
 These configurations will change the behavior of your cluster and how it interacts with its Nodes. For more details, visit the [upstream Cloud Controller documentation](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/).
 
-### Install the Linode CCM
+### Install Linode CCM using helm
+
+Installing linode CCM using helm is the most preferred way. Helm chart contents are available in [deploy/chart](https://github.com/linode/linode-cloud-controller-manager/tree/main/deploy/chart) dir.
+
+1. Install the ccm-linode repo.
+
+    ```command
+    helm repo add ccm-linode https://linode.github.io/linode-cloud-controller-manager/
+    helm repo update ccm-linode
+    ```
+
+1. Deploy ccm-linode helm chart.
+
+    ```command
+    export LINODE_API_TOKEN=<linodeapitoken>
+    export REGION=<linoderegion>
+    helm install ccm-linode --set apiToken=$LINODE_API_TOKEN,region=$REGION ccm-linode/ccm-linode
+    ```
+
+For advanced configuration, one can specify their own [values.yaml](https://github.com/linode/linode-cloud-controller-manager/blob/main/deploy/chart/values.yaml) file when installing the helm chart.
+
+### Install Linode CCM using generated manifest
 
 The Linode CCM's GitHub repository provides a helper script that creates a Kubernetes manifest file that you can use to install the CCM on your cluster. These steps should be run on your local computer and were tested on a macOS.
 
@@ -98,6 +121,15 @@ You will need your [Linode APIv4](/docs/products/tools/api/get-started/#get-an-a
     You can create your own `ccm-linode.yaml` manifest file by editing the contents of the `ccm-linode-template.yaml` file and changing the values of the `data.apiToken` and `data.region` fields with your own desired values. This template file is located in the `deploy` directory of the Linode CCM repository.
     {{< /note >}}
 
+    {{< note >}}
+    Helm can also be used to render the ccm-linode helm chart and apply it manually.
+    {{< /note >}}
+
+    ```command
+    cd linode-cloud-controller-manager/
+    helm template --set apiToken=$LINODE_API_TOKEN,region=$REGION deploy/chart/
+    ```
+
 ## Updating the Linode CCM
 
 The easiest way to update the Linode CCM is to edit the DaemonSet that creates the Linode CCM Pod. To do so:
@@ -111,13 +143,13 @@ The easiest way to update the Linode CCM is to edit the DaemonSet that creates t
 1. The CCM Daemonset manifest will appear in vim. Press `i` to enter insert mode. Navigate to `spec.template.spec.image` and change the field's value to the desired version tag. For instance, if you had the following image:
 
     ```file
-    image: linode/linode-cloud-controller-manager:v0.2.2
+    image: linode/linode-cloud-controller-manager:v0.4.12
     ```
 
-    You could update the image to `v0.2.3` by changing the image tag:
+    You could update the image to `v0.4.20` by changing the image tag:
 
     ```file
-    image: linode/linode-cloud-controller-manager:v0.2.3
+    image: linode/linode-cloud-controller-manager:v0.4.20
     ```
 
     For a complete list of CCM version tags, visit the [CCM DockerHub page](https://hub.docker.com/r/linode/linode-cloud-controller-manager/tags).

--- a/docs/guides/kubernetes/install-the-linode-ccm-on-unmanaged-kubernetes/index.md
+++ b/docs/guides/kubernetes/install-the-linode-ccm-on-unmanaged-kubernetes/index.md
@@ -54,8 +54,6 @@ Instructions are shown for manually installing the Linode CCM on your unmanaged 
 
 1. Generate a [Linode APIv4 token](/docs/products/tools/api/get-started/#get-an-access-token). This is required for both methods of installing the Linode CCM in this guide.
 
-1. [Install Helm](https://helm.sh/docs/intro/install/)
-
 ## Running the Linode Cloud Controller Manager
 
 ### Update Your Cluster Configuration


### PR DESCRIPTION
This PR updates instructions for manual install of CCM on a k8s cluster. Since terraform k8s provider for linode is deprecated, this PR also removes reference to it and instead suggests to use CAPL as an alternative.