### PR TITLE
[update] Securing Nginx With ModSecurity

### DIFF
--- a/docs/guides/security/basics/securing-nginx-with-modsecurity/index.md
+++ b/docs/guides/security/basics/securing-nginx-with-modsecurity/index.md
@@ -198,15 +198,15 @@ ModSecurity is a firewall and therefore requires rules to function. This section
 1.  Copy over the unicode mapping file and the ModSecurity configuration file from your cloned ModSecurity GitHub repository:
 
         sudo cp /opt/ModSecurity/unicode.mapping /etc/nginx/modsec
-        sudo cp /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf
+        sudo cp /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec
 
-1. Remove the `.recommended` extension from the ModSecurity configuration filename with the following command:
+1. Remove the `-recommended` extension from the ModSecurity configuration filename with the following command:
 
-        sudo cp /etc/modsecurity/modsecurity.conf-recommended /etc/modsecurity/modsecurity.conf
+        sudo cp /etc/nginx/modsec/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf
 
-1.  With a text editor such as vim, open `/etc/modsecurity/modsecurity.conf` and change the value for `SecRuleEngine` to `On`:
+1.  With a text editor such as vim, open `/etc/nginx/modsec/modsecurity.conf` and change the value for `SecRuleEngine` to `On`:
 
-    {{< file "/etc/modsecurity/modsecurity.conf" aconf >}}
+    {{< file "/etc/nginx/modsec/modsecurity.conf" aconf >}}
 # -- Rule engine initialization ----------------------------------------------
 
 # Enable ModSecurity, attaching it to every transaction. Use detection


### PR DESCRIPTION
Fixes: https://github.com/linode/docs/issues/6803

Tested, validated, and updated the guide.
```
rajie@nginx:/opt/nginx-1.18.0$ sudo make modules
make -f objs/Makefile modules
make[1]: Entering directory '/opt/nginx-1.18.0'
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/http/modules/ngx_http_xslt_filter_module.o \
	src/http/modules/ngx_http_xslt_filter_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/ngx_http_xslt_filter_module_modules.o \
	objs/ngx_http_xslt_filter_module_modules.c
cc -o objs/ngx_http_xslt_filter_module.so \
objs/src/http/modules/ngx_http_xslt_filter_module.o \
objs/ngx_http_xslt_filter_module_modules.o \
-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -fPIC -lxml2 -lxslt -lexslt \
-shared
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/http/modules/ngx_http_image_filter_module.o \
	src/http/modules/ngx_http_image_filter_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/ngx_http_image_filter_module_modules.o \
	objs/ngx_http_image_filter_module_modules.c
cc -o objs/ngx_http_image_filter_module.so \
objs/src/http/modules/ngx_http_image_filter_module.o \
objs/ngx_http_image_filter_module_modules.o \
-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -fPIC -lgd \
-shared
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/addon/src/ngx_http_modsecurity_module.o \
	../ModSecurity-nginx/src/ngx_http_modsecurity_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/addon/src/ngx_http_modsecurity_pre_access.o \
	../ModSecurity-nginx/src/ngx_http_modsecurity_pre_access.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/addon/src/ngx_http_modsecurity_header_filter.o \
	../ModSecurity-nginx/src/ngx_http_modsecurity_header_filter.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/addon/src/ngx_http_modsecurity_body_filter.o \
	../ModSecurity-nginx/src/ngx_http_modsecurity_body_filter.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/addon/src/ngx_http_modsecurity_log.o \
	../ModSecurity-nginx/src/ngx_http_modsecurity_log.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/addon/src/ngx_http_modsecurity_rewrite.o \
	../ModSecurity-nginx/src/ngx_http_modsecurity_rewrite.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/ngx_http_modsecurity_module_modules.o \
	objs/ngx_http_modsecurity_module_modules.c
cc -o objs/ngx_http_modsecurity_module.so \
objs/addon/src/ngx_http_modsecurity_module.o \
objs/addon/src/ngx_http_modsecurity_pre_access.o \
objs/addon/src/ngx_http_modsecurity_header_filter.o \
objs/addon/src/ngx_http_modsecurity_body_filter.o \
objs/addon/src/ngx_http_modsecurity_log.o \
objs/addon/src/ngx_http_modsecurity_rewrite.o \
objs/ngx_http_modsecurity_module_modules.o \
-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -fPIC -Wl,-rpath,/usr/local/modsecurity/lib -L/usr/local/modsecurity/lib -lmodsecurity \
-shared
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail.o \
	src/mail/ngx_mail.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_core_module.o \
	src/mail/ngx_mail_core_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_handler.o \
	src/mail/ngx_mail_handler.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_parse.o \
	src/mail/ngx_mail_parse.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_ssl_module.o \
	src/mail/ngx_mail_ssl_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_pop3_module.o \
	src/mail/ngx_mail_pop3_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_pop3_handler.o \
	src/mail/ngx_mail_pop3_handler.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_imap_module.o \
	src/mail/ngx_mail_imap_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_imap_handler.o \
	src/mail/ngx_mail_imap_handler.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_smtp_module.o \
	src/mail/ngx_mail_smtp_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_smtp_handler.o \
	src/mail/ngx_mail_smtp_handler.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_auth_http_module.o \
	src/mail/ngx_mail_auth_http_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/mail/ngx_mail_proxy_module.o \
	src/mail/ngx_mail_proxy_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/ngx_mail_module_modules.o \
	objs/ngx_mail_module_modules.c
cc -o objs/ngx_mail_module.so \
objs/src/mail/ngx_mail.o \
objs/src/mail/ngx_mail_core_module.o \
objs/src/mail/ngx_mail_handler.o \
objs/src/mail/ngx_mail_parse.o \
objs/src/mail/ngx_mail_ssl_module.o \
objs/src/mail/ngx_mail_pop3_module.o \
objs/src/mail/ngx_mail_pop3_handler.o \
objs/src/mail/ngx_mail_imap_module.o \
objs/src/mail/ngx_mail_imap_handler.o \
objs/src/mail/ngx_mail_smtp_module.o \
objs/src/mail/ngx_mail_smtp_handler.o \
objs/src/mail/ngx_mail_auth_http_module.o \
objs/src/mail/ngx_mail_proxy_module.o \
objs/ngx_mail_module_modules.o \
-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -fPIC \
-shared
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream.o \
	src/stream/ngx_stream.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_variables.o \
	src/stream/ngx_stream_variables.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_script.o \
	src/stream/ngx_stream_script.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_handler.o \
	src/stream/ngx_stream_handler.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_core_module.o \
	src/stream/ngx_stream_core_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_log_module.o \
	src/stream/ngx_stream_log_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_proxy_module.o \
	src/stream/ngx_stream_proxy_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_upstream.o \
	src/stream/ngx_stream_upstream.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_upstream_round_robin.o \
	src/stream/ngx_stream_upstream_round_robin.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_write_filter_module.o \
	src/stream/ngx_stream_write_filter_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_ssl_module.o \
	src/stream/ngx_stream_ssl_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_limit_conn_module.o \
	src/stream/ngx_stream_limit_conn_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_access_module.o \
	src/stream/ngx_stream_access_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_geo_module.o \
	src/stream/ngx_stream_geo_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_map_module.o \
	src/stream/ngx_stream_map_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_split_clients_module.o \
	src/stream/ngx_stream_split_clients_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_return_module.o \
	src/stream/ngx_stream_return_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_upstream_hash_module.o \
	src/stream/ngx_stream_upstream_hash_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_upstream_least_conn_module.o \
	src/stream/ngx_stream_upstream_least_conn_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_upstream_random_module.o \
	src/stream/ngx_stream_upstream_random_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/src/stream/ngx_stream_upstream_zone_module.o \
	src/stream/ngx_stream_upstream_zone_module.c
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fdebug-prefix-map=/build/nginx-09OHwu/nginx-1.18.0=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/modsecurity/include -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
	-o objs/ngx_stream_module_modules.o \
	objs/ngx_stream_module_modules.c
cc -o objs/ngx_stream_module.so \
objs/src/stream/ngx_stream.o \
objs/src/stream/ngx_stream_variables.o \
objs/src/stream/ngx_stream_script.o \
objs/src/stream/ngx_stream_handler.o \
objs/src/stream/ngx_stream_core_module.o \
objs/src/stream/ngx_stream_log_module.o \
objs/src/stream/ngx_stream_proxy_module.o \
objs/src/stream/ngx_stream_upstream.o \
objs/src/stream/ngx_stream_upstream_round_robin.o \
objs/src/stream/ngx_stream_write_filter_module.o \
objs/src/stream/ngx_stream_ssl_module.o \
objs/src/stream/ngx_stream_limit_conn_module.o \
objs/src/stream/ngx_stream_access_module.o \
objs/src/stream/ngx_stream_geo_module.o \
objs/src/stream/ngx_stream_map_module.o \
objs/src/stream/ngx_stream_split_clients_module.o \
objs/src/stream/ngx_stream_return_module.o \
objs/src/stream/ngx_stream_upstream_hash_module.o \
objs/src/stream/ngx_stream_upstream_least_conn_module.o \
objs/src/stream/ngx_stream_upstream_random_module.o \
objs/src/stream/ngx_stream_upstream_zone_module.o \
objs/ngx_stream_module_modules.o \
-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -fPIC \
-shared
make[1]: Leaving directory '/opt/nginx-1.18.0'
rajie@nginx:/opt/nginx-1.18.0$ sudo mkdir /etc/nginx/modules
rajie@nginx:/opt/nginx-1.18.0$ sudo cp objs/ngx_http_modsecurity_module.so /etc/nginx/modules
rajie@nginx:/opt/nginx-1.18.0$ load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
load_module: command not found
rajie@nginx:/opt/nginx-1.18.0$ sudo nano /etc/nginx/nginx.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo rm -rf /usr/share/modsecurity-crs
rajie@nginx:/opt/nginx-1.18.0$ sudo git clone https://github.com/coreruleset/coreruleset /usr/local/modsecurity-crs
Cloning into '/usr/local/modsecurity-crs'...
remote: Enumerating objects: 34159, done.
remote: Counting objects: 100% (80/80), done.
remote: Compressing objects: 100% (28/28), done.
remote: Total 34159 (delta 68), reused 52 (delta 52), pack-reused 34079 (from 2
Receiving objects: 100% (34159/34159), 9.58 MiB | 9.79 MiB/s, done.
Resolving deltas: 100% (26980/26980), done.
rajie@nginx:/opt/nginx-1.18.0$ sudo mv /usr/local/modsecurity-crs/crs-setup.conf.example /usr/local/modsecurity-crs/crs-setup.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo mv /usr/local/modsecurity-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example /usr/local/modsecurity-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo mkdir -p /etc/nginx/modsec
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /opt/ModSecurity/unicode.mapping /etc/nginx/modsec
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf
rajie@nginx:/opt/nginx-1.18.0$ cd ..
rajie@nginx:/opt$ ls
ModSecurity  ModSecurity-nginx  nginx-1.18.0  nginx-1.18.0.tar.gz
rajie@nginx:/opt$ cd ModSecurity
rajie@nginx:/opt/ModSecurity$ ls
aclocal.m4    config.status  LICENSE                       README.md
ar-lib        config.sub     ltmain.sh                     SECURITY.md
AUTHORS       configure      Makefile                      src
bindings      configure.ac   Makefile.am                   test
build         depcomp        Makefile.in                   test-driver
build.sh      doc            missing                       tools
CHANGES       examples       modsecurity.conf-recommended  unicode.mapping
compile       headers        modsecurity.pc                vcbuild.bat
config.guess  install-sh     modsecurity.pc.in             ylwrap
config.log    libtool        others
rajie@nginx:/opt/ModSecurity$ cd ..
rajie@nginx:/opt$ cd nginx-1.18.0/
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /etc/modsecurity/modsecurity.conf-recommended /etc/modsecurity/modsecurity.conf
cp: cannot stat '/etc/modsecurity/modsecurity.conf-recommended': No such file or directory
rajie@nginx:/opt/nginx-1.18.0$ cd /etc/modsecurity
-bash: cd: /etc/modsecurity: No such file or directory
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /opt/ModSecurity/unicode.mapping /etc/nginx/modsec
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /etc/modsecurity/modsecurity.conf-recommended /etc/modsecurity/modsecurity.conf
cp: cannot stat '/etc/modsecurity/modsecurity.conf-recommended': No such file or directory
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /etc/modsecurity/modsecurity.conf-recommended /etc/modsec/modsecurity.conf
cp: cannot stat '/etc/modsecurity/modsecurity.conf-recommended': No such file or directory
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo cp /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo nano /etc/modsec/modecurity.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo nano /etc/nginx/modsec/modecurity.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo nano /etc/nginx/modsec/modsecurity.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo nano /etc/nginx/modsec/main.conf
rajie@nginx:/opt/nginx-1.18.0$ sudo nano /etc/nginx/sites-available/default
rajie@nginx:/opt/nginx-1.18.0$ sudo systemctl restart nginx
rajie@nginx:/opt/nginx-1.18.0$ sudo systemctl status nginx
● nginx.service - A high performance web server and a reverse proxy server
     Loaded: loaded (/lib/systemd/system/nginx.service; enabled; vendor preset:>
     Active: active (running) since Thu 2024-12-26 14:24:53 IST; 16s ago
       Docs: man:nginx(8)
    Process: 40609 ExecStartPre=/usr/sbin/nginx -t -q -g daemon on; master_proc>
    Process: 40622 ExecStart=/usr/sbin/nginx -g daemon on; master_process on; (>
   Main PID: 40633 (nginx)
      Tasks: 3 (limit: 4594)
     Memory: 4.9M
     CGroup: /system.slice/nginx.service
             ├─40633 nginx: master process /usr/sbin/nginx -g daemon on; master>
             ├─40634 nginx: worker process
             └─40635 nginx: worker process

Dec 26 14:24:53 nginx systemd[1]: Starting A high performance web server and a >
Dec 26 14:24:53 nginx systemd[1]: Started A high performance web server and a r>

[2]+  Stopped                 sudo systemctl status nginx
rajie@nginx:/opt/nginx-1.18.0$ curl http://172.232.110.150/index.html?exec=/bin/bash
<!doctype html>
<html>
<body>
    <h1>Hello, World!</h1>
    <p>This is an example website running on NGINX.</p>
</body>
</html>
    
rajie@nginx:/opt/nginx-1.18.0$ sudo nano /etc/nginx/sites-available/default
rajie@nginx:/opt/nginx-1.18.0$ sudo systemctl restart nginx
rajie@nginx:/opt/nginx-1.18.0$ sudo systemctl status nginx
● nginx.service - A high performance web server and a reverse proxy server
     Loaded: loaded (/lib/systemd/system/nginx.service; enabled; vendor preset:>
     Active: active (running) since Thu 2024-12-26 14:32:58 IST; 4s ago
       Docs: man:nginx(8)
    Process: 40653 ExecStartPre=/usr/sbin/nginx -t -q -g daemon on; master_proc>
    Process: 40667 ExecStart=/usr/sbin/nginx -g daemon on; master_process on; (>
   Main PID: 40668 (nginx)
      Tasks: 3 (limit: 4594)
     Memory: 5.0M
     CGroup: /system.slice/nginx.service
             ├─40668 nginx: master process /usr/sbin/nginx -g daemon on; master>
             ├─40669 nginx: worker process
             └─40670 nginx: worker process

Dec 26 14:32:58 nginx systemd[1]: Starting A high performance web server and a >
Dec 26 14:32:58 nginx systemd[1]: Started A high performance web server and a r>

[3]+  Stopped                 sudo systemctl status nginx
rajie@nginx:/opt/nginx-1.18.0$ curl http://172.232.110.150/index.html?exec=/bin/bash
<!doctype html>
<html>
<body>
    <h1>Hello, World!</h1>
    <p>This is an example website running on NGINX.</p>
</body>
</html>
    
rajie@nginx:/opt/nginx-1.18.0$ cd /etc
rajie@nginx:/etc$ ls
adduser.conf                   iscsi                    protocols
adjtime                        issue                    python3
alternatives                   issue.net                python3.8
apparmor                       kernel                   rc0.d
apparmor.d                     kernel-img.conf          rc1.d
apport                         landscape                rc2.d
apt                            ldap                     rc3.d
at.deny                        ld.so.cache              rc4.d
bash.bashrc                    ld.so.conf               rc5.d
bash_completion                ld.so.conf.d             rc6.d
bash_completion.d              legal                    rcS.d
bindresvport.blacklist         libaudit.conf            resolv.conf
binfmt.d                       libblockdev              rmt
byobu                          libnl-3                  rpc
ca-certificates                locale.alias             rsyslog.conf
ca-certificates.conf           locale.gen               rsyslog.d
ca-certificates.conf.dpkg-old  localtime                screenrc
calendar                       logcheck                 security
cloud                          login.defs               selinux
console-setup                  logrotate.conf           sensors3.conf
cron.d                         logrotate.d              sensors.d
cron.daily                     lsb-release              services
cron.hourly                    ltrace.conf              shadow
cron.monthly                   lvm                      shadow-
crontab                        machine-id               shells
cron.weekly                    magic                    skel
cryptsetup-initramfs           magic.mime               sos
crypttab                       mailcap                  ssh
dbus-1                         mailcap.order            ssl
dconf                          manpath.config           subgid
debconf.conf                   mdadm                    subgid-
debian_version                 mime.types               subuid
default                        mke2fs.conf              subuid-
deluser.conf                   ModemManager             sudoers
depmod.d                       modprobe.d               sudoers.d
dhcp                           modules                  sysctl.conf
dpkg                           modules-load.d           sysctl.d
e2scrub.conf                   mtab                     sysstat
emacs                          multipath.conf           systemd
environment                    nanorc                   terminfo
ethertypes                     netplan                  thermald
fonts                          network                  timezone
fstab                          networkd-dispatcher      tmpfiles.d
fuse.conf                      networks                 ubuntu-advantage
fwupd                          newt                     ucf.conf
gai.conf                       nginx                    udev
groff                          nsswitch.conf            udisks2
group                          opt                      ufw
group-                         os-release               update-manager
grub.d                         overlayroot.conf         update-motd.d
gshadow                        PackageKit               update-notifier
gshadow-                       pam.conf                 UPower
gss                            pam.d                    usb_modeswitch.conf
hdparm.conf                    passwd                   usb_modeswitch.d
host.conf                      passwd-                  vim
hostname                       perl                     vmware-tools
hosts                          pki                      vtrgb
hosts.allow                    pm                       wgetrc
hosts.deny                     polkit-1                 X11
init.d                         pollinate                xattr.conf
initramfs-tools                popularity-contest.conf  xdg
inputrc                        profile                  zlibc.conf
iproute2                       profile.d                zsh_command_not_found
rajie@nginx:/etc$ cd nginx
rajie@nginx:/etc/nginx$ ls
conf.d          koi-win     modules-available  scgi_params      uwsgi_params
fastcgi.conf    mime.types  modules-enabled    sites-available  win-utf
fastcgi_params  modsec      nginx.conf         sites-enabled
koi-utf         modules     proxy_params       snippets
rajie@nginx:/etc/nginx$ cd modsec
rajie@nginx:/etc/nginx/modsec$ ls
main.conf  modsecurity.conf  unicode.mapping
rajie@nginx:/etc/nginx/modsec$ sudo cp /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf
rajie@nginx:/etc/nginx/modsec$ ls
main.conf  modsecurity.conf  unicode.mapping
rajie@nginx:/etc/nginx/modsec$ sudo cp /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec
rajie@nginx:/etc/nginx/modsec$ ls
main.conf  modsecurity.conf  modsecurity.conf-recommended  unicode.mapping
rajie@nginx:/etc/nginx/modsec$ sudo cp /etc/nginx/modsec/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf
rajie@nginx:/etc/nginx/modsec$ ls
main.conf  modsecurity.conf  modsecurity.conf-recommended  unicode.mapping
rajie@nginx:/etc/nginx/modsec$ sudo nano /etc/nginx/modsec/modsecurity.conf
rajie@nginx:/etc/nginx/modsec$ sudo systemctl restart nginx
rajie@nginx:/etc/nginx/modsec$ curl http://172.232.110.150/index.html?exec=/bin/bash
<!doctype html>
<html>
<body>
    <h1>Hello, World!</h1>
    <p>This is an example website running on NGINX.</p>
</body>
</html>
    
rajie@nginx:/etc/nginx/modsec$ ls
main.conf  modsecurity.conf  modsecurity.conf-recommended  unicode.mapping
rajie@nginx:/etc/nginx/modsec$ sudo nano main.conf
rajie@nginx:/etc/nginx/modsec$ cd ..
rajie@nginx:/etc/nginx$ cd site-available
-bash: cd: site-available: No such file or directory
rajie@nginx:/etc/nginx$ cd sites-available
rajie@nginx:/etc/nginx/sites-available$ ls
default  rajie.wiki
rajie@nginx:/etc/nginx/sites-available$ 
```