### PR TITLE
Update index.md

### DIFF
--- a/docs/guides/kubernetes/deploy-prometheus-operator-with-grafana-on-lke/index.md
+++ b/docs/guides/kubernetes/deploy-prometheus-operator-with-grafana-on-lke/index.md
@@ -150,13 +150,12 @@ In this section, you will create a Helm chart values file and use it to deploy P
 1.  Using Helm, deploy a Prometheus Operator release labeled `lke-monitor` in the `monitoring` namespace on your LKE cluster with the settings established in your `values.yaml` file:
 
     ```command
-    helm install \
-    lke-monitor stable/kube-prometheus-stack\
+    helm install lke-monitor kube-prometheus-stack \
+    --repo https://prometheus-community.github.io/helm-charts \
     -f ~/lke-monitor/values.yaml \
     --namespace monitoring \
-    --set grafana.adminPassword=$GRAFANA_ADMINPASSWORD \
-    --set prometheusOperator.createCustomResource=false \
-    --repo https://prometheus-community.github.io/helm-charts
+    --set grafana.adminPassword="$GRAFANA_ADMINPASSWORD" \
+    --set prometheusOperator.createCustomResource=false
     ```
 
     {{< note >}}


### PR DESCRIPTION
fixed the command to install the prometheus operator.
Fixes: https://github.com/linode/docs/issues/6212

Tested and validated the command and fixed it:
```
rkodhand@blr-mpe5j lke-monitor % nano values.yaml
rkodhand@blr-mpe5j lke-monitor % export GRAFANA_ADMINPASSWORD="prom-operator"
rkodhand@blr-mpe5j lke-monitor % helm install \
lke-monitor stable/kube-prometheus-stack\
-f ~/lke-monitor/values.yaml \
--namespace monitoring \
--set grafana.adminPassword=$GRAFANA_ADMINPASSWORD \
--set prometheusOperator.createCustomResource=false \
--repo https://prometheus-community.github.io/helm-charts
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/rkodhand/Downloads/test-kubeconfig.yaml
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/rkodhand/Downloads/test-kubeconfig.yaml
Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments: /Users/rkodhand/lke-monitor/values.yaml
rkodhand@blr-mpe5j lke-monitor % helm install lke-monitor kube-prometheus-stack \
  --repo https://prometheus-community.github.io/helm-charts \
  -f ~/lke-monitor/values.yaml \
  --namespace monitoring \
  --set grafana.adminPassword="$GRAFANA_ADMINPASSWORD" \
  --set prometheusOperator.createCustomResource=false

WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/rkodhand/Downloads/test-kubeconfig.yaml
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/rkodhand/Downloads/test-kubeconfig.yaml
NAME: lke-monitor
LAST DEPLOYED: Tue May 27 10:49:49 2025
NAMESPACE: monitoring
STATUS: deployed
REVISION: 1
NOTES:
kube-prometheus-stack has been installed. Check its status by running:
  kubectl --namespace monitoring get pods -l "release=lke-monitor"

Get Grafana 'admin' user password by running:

  kubectl --namespace monitoring get secrets lke-monitor-grafana -o jsonpath="{.data.admin-password}" | base64 -d ; echo

Access Grafana local instance:

  export POD_NAME=$(kubectl --namespace monitoring get pod -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=lke-monitor" -oname)
  kubectl --namespace monitoring port-forward $POD_NAME 3000

Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.
rkodhand@blr-mpe5j lke-monitor % kubectl -n monitoring get pods
NAME                                                     READY   STATUS    RESTARTS   AGE
alertmanager-lke-monitor-kube-prometheu-alertmanager-0   2/2     Running   0          6m2s
lke-monitor-grafana-74d68d6648-722kn                     3/3     Running   0          6m16s
lke-monitor-kube-prometheu-operator-859ff758c4-x52rw     1/1     Running   0          6m16s
lke-monitor-kube-state-metrics-95dcbd6f5-gjf5p           1/1     Running   0          6m16s
lke-monitor-prometheus-node-exporter-7xqcn               1/1     Running   0          6m16s
lke-monitor-prometheus-node-exporter-k4c55               1/1     Running   0          6m16s
lke-monitor-prometheus-node-exporter-z2vkb               1/1     Running   0          6m16s
prometheus-lke-monitor-kube-prometheu-prometheus-0       2/2     Running   0          6m1s
rkodhand@blr-mpe5j lke-monitor % 
```