### PR TITLE
[update] Install and Configure a StrongSwan Gateway VPN Server

### DIFF
--- a/docs/guides/networking/vpn/strongswan-vpn-server-install/index.md
+++ b/docs/guides/networking/vpn/strongswan-vpn-server-install/index.md
@@ -51,8 +51,8 @@ The steps in this guide are written for non-root users. Commands that require el
 1. Create and sign the root certificate with the configurations included below. Ensure you replace the value of the `CN` configuration with your own desired name for your StrongSwan VPN server.
 
         sudo ipsec pki --self --in /etc/ipsec.d/private/ca.key.pem --type rsa \
-          --dn "CN=<Name of this VPN Server>" --ca --lifetime 3650 --outform pem | \
-          sudo tee /etc/ipsec.d/cacerts/ca.cert.pem > /dev/null
+        --dn "CN=<Name of this VPN Server>" --ca --lifetime 3650 --outform pem | \
+        sudo tee /etc/ipsec.d/cacerts/ca.cert.pem > /dev/null
 
     In the example above, the `--lifetime 3650` configuration sets the certificate's lifetime to 3650 days or approximately ten years. The lifetime of the certificate determines when it is to be regenerated and distributed to your StrongSwan server and connected clients. You can adjust this setting to your preferred value.
 

--- a/docs/guides/networking/vpn/strongswan-vpn-server-install/index.md
+++ b/docs/guides/networking/vpn/strongswan-vpn-server-install/index.md
@@ -56,7 +56,7 @@ The steps in this guide are written for non-root users. Commands that require el
 
     In the example above, the `--lifetime 3650` configuration sets the certificate's lifetime to 3650 days or approximately ten years. The lifetime of the certificate determines when it is to be regenerated and distributed to your StrongSwan server and connected clients. You can adjust this setting to your preferred value.
 
-1. Generate the StrongSwan VPN server's private certificate.
+1. Generate the StrongSwan VPN server’s private key and save it to `/etc/ipsec.d/private/server.key.pem`. This command ensures root permissions for file creation, and suppresses terminal output.
 
         sudo ipsec pki --gen --size 4096 --type rsa --outform pem | sudo tee /etc/ipsec.d/private/server.key.pem > /dev/null
 

--- a/docs/guides/networking/vpn/strongswan-vpn-server-install/index.md
+++ b/docs/guides/networking/vpn/strongswan-vpn-server-install/index.md
@@ -44,17 +44,21 @@ The steps in this guide are written for non-root users. Commands that require el
 
 1. Use the IPsec command-line utility to create your IPsec private key. In the case of this tutorial, the private key is used to create the root certificate for StrongSwan. You can also use this key to generate other certificates.
 
-        sudo ipsec pki --gen --size 4096 --type rsa --outform pem > /etc/ipsec.d/private/ca.key.pem
+        sudo ipsec pki --gen --size 4096 --type rsa --outform pem > ca.key.pem
+        sudo mv ca.key.pem /etc/ipsec.d/private/ca.key.pem
+        sudo chmod 600 /etc/ipsec.d/private/ca.key.pem
 
 1. Create and sign the root certificate with the configurations included below. Ensure you replace the value of the `CN` configuration with your own desired name for your StrongSwan VPN server.
 
-        ipsec pki --self --in /etc/ipsec.d/private/ca.key.pem --type rsa --dn "CN=<Name of this VPN Server>" --ca --lifetime 3650 --outform pem > /etc/ipsec.d/cacerts/ca.cert.pem
+        sudo ipsec pki --self --in /etc/ipsec.d/private/ca.key.pem --type rsa \
+          --dn "CN=<Name of this VPN Server>" --ca --lifetime 3650 --outform pem | \
+          sudo tee /etc/ipsec.d/cacerts/ca.cert.pem > /dev/null
 
     In the example above, the `--lifetime 3650` configuration sets the certificate's lifetime to 3650 days or approximately ten years. The lifetime of the certificate determines when it is to be regenerated and distributed to your StrongSwan server and connected clients. You can adjust this setting to your preferred value.
 
 1. Generate the StrongSwan VPN server's private certificate.
 
-        ipsec pki --gen --size 4096 --type rsa --outform pem > /etc/ipsec.d/private/server.key.pem
+        sudo ipsec pki --gen --size 4096 --type rsa --outform pem | sudo tee /etc/ipsec.d/private/server.key.pem > /dev/null
 
 1. Generate the host server certificate. There are two ways to generate the certificate, however, they cannot be mixed. The two ways are as follows:
 
@@ -64,13 +68,26 @@ The steps in this guide are written for non-root users. Commands that require el
     **Local Resolver Method**
     The example below uses a local resolver. The IPsec utility takes the server key from step 2 and uses it as an input private certificate source, and generates a resolver-based certificate. Ensure you replace the value of `CN` and `san` with your own. The `--dn “CN=<serverhost.ourdomain.tld>` is a DNS or `/etc/hosts` call that should be changed to reflect your organization's own hostname.
 
-        ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | ipsec pki --issue --lifetime 3650 --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem --dn "CN=<serverhost.ourdomain.tld>" --san="<server.ourdomain.tld>" --flag serverAuth --flag ikeIntermediate --outform pem > /etc/ipsec.d/certs/server.cert.pem
+        sudo ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
+        sudo ipsec pki --issue --lifetime 3650 \
+        --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
+        --dn "CN=<serverhost.ourdomain.tld>" --san="<server.ourdomain.tld>" \
+        --flag serverAuth --flag ikeIntermediate --outform pem | \
+        sudo tee /etc/ipsec.d/certs/server.cert.pem > /dev/null
+
 
     **Gateway Server IPv4 Address**
 
     The duplicate `–san=”<server static IP address>` configuration in the command below is correct; do not omit both configurations. Replace their values with your own gateway server's IPv4 address.
 
-        ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | ipsec pki --issue --lifetime 3650 --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem --dn "CN=<server static IP address>" –san=”<server static IP address>” --san="<server static IP address>" --flag serverAuth --flag ikeIntermediate --outform pem > /etc/ipsec.d/certs/server.cert.pem
+        sudo ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
+        sudo ipsec pki --issue --lifetime 3650 \
+        --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
+        --dn "CN=<server static IP address>" \
+        --san="<server static IP address>" --san="<server static IP address>" \
+        --flag serverAuth --flag ikeIntermediate --outform pem | \
+        sudo tee /etc/ipsec.d/certs/server.cert.pem > /dev/null
+
 
 At the end of this section, you should have generated the following files on your Ubuntu 20.04 server:
 


### PR DESCRIPTION
Tested and validated the guide and then updated the commands.
Fixes: https://github.com/linode/docs/issues/6062
```
rajie@ss:~$ sudo apt-get update && sudo apt-get upgrade
[sudo] password for rajie: 
Hit:1 http://mirrors.linode.com/ubuntu focal InRelease
Hit:2 http://mirrors.linode.com/ubuntu focal-updates InRelease
Hit:3 http://mirrors.linode.com/ubuntu focal-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease
Reading package lists... Done         
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Calculating upgrade... Done
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
rajie@ss:~$ sudo apt install strongswan strongswan-pki libcharon-extra-plugins libcharon-extauth-plugins libstrongswan-extra-plugins libtss2-tcti-tabrmd0 -y
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  libstrongswan libstrongswan-standard-plugins strongswan-charon
  strongswan-libcharon strongswan-starter
The following NEW packages will be installed:
  libcharon-extauth-plugins libcharon-extra-plugins libstrongswan
  libstrongswan-extra-plugins libstrongswan-standard-plugins
  libtss2-tcti-tabrmd0 strongswan strongswan-charon strongswan-libcharon
  strongswan-pki strongswan-starter
0 upgraded, 11 newly installed, 0 to remove and 0 not upgraded.
Need to get 1,383 kB of archives.
After this operation, 6,578 kB of additional disk space will be used.
Get:1 http://mirrors.linode.com/ubuntu focal-updates/main amd64 libstrongswan amd64 5.8.2-1ubuntu3.6 [356 kB]
Get:2 http://mirrors.linode.com/ubuntu focal-updates/main amd64 strongswan-libcharon amd64 5.8.2-1ubuntu3.6 [241 kB]
Get:3 http://mirrors.linode.com/ubuntu focal-updates/main amd64 strongswan-charon amd64 5.8.2-1ubuntu3.6 [22.2 kB]
Get:4 http://mirrors.linode.com/ubuntu focal-updates/main amd64 strongswan-starter amd64 5.8.2-1ubuntu3.6 [148 kB]
Get:5 http://mirrors.linode.com/ubuntu focal-updates/main amd64 libcharon-extauth-plugins amd64 5.8.2-1ubuntu3.6 [23.0 kB]
Get:6 http://mirrors.linode.com/ubuntu focal-updates/universe amd64 libcharon-extra-plugins amd64 5.8.2-1ubuntu3.6 [191 kB]
Get:7 http://mirrors.linode.com/ubuntu focal-updates/universe amd64 libstrongswan-extra-plugins amd64 5.8.2-1ubuntu3.6 [208 kB]
Get:8 http://mirrors.linode.com/ubuntu focal-updates/main amd64 libstrongswan-standard-plugins amd64 5.8.2-1ubuntu3.6 [67.3 kB]
Get:9 http://mirrors.linode.com/ubuntu focal/universe amd64 libtss2-tcti-tabrmd0 amd64 2.3.1-1 [54.3 kB]
Get:10 http://mirrors.linode.com/ubuntu focal-updates/main amd64 strongswan all 5.8.2-1ubuntu3.6 [18.2 kB]
Get:11 http://mirrors.linode.com/ubuntu focal-updates/universe amd64 strongswan-pki amd64 5.8.2-1ubuntu3.6 [55.0 kB]
Fetched 1,383 kB in 0s (33.7 MB/s)
Preconfiguring packages ...
Selecting previously unselected package libstrongswan.
(Reading database ... 109039 files and directories currently installed.)
Preparing to unpack .../00-libstrongswan_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking libstrongswan (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package strongswan-libcharon.
Preparing to unpack .../01-strongswan-libcharon_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking strongswan-libcharon (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package strongswan-charon.
Preparing to unpack .../02-strongswan-charon_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking strongswan-charon (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package strongswan-starter.
Preparing to unpack .../03-strongswan-starter_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking strongswan-starter (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package libcharon-extauth-plugins.
Preparing to unpack .../04-libcharon-extauth-plugins_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking libcharon-extauth-plugins (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package libcharon-extra-plugins.
Preparing to unpack .../05-libcharon-extra-plugins_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking libcharon-extra-plugins (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package libstrongswan-extra-plugins.
Preparing to unpack .../06-libstrongswan-extra-plugins_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking libstrongswan-extra-plugins (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package libstrongswan-standard-plugins.
Preparing to unpack .../07-libstrongswan-standard-plugins_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking libstrongswan-standard-plugins (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package libtss2-tcti-tabrmd0:amd64.
Preparing to unpack .../08-libtss2-tcti-tabrmd0_2.3.1-1_amd64.deb ...
Unpacking libtss2-tcti-tabrmd0:amd64 (2.3.1-1) ...
Selecting previously unselected package strongswan.
Preparing to unpack .../09-strongswan_5.8.2-1ubuntu3.6_all.deb ...
Unpacking strongswan (5.8.2-1ubuntu3.6) ...
Selecting previously unselected package strongswan-pki.
Preparing to unpack .../10-strongswan-pki_5.8.2-1ubuntu3.6_amd64.deb ...
Unpacking strongswan-pki (5.8.2-1ubuntu3.6) ...
Setting up libtss2-tcti-tabrmd0:amd64 (2.3.1-1) ...
Setting up libstrongswan (5.8.2-1ubuntu3.6) ...
Setting up strongswan-libcharon (5.8.2-1ubuntu3.6) ...
Setting up libcharon-extauth-plugins (5.8.2-1ubuntu3.6) ...
Setting up libstrongswan-extra-plugins (5.8.2-1ubuntu3.6) ...
Setting up strongswan-charon (5.8.2-1ubuntu3.6) ...
Setting up strongswan-pki (5.8.2-1ubuntu3.6) ...
Setting up libcharon-extra-plugins (5.8.2-1ubuntu3.6) ...
Setting up libstrongswan-standard-plugins (5.8.2-1ubuntu3.6) ...
Setting up strongswan-starter (5.8.2-1ubuntu3.6) ...
Created symlink /etc/systemd/system/multi-user.target.wants/strongswan-starter.service → /lib/systemd/system/strongswan-starter.service.
Setting up strongswan (5.8.2-1ubuntu3.6) ...
Processing triggers for systemd (245.4-4ubuntu3.24) ...
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for libc-bin (2.31-0ubuntu9.16) ...
rajie@ss:~$ sudo ipsec pki --gen --size 4096 --type rsa --outform pem > /etc/ipsec.d/private/ca.key.pem
-bash: /etc/ipsec.d/private/ca.key.pem: Permission denied
rajie@ss:~$ sudo ipsec pki --gen --size 4096 --type rsa --outform pem | sudo tee /etc/ipsec.d/private/server.key.pem > /dev/null
rajie@ss:~$ ipsec pki --self --in /etc/ipsec.d/private/ca.key.pem --type rsa --dn "CN=SS VPN Server" --ca --lifetime 3650 --outform pem > /etc/ipsec.d/cacerts/ca.cert.pem
-bash: /etc/ipsec.d/cacerts/ca.cert.pem: Permission denied
rajie@ss:~$ sudo ipsec pki --self --in /etc/ipsec.d/private/ca.key.pem --type rsa \
> --dn "CN=SS VPN Server" --ca --lifetime 3650 --outform pem | \
> sudo tee
  opening '/etc/ipsec.d/private/ca.key.pem' failed: No such file or directory
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
loading private key failed
rajie@ss:~$ ls
rajie@ss:~$ ls -l /etc/ipsec.d/private/ca.key.pem
ls: cannot access '/etc/ipsec.d/private/ca.key.pem': Permission denied
rajie@ss:~$ sudo ls -l /etc/ipsec.d/private/ca.key.pem
ls: cannot access '/etc/ipsec.d/private/ca.key.pem': No such file or directory
rajie@ss:~$ sudo ipsec pki --gen --size 4096 --type rsa --outform pem > ca.key.pem
rajie@ss:~$ sudo mv ca.key.pem /etc/ipsec.d/private/ca.key.pem
rajie@ss:~$ sudo chmod 600 /etc/ipsec.d/private/ca.key.pem
rajie@ss:~$ sudo ipsec pki --self --in /etc/ipsec.d/private/ca.key.pem --type rsa \
> --dn "CN=SS VPN Server" --ca --lifetime 3650 --outform pem | \
> sudo tee /etc/ipsec.d/cacerts/ca.cert.pem > /dev/null
rajie@ss:~$ 
rajie@ss:~$ sudo ls -l /etc/ipsec.d/private/ca.key.pem
-rw------- 1 rajie rajie 3243 Feb  6 12:40 /etc/ipsec.d/private/ca.key.pem
rajie@ss:~$ ipsec pki --gen --size 4096 --type rsa --outform pem > /etc/ipsec.d/private/server.key.pem
-bash: /etc/ipsec.d/private/server.key.pem: Permission denied
rajie@ss:~$ sudo ipsec pki --gen --size 4096 --type rsa --outform pem | sudo tee /etc/ipsec.d/private/server.key.pem > /dev/null
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | ipsec pki --issue --lifetime 3650 --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem --dn "CN=<serverhost.ourdomain.tld>" --san="<server.ourdomain.tld>" --flag serverAuth --flag ikeIntermediate --outform pem > /etc/ipsec.d/certs/server.cert.pem
-bash: /etc/ipsec.d/certs/server.cert.pem: Permission denied
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | ipsec pki --issue --lifetime 3650 --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem --dn "CN=SS VPN Server.rajie.wiki.tld" --san="SS VPN Server.rajie.wiki.tld" --flag serverAuth --flag ikeIntermediate --outform pem > /etc/ipsec.d/certs/server.cert.pem
-bash: /etc/ipsec.d/certs/server.cert.pem: Permission denied
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | ipsec pki --issue --lifetime 3650 --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem --dn "CN=SS VPN Server.rajie.wiki.tld" --san="SS VPN Server.rajie.wiki.tld" --flag serverAuth --flag ikeIntermediate --outform pem > /etc/ipsec.d/certs/server.cert.pem
-bash: /etc/ipsec.d/certs/server.cert.pem: Permission denied
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
rajie@ss:~$ hostname -f
ss.rajie.wiki
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | ipsec pki --issue --lifetime 3650 --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem --dn "CN=SS VPN Server" --san="ss.rajie.wiki" --flag serverAuth --flag ikeIntermediate --outform pem > /etc/ipsec.d/certs/server.cert.pem
-bash: /etc/ipsec.d/certs/server.cert.pem: Permission denied
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | ipsec pki --issue --lifetime 3650 --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem --dn "CN=SS VPN Server" --san="ss.rajie.wiki" --flag serverAuth --flag ikeIntermediate --outform pem > /etc/ipsec.d/certs/server.cert.pem
-bash: /etc/ipsec.d/certs/server.cert.pem: Permission denied
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
rajie@ss:~$ -bash: /etc/ipsec.d/certs/server.cert.pem: Permission denied
-bash:: command not found
rajie@ss:~$   opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
opening: command not found
rajie@ss:~$ building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
building: command not found
rajie@ss:~$ parsing private key failed
parsing: command not found
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
> ipsec pki --issue --lifetime 3650 \
> --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
> --dn "CN=SS VPN Server" --san="ss.rajie.wiki" \
> --flag serverAuth --flag ikeIntermediate --outform pem | \
> sudo tee /etc/ipsec.d/certs/server.cert.pem > /dev/null
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
  opening '/etc/ipsec.d/private/ca.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
loading CA private key failed
rajie@ss:~$ 
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
> ipsec pki --issue --lifetime 3650 \
> --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
> --dn "CN=SS VPN Server" --san="ss.rajie.wiki" \
> --flag serverAuth --flag ikeIntermediate --outform pem | \
> sudo tee /etc/ipsec.d/certs/server.cert.pem > /dev/null
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
  opening '/etc/ipsec.d/private/ca.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
loading CA private key failed
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
> ipsec pki --issue --lifetime 3650 \
> --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
> --dn "CN=SS VPN Server" --san="ss.rajie.wiki" \
> --flag serverAuth --flag ikeIntermediate --outform pem | \
> sudo tee /etc/ipsec.d/certs/server.cert.pem > /dev/null
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
  opening '/etc/ipsec.d/private/ca.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
loading CA private key failed
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
> ipsec pki --issue --lifetime 3650 \
> --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
> --dn "CN=SS VPN Server" --san="ss.rajie.wiki" \
> --flag serverAuth --flag ikeIntermediate --outform pem | \
> sudo tee /etc/ipsec.d/certs/server.cert.pem > /dev/null
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
  opening '/etc/ipsec.d/private/ca.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
loading CA private key failed
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
> ipsec pki --issue --lifetime 3650 \
> --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
> --dn "CN=SS VPN Server" --san="ss.rajie.wiki" \
> --flag serverAuth --flag ikeIntermediate --outform pem > server.cert.pem
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
  opening '/etc/ipsec.d/private/ca.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
loading CA private key failed
rajie@ss:~$ ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
> ipsec pki --issue --lifetime 3650 \
> --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
> --dn "CN=SS VPN Server" --san="ss.rajie.wiki" \
> --flag serverAuth --flag ikeIntermediate --outform pem > server.cert.pem
  opening '/etc/ipsec.d/private/server.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
parsing private key failed
  opening '/etc/ipsec.d/private/ca.key.pem' failed: Permission denied
building CRED_PRIVATE_KEY - RSA failed, tried 9 builders
loading CA private key failed
rajie@ss:~$ sudo ipsec pki --pub --in /etc/ipsec.d/private/server.key.pem --type rsa | \
> sudo ipsec pki --issue --lifetime 3650 \
> --cacert /etc/ipsec.d/cacerts/ca.cert.pem --cakey /etc/ipsec.d/private/ca.key.pem \
> --dn "CN=SS VPN Server" --san="ss.rajie.wiki" \
> --flag serverAuth --flag ikeIntermediate --outform pem | \
> sudo tee /etc/ipsec.d/certs/server.cert.pem > /dev/null
rajie@ss:~$ ls -l /etc/ipsec.d/private/server.key.pem
ls: cannot access '/etc/ipsec.d/private/server.key.pem': Permission denied
rajie@ss:~$ sudo ls -l /etc/ipsec.d/private/server.key.pem
-rw-r--r-- 1 root root 3243 Feb  6 12:42 /etc/ipsec.d/private/server.key.pem
rajie@ss:~$ 
```