### PR TITLE
[NEW] Transfer VM Using Disk Images Migration Guides

### DIFF
--- a/docs/guides/platform/migrate-to-linode/transfer-azure-virtual-machine-to-akamai-using-disk-images/index.md
+++ b/docs/guides/platform/migrate-to-linode/transfer-azure-virtual-machine-to-akamai-using-disk-images/index.md
@@ -1,0 +1,383 @@
+---
+slug: transfer-azure-virtual-machine-to-akamai-using-disk-images
+title: "Transfer Azure Virtual Machine to Akamai Using Disk Images"
+description: "Two to three sentences describing your guide."
+authors: ["Linode"]
+contributors: ["Linode"]
+published: 2025-05-28
+keywords: ['list','of','keywords','and key phrases']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+external_resources:
+- '[Link Title 1](http://www.example.com)'
+- '[Link Title 2](http://www.example.net)'
+---
+
+In modern cloud computing, virtual machine (VM) migration is a process that enables organizations to transition workloads between cloud platforms to optimize costs, improve performance, or enhance flexibility. By migrating VMs, organizations can select the capabilities of various cloud providers that best satisfy their business needs.
+
+This guide focuses on migrating an Azure Virtual Machine to Akamai Cloud using disk images and suggests how to plan, execute, and validate the migration.
+
+## Prerequisites
+
+To follow along in this walkthrough, you’ll need the following:
+
+* An [account with Akamai Linode](https://www.linode.com/cfe)  
+* A [Linode API token (personal access token)](https://www.linode.com/docs/products/platform/accounts/guides/manage-api-tokens/)  
+* The [Linode CLI](https://www.linode.com/docs/products/tools/cli/guides/install/) installed and configured  
+* An Azure account with sufficient permissions to work with Managed Disks and Storage Accounts.  
+* The [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) (az) installed and configured  
+* [QEMU](https://www.qemu.org/) installed and configured
+
+## Preparing Your Azure VM for Migration
+
+Prepare your current Azure environment to ensure a smooth and efficient transition. As you assess your Azure VM requirements, familiarize yourself with any limitations that Akamai Linode imposes on resources imported into its systems.
+
+| Important note: [Images imported into Akamai Linode](https://techdocs.akamai.com/cloud-computing/docs/upload-an-image) must be smaller than 6 GB unzipped and 5 GB zipped. Larger images will be rejected and not imported. |
+| :---- |
+
+### Assess current Azure VM requirements
+
+Capture the current configuration of your Compute Engine VM so that you can select the appropriate [Akamai Connected Cloud plan](https://www.linode.com/pricing/#compute-shared) to ensure post-migration performance.
+
+From the **Resource Groups** page in the Azure Portal, identify the Resource Group that contains the VM you wish to migrate. Click the name of the Resource Group.
+
+![][image2]
+
+From the list of resources displayed, find your VM and click on it.
+
+![][image3]
+
+#### VM size, CPU, and memory usage
+
+In the **Essentials** section of your VM details, you’ll see the machine type and basic capabilities for this VM instance. In the following example, the machine type is Standard B2s, which has 2 vCPUs and 4 GiB of memory.
+
+![][image4]
+
+To obtain this information via the Azure CLI, run the following commands:
+
+1. List all the VMs in a Resource Group using the name of your specific Resource Group.
+
+| $ az vm list \--resource-group my-resource-group \--output table Name         ResourceGroup      Location    Zones\-----------  \-----------------  \----------  \-------my-azure-vm  my-resource-group  westus |
+| :---- |
+
+2. Get the VM size of your instance using the names of your Resource Group and VM.
+
+| $ az vm show \\     \--resource-group my-resource-group \\     \--name my-azure-vm \\     \--query "hardwareProfile.vmSize""Standard\_B2s" |
+| :---- |
+
+3. Show the details of a specific VM size configuration, supplying the location of your Resource Group and the VM size.
+
+| $ az vm list-sizes \--location westus \--query "\[?name=='Standard\_B2s'\]" \[  {    "maxDataDiskCount": 4,    "memoryInMB": 4096,    "name": "Standard\_B2s",    "numberOfCores": 2,    "osDiskSizeInMB": 1047552,    "resourceDiskSizeInMB": 8192  }\] |
+| :---- |
+
+#### Storage usage
+
+Return to the list of resources for your Resource Group. Find the disk associated with your VM and click on it.
+
+![][image5]
+
+The **Properties** section of the disk details page shows the disk’s size and storage type.
+
+![][image6]
+
+Alternatively, use az to retrieve the disk details for your VM:
+
+| $ az vm show \\     \--resource-group my-resource-group \\     \--name my-azure-vm \\     \--query "storageProfile.osDisk" {  "caching": "ReadWrite",  "createOption": "FromImage",  "deleteOption": "Delete",  "diffDiskSettings": null,  "diskSizeGb": 5,  "encryptionSettings": null,  "image": null,  "managedDisk": {    "diskEncryptionSet": null,    "id": "/subscriptions/980e30f1-992f-4635-9eb0-1b5fe23ec084/resourceGroups/my-resource-group/providers/Microsoft.Compute/disks/my-azure-vm\_disk1\_bfb86e561c3a4716b164f82f4e558b8e",    "resourceGroup": "my-resource-group",    "securityProfile": null,    "storageAccountType": "Premium\_LRS"  },  "name": "my-azure-vm\_disk1\_bfb86e561c3a4716b164f82f4e558b8e",  "osType": "Linux",  "vhd": null,  "writeAcceleratorEnabled": null} |
+| :---- |
+
+The example Azure disk for this guide has a size of 5 GB.
+
+#### IP addresses
+
+The external IP address (13.91.244.136) for the VM was shown in the **Essentials** section of the VM details page. To retrieve this information via the Azure CLI, run the following commands:
+
+1. Get the name of the network interface, supplying the names of the Resource Group and VM.
+
+| $ az vm show \\     \--resource-group my-resource-group \\     \--name my-azure-vm \\     \--query "networkProfile.networkInterfaces\[0\].id" "/subscriptions/980e30f1-992f-4635-9eb0-1b5fe23ec084/resourceGroups/my-resource-group/providers/Microsoft.Network/networkInterfaces/my-azure-vm930" |
+| :---- |
+
+| Note: In Azure, a resource has an ID and a name. The ID has the form of a full path, such as the following: /subscriptions/980e30f1-992f-4635-9eb0-1b5fe23ec084/resourceGroups/my-resource-group/providers/Microsoft.Network/networkInterfaces/my-azure-vm930 The name of the resource can be inferred through the final part of the path in the ID. For the resource above, the name is my-azure-vm930. |
+| :---- |
+
+2. Use the resulting network interface name to get the name of the public IP address created by Azure.
+
+| $ az network nic show \\     \--name my-azure-vm930 \\     \--resource-group my-resource-group \\     \--query "ipConfigurations\[0\].publicIPAddress.id" "/subscriptions/980e30f1-992f-4635-9eb0-1b5fe23ec084/resourceGroups/my-resource-group/providers/Microsoft.Network/publicIPAddresses/my-azure-vm-ip" |
+| :---- |
+
+3. Use the resulting IP address name to retrieve the details for this resource, including the actual IP address.
+
+| $ az network public-ip show \\     \--name my-azure-vm-ip \\     \--resource-group my-resource-group \\    \--query "ipAddress" "13.91.244.136" |
+| :---- |
+
+#### Network security groups and firewall rules
+
+To see network security group information from the Azure Portal, find and click on the network security group resource from the list of resources for your Resource Group.
+
+![][image7]
+
+A list of inbound and outbound security rules for the network security group will be displayed.
+
+![][image8]
+
+To find all the firewall rules with the Azure CLI, start with the network interface name obtained from your VM information. Then, run the following command to obtain the network security group name:
+
+| $ az network nic show \\     \--name my-azure-vm930 \\     \--resource-group my-resource-group \\     \--query "networkSecurityGroup.id""/subscriptions/980e30f1-992f-4635-9eb0-1b5fe23ec084/resourceGroups/my-resource-group/providers/Microsoft.Network/networkSecurityGroups/my-azure-vm-nsg" |
+| :---- |
+
+To get a detailed breakdown of the network security group’s configuration, including ingress and egress ports and firewall settings, run the following command:
+
+| $ az network nsg show \\     \--name my-azure-vm-nsg \\     \--resource-group my-resource-group {  "defaultSecurityRules": \[    {      "access": "Allow",      "description": "Allow inbound traffic from all VMs in VNET",       …      "destinationPortRanges": \[\],      "direction": "Inbound",      …       "sourcePortRange": "\*",      "sourcePortRanges": \[\],    },    {      "access": "Allow",      "description": "Allow inbound traffic from azure load balancer",      …      "destinationPortRange": "\*",      "destinationPortRanges": \[\],      …      "sourcePortRange": "\*",      "sourcePortRanges": \[\],    },    …  \],   …  "securityRules": \[    {      "access": "Allow",      …      "destinationPortRange": "22",      "destinationPortRanges": \[\],      "direction": "Inbound",      …      "protocol": "TCP",      …      "sourcePortRange": "\*",      "sourcePortRanges": \[\],    }  \],  "type": "Microsoft.Network/networkSecurityGroups"} |
+| :---- |
+
+Back up your Azure VM Disk (optional)  
+Before starting your migration, consider backing up the Azure VM disk just in case a restoration is needed in the future. Return to the list of resources for the Resource Group and select the VM disk. On the disk details page, click **Create snapshot** and walk through the configuration options for the snapshot.
+
+![][image9]
+
+With az, the equivalent command for creating a snapshot looks like this:
+
+| $ az snapshot create \\    \--resource-group \<RESOURCE\_GROUP\_NAME\> \\    \--name \<SNAPSHOT\_NAME\> \\    \--source \<DISK\_NAME\_OR\_ID\> \\    \--location \<LOCATION\> |
+| :---- |
+
+For example:
+
+| $ az snapshot create \\     \--resource-group my-resource-group \\     \--name my-disk-snapshot \\     \--source my-azure-vm\_disk1\_bfb86e561c3a4716b164f82f4e558b8e \\     \--location westus {  "creationData": {    "createOption": "Copy",    "sourceResourceId": "/subscriptions/980e30f1-992f-4635-9eb0-1b5fe23ec084/resourceGroups/my-resource-group/providers/Microsoft.Compute/disks/my-azure-vm\_disk1\_bfb86e561c3a4716b164f82f4e558b8e",    "sourceUniqueId": "bfb86e56-1c3a-4716-b164-f82f4e558b8e"  },  "diskSizeBytes": 5368709120,   "diskSizeGB": 5,   …  "location": "westus",  "name": "my-disk-snapshot",  "networkAccessPolicy": "AllowAll",  "osType": "Linux",  "provisioningState": "Succeeded",  … } |
+| :---- |
+
+Your newly created snapshot can be found on the **Snapshots** page.
+
+![][image10]
+
+Alternatively, use the Azure CLI to list all snapshots for a resource group:
+
+| $ az snapshot list \--resource-group my-resource-group \[  {     …    "diskSizeBytes": 5368709120,     "diskSizeGB": 5,     "location": "westus",    "name": "my-disk-snapshot",    "provisioningState": "Succeeded",    "publicNetworkAccess": "Enabled",     …  }\] |
+| :---- |
+
+The [cost of Azure snapshots](https://azure.microsoft.com/en-us/pricing/details/managed-disks/#pricing) varies depending on redundancy options (local or zone).
+
+## Migrating to Akamai Linode
+
+Using a disk image to migrate an Azure VM to Akamai Linode involves exporting the VM disk from Azure, and then preparing and importing it when launching a new Linode Compute Instance.
+
+### Export the Azure VM disk
+
+Before you can export your disk, you must first stop your VM. On the details page for your VM, click **Stop**.
+
+![][image11]
+
+Next, navigate to the details for your Azure VM disk. Under **Settings**, click **Disk Export**.
+
+![][image12]
+
+When exporting a disk, Azure provides a temporary link to download the disk directly as a virtual hard disk (VHD) file. Specify an expiration time for the link. Since you will use the link immediately, the expiration window can be small. Click **Generate URL**.
+
+![][image13]
+
+To generate the disk export URL from the command line, run the following command:
+
+| $ az disk grant-access \\     \--name my-azure-vm\_disk1\_bfb86e561c3a4716b164f82f4e558b8e \\     \--resource-group my-resource-group \\     \--duration-in-seconds 120{  "accessSAS": "https://md-3rnqkqjjh5nk.z41.blob.storage.azure.net/5zfpv2fgr3wv/abcd?sv=2018-03-28\&sr=b\&si=8f527a7b-e94d-4e44-b6a9-313d2974197b\&sig=u0gKMJ%2BSlWEahBUoMg8%2Bppgi5bU65SotEaYD653YI0I%3D"} |
+| :---- |
+
+Then, use wget on your local machine to download and save the file using the provided URL.
+
+| $ wget \-O azure-download.vhd "\<GENERATED URL IN QUOTES\>" |
+| :---- |
+
+An example response to the wget call looks like this:
+
+| HTTP request sent, awaiting response... 200 OKLength: 5368709632 (5.0G) \[text/x-vhdl\]Saving to: 'azure-download.vhd' azure-download.vhd                                  100%\[=====================================\>\]  5.00G  2.91MB/s    in 24m 45s  'azure-download.vhd' saved \[5368709632/5368709632\] |
+| :---- |
+
+The total download time will depend on the disk size and your internet speeds.
+
+### Import and deploy VM image on Akamai Linode
+
+To provision a Linode Compute Instance by importing an existing VM image, ensure the image is in the proper format and compressed with gzip.
+
+#### Convert disk image to to raw format
+
+Linode does not support importing the VHD format, but instead requires a raw disk image format with a .img extension. To convert the VHD file from Azure to the raw format, use [qemu-img convert](https://qemu-project.gitlab.io/qemu/tools/qemu-img.html#cmdoption-qemu-img-arg-convert):
+
+| $ qemu-img convert \-f vpc \-O raw azure-download.vhd azure-image.raw |
+| :---- |
+
+The parameters used for the command are \-f, which specifies the input format (vpc \= Microsoft Virtual PC format), and \-O, which specifies the desired output format (raw). This is followed by the name of the input file to convert and the name of the output file to create.
+
+The resulting raw file should be nearly the same size as the original VHD file.
+
+| $ stat \-c "%s %n" \-- azure-\*  5368430592 azure-image.raw 5368709632 azure-download.vhd |
+| :---- |
+
+#### Prepare image file for import
+
+Linode requires an image file to have a .img extension. The naming convention does not have a functional difference. Nonetheless, if your raw image file does not have this extension, rename the file accordingly.
+
+| $ mv azure-image.raw azure-image.img |
+| :---- |
+
+Compress the image using gzip to reduce its size:
+
+| $ gzip azure-image.img$ du \-BM azure-image.img.gz  1737M	azure-image.img.gz  |
+| :---- |
+
+#### Upload the compressed file to Akamai Linode
+
+Use the Linode CLI to upload the compressed image file. Replace the .gz file with your specific file name. Specify the label, description, and region based on your use case.
+
+| $ linode-cli image-upload \\    \--label "azure-vm-migration" \\    \--description "Azure VM Import" \\    \--region "us-lax" \\    ./azure-image.img.gz `┌-----------------------┬-----------┬----------------┐ │ label                 │ is_public │ status         │ ├-----------------------┼-----------┼----------------┤ │ azure-vm-migration    │ False     │ pending_upload │ └-----------------------┴-----------┴----------------┘` |
+| :---- |
+
+The upload may take several minutes, depending on your image's size and internet speed.
+
+#### Verify the successful image upload
+
+After the upload, ensure the image is successfully processed and available for use. Run the following command to list your private images:
+
+| $ linode-cli images list \--is\_public false  ┌------------------┬-----------------------┬-----------┬--------┐ │ id               │ label                 │ status    │ size   │ ├------------------┼-----------------------┼-----------┼--------┤ │ private/30228641 │ azure-vm-migration    │ available │ 5120   │ └------------------┴-----------------------┴-----------┴--------┘ |
+| :---- |
+
+Verify that the status of the image is available. If the status is pending, wait a few minutes and then check again.
+
+You can also watch the progress of the image upload via the Linode Images dashboard:
+
+![][image14]
+
+#### Launch a Linode Compute Instance from the uploaded image
+
+Once the image is available, you can deploy it to a new Linode Compute instance. For this command, provide the ID of your uploaded image, which was displayed when running the previous command. In addition, provide the following:
+
+* \--label: A unique label for your instance.  
+* \--region: The region for your instance.  
+* \--type: The size of the instance to deploy.  
+* \--root\_pass: A unique, secure root password for your new instance.
+
+The following example deploys a g6-standard-2 Linode with 2 cores, 80 GB disk, and 4 GB RAM with a 4000 Mbps transfer rate. Recall that the original Azure VM instance for this migration is a Standard B2s, which has 2 CPUs and 4 GiB RAM. Therefore, the g6-standard-2 Linode instance is comparable.
+
+See the [pricing page for Akamai Connected Cloud](https://www.linode.com/pricing/#compute-shared) for details on different Linode types.
+
+| $ linode-cli linodes create \\    \--image \<LINODE IMAGE ID\> \\    \--label "migrated-from-azure" \\    \--region "us-lax" \\    \--type "g6-standard-2" \\    \--root\_pass "thisismysecurerootpassword"  ┌-----------------------┬--------┬---------------┬--------------┐ │ label                 │ region │ type          │ status       │ ├-----------------------┼--------┼---------------┼--------------┤ │ migrated-from-azure   │ us-lax │ g6-standard-2 │ provisioning │ └-----------------------┴--------┴---------------┴--------------┘ |
+| :---- |
+
+By default, Linode boots instances with its own kernel. However, you should use the kernel inside your image when booting it up. This can be done in the Linode dashboard. Navigate to your Linode Compute Instance. Click the **Configurations** tab at the bottom. Then, click **Edit**.
+
+![][image15]
+
+Under **Boot Settings**, select **Direct Disk** as the kernel.
+
+![][image16]
+
+Click **Save Changes**. Then, **reboot** your Linode.
+
+![][image17]
+
+After several minutes, your Linode Compute Instance will be up and running based on the exported VM image from Azure.
+
+### Configure and validate the Linode instance
+
+By migrating via an image exported from your Azure VM disk, you ensure that the operating system and all installed software and services are on the newly provisioned Linode. This reduces the time needed to configure the Linode instance to closely match the environment of the original VM.
+
+However, you must perform steps to configure networking to align with your needs. Recall the configurations from your original Azure VM:
+
+* [IP addresses](https://techdocs.akamai.com/cloud-computing/docs/managing-ip-addresses-on-a-compute-instance)  
+* [Firewall rules](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-cloud-firewalls)  
+* [Load balancing](https://techdocs.akamai.com/cloud-computing/docs/nodebalancer)  
+* [DNS](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-dns-manager)
+
+Linode does not have a direct equivalent to Azure network security groups. However, you can still implement a firewall with rules to control traffic. Options include:
+
+* [Linode Cloud Firewall](https://techdocs.akamai.com/cloud-computing/docs/cloud-firewall), for setting up inbound and outbound rules on Linode Compute Instances, either through the Linode API or the Linode CLI.  
+* [iptables](https://www.linode.com/docs/guides/control-network-traffic-with-iptables/) or [ufw](https://www.linode.com/docs/guides/configure-firewall-with-ufw/), which run from within the Linode instance to manage the Linux kernel firewall (Netfilter).
+
+Akamai Linode provides [NodeBalancers](https://www.linode.com/products/nodebalancers/), which are equivalent to the [Azure Application Gateway](https://learn.microsoft.com/en-us/azure/application-gateway/overview). If you are migrating an AzureVM with an attached Application Gateway, you can implement a similar configuration for your Linode.
+
+If you used Azure DNS to implement DNS rules to route traffic to your VM, then you will need to modify your DNS settings to ensure traffic routes to your new Linode instance. This may involve pointing nameservers to Akamai Linode and creating DNS rules within the Akamai Cloud Manager.
+
+After completing your configurations, test your Linode instance to verify that the migration was successful. Validation steps may include:
+
+* **Check running services**. Ensure that all critical services, such as web servers, databases, and application processes are running as expected and configured to start on boot.  
+* **Test application functionality**. Access any applications on the new Linode through their web interface or API endpoints to confirm that they behave as expected, including core functionality and error handling.  
+* **Inspect resource utilization**. Monitor CPU, memory, and disk usage on the Linode to ensure the system performs within acceptable thresholds post-migration.  
+* **Validate DNS configuration**. Ensure DNS changes (if made) are propagating correctly, pointing to your Linode instance, and resolving to the expected IP addresses.  
+* **Check external connectivity**. Verify that the instance can access any required external resources, such as third-party APIs, databases, or storage, and that outbound requests succeed.  
+* **Review logs**. Examine system and application logs for errors or warnings that might indicate migration-related issues.  
+* **Backup and snapshot functionality**. Confirm that backups and snapshots can be created successfully on Linode to safeguard your data post migration.  
+* **Verify externally attached storage**: Ensure that any additional storage volumes, block devices, or network-attached storage are properly mounted and accessible. Check /etc/fstab entries and update disk mappings as needed.
+
+## Additional Considerations
+
+### Cost management
+
+Review the pricing for your current Azure VM instance ([compute](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows/), [storage](https://azure.microsoft.com/en-ca/pricing/details/managed-disks/), and [bandwidth](https://azure.microsoft.com/en-us/pricing/details/bandwidth/)). Compare this with the [pricing plans for Akamai Connected Cloud](https://www.linode.com/pricing/). Use [Akamai’s Cloud Computing Calculator](https://www.linode.com/cloud-computing-calculator/) to estimate potential costs.
+
+### Data consistency and accuracy
+
+Verify that the Linode migrated from the image export contains all necessary files, configurations, and application data. Double-check for corrupted or missing files during the image export and upload process. Verification steps may include:
+
+* **Generate and compare file checksums**: Use tools like md5sum to generate checksums of critical files or directories on both the source VM and the migrated Linode. Ensure the checksums match to confirm data integrity.  
+* **Count files and directories**: Use find or ls commands to count the number of files and directories in key locations (for example: find /path \-type f | wc \-l). Compare these counts between the source and destination to identify any discrepancies.  
+* **Check application logs and settings**: Compare configuration files, environment variables, and application logs between the source and the destination to confirm they are identical or appropriately modified for the new environment. Common locations to review may include:
+
+| Application | Configuration | Location |
+| :---- | :---- | :---- |
+| **Apache Web Server** | Main | /etc/apache2/apache2.conf |
+|  | Virtual hosts | /etc/apache2/sites-available /etc/apache2/sites-enabled |
+| **NGINX Web Server** | Main | /etc/nginx/nginx.conf |
+|  | Virtual hosts | /etc/nginx/sites-available/etc/nginx/sites-enabled |
+| **Cron** | Application | /etc/cron.d |
+|  | System-wide cron jobs | /etc/crontab |
+|  | User-specific cron jobs | /var/spool/cron/crontabs |
+| **MySQL/MariaDB** | Main | /etc/mysql |
+| **PostgreSQL** | Main | /etc/postgresql |
+| **SSH** | Main | /etc/ssh/sshd\_config |
+| **Networking** | Hostname | /etc/hostname |
+|  | Hosts file | /etc/hosts |
+| **Rsyslog** | Main | /etc/rsyslog.conf |
+
+
+* **Review symbolic links and permissions**: Use CLI tools and commands to confirm that symbolic links and file permissions on the migrated Linode match those on the source VM. Examples include:
+
+| Description | Command |
+| :---- | :---- |
+| List all symbolic links in folder (recursive) | **ls \-Rla /path/to/folder | grep "\\-\>"** |
+| Calculate md5 hash for all files in a folder, then sort by filename and write to file. Then, compare files from both VMs using diff. | **find /path/to/folder/ \-type f \\  \-exec md5sum {} \+ \\  | sort \-k 2 \> hashes.txt** |
+| Write to file the folder contents (recursive) with permissions, owner name, and group name. Then, compare permissions files from both VMs using diff. | **tree /path/to/folder \-fpuig \> permissions.txt** |
+
+
+After deploying your Linode, confirm that configurations (network settings, environment variables, and application dependencies) match the original VM to avoid runtime issues.
+
+### Security and access controls
+
+[Azure roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/rbac-and-directory-admin-roles) govern instance access. Migrate these roles and permissions to Linode by setting up Linode API tokens and fine-tuning user permissions.
+
+Use the Linode Cloud Firewall or existing system firewall on your instance to restrict access. Ensure SSH keys are properly configured, and disable root login if not required. Map Azure network security group policy rules to your firewall for consistent protection.
+
+### Alternative migration options
+
+This guide covered migrating a VM by exporting an image from the original Azure VM instance disk and importing that image to Akamai Linode as the basis of a new Linode Compute Instance. When cloud provider restrictions or image size limits make this approach unavailable, consider other migration options, including:
+
+* **Rclone**: For example, provision a Linode Compute Instance with resource levels comparable to your original VM. Then, use [rclone](https://rclone.org/)—a command line utility for managing files in cloud storage—to move all data from your original VM to your new Linode. This can effectively move your workloads from your Azure VM to your Linode.
+
+* **IaC**: You can also leverage infrastructure-as-code (IaC) and configuration management tools to streamline your migration process. Tools like [Ansible](https://docs.ansible.com/ansible/latest/index.html), [Terraform](https://www.terraform.io/), [Chef](https://www.chef.io/products/chef-infra), and [Puppet](https://www.puppet.com/why-puppet/use-cases/continuous-configuration-automation) can help you automatically replicate server configurations, deploy applications, and ensure consistent settings across your source and destination VMs. By using these tools, you can create repeatable migration workflows that reduce manual intervention and minimize the risk of configuration errors during the transition.
+
+* **Containerization**: Another option is to containerize any workloads on your original VM. These containerized images can be run in the Akamai Connected Cloud. For example, you can provision a [Linode Kubernetes Engine (LKE)](https://techdocs.akamai.com/cloud-computing/docs/linode-kubernetes-engine) cluster to host and run these containers, thereby removing the need for a VM.
+
+## Resources
+
+Azure
+
+* [Azure CLI (az) Documentation](https://learn.microsoft.com/en-us/cli/azure/)  
+* Downloading a VHD from Azure  
+  * [Linux](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/download-vhd)  
+  * [Windows](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/download-vhd?tabs=azure-portal)  
+* [Troubleshooting backup failures on Azure virtual machines](https://learn.microsoft.com/en-us/azure/backup/backup-azure-vms-troubleshoot)
+
+Akamai Linode
+
+* [Linode CLI and Object Storage](https://techdocs.akamai.com/cloud-computing/docs/using-the-linode-cli-with-object-storage)  
+* [Uploading an image](https://techdocs.akamai.com/cloud-computing/docs/upload-an-image)  
+* [Deploying an Image](https://techdocs.akamai.com/cloud-computing/docs/deploy-an-image-to-a-new-compute-instance)
+
+Other helpful utilities
+
+* [QEMU Disk Imaging Utility](https://www.qemu.org/download/)  
+* [rclone](https://rclone.org/)  
+* [Shrinking images on Linux](https://softwarebakery.com//shrinking-images-on-linux)

--- a/docs/guides/platform/migrate-to-linode/transfer-vm-from-aws-ec2-to-akamai-using-disk-images/index.md
+++ b/docs/guides/platform/migrate-to-linode/transfer-vm-from-aws-ec2-to-akamai-using-disk-images/index.md
@@ -1,0 +1,373 @@
+---
+slug: transfer-vm-from-aws-ec2-to-akamai-using-disk-images
+title: "Transfer VM From AWS EC2 to Akamai Using Disk Images"
+description: "Two to three sentences describing your guide."
+authors: ["Linode"]
+contributors: ["Linode"]
+published: 2025-05-28
+keywords: ['list','of','keywords','and key phrases']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+external_resources:
+- '[Link Title 1](http://www.example.com)'
+- '[Link Title 2](http://www.example.net)'
+---
+
+In modern cloud computing, virtual machine (VM) migration is a process that enables organizations to transition workloads across cloud platforms to optimize costs, improve performance, or enhance flexibility. By migrating VMs, organizations can pick and choose the capabilities of various cloud providers that best satisfy their business needs.
+
+This guide focuses on using a disk image to transfer a VM from AWS EC2 to Akamai Linode, suggesting how to plan, execute, and validate a migration.
+
+## Prerequisites
+
+To follow along in this walkthrough, you’ll need the following:
+
+* An [account with Akamai Linode](https://www.linode.com/cfe)  
+* A [Linode API token (personal access token)](https://www.linode.com/docs/products/platform/accounts/guides/manage-api-tokens/)  
+* The [Linode CLI](https://www.linode.com/docs/products/tools/cli/guides/install/) installed and configured  
+* Access to your AWS account with sufficient permissions to work with EC2 instances  
+* The [AWS CLI](https://aws.amazon.com/cli/) installed and configured  
+* [jq](https://jqlang.github.io/jq/download/) installed and configured
+
+## Preparing Your AWS EC2 Environment for Migration
+
+Prepare your current AWS EC2 environment to ensure a smooth and efficient transition. As you assess your EC2 instance requirements, familiarize yourself with any limitations that Akamai Linode imposes on resources imported into its systems.
+
+| Important note: [Images imported into Akamai Linode](https://techdocs.akamai.com/cloud-computing/docs/upload-an-image) must be smaller than 6 GB unzipped and 5 GB zipped. Larger images will be rejected and not imported. |
+| :---- |
+
+### Assess current EC2 instance requirements
+
+Capture the current configuration of your EC2 instance so that you can select the appropriate [Akamai Connected Cloud plan](https://www.linode.com/pricing/#compute-shared) to ensure post-migration performance. In the AWS Console, navigate to the **Instances** page of the **EC2** service.
+
+![][image2]
+
+Find the EC2 instance you want to migrate. Note the instance ID and the instance type.
+
+![][image3]
+
+In the example above, the instance ID is i-0e1dc0292b0ae7293 and the instance type is t2.medium.
+
+#### CPU and memory usage
+
+To determine the CPU and memory usage of your EC2 instance, run the following command with the AWS CLI, inserting the appropriate instance type:
+
+| $ aws ec2 describe-instance-types \--instance-types=t2.medium \\     | jq '.InstanceTypes\[0\] | {VCpuInfo, MemoryInfo}' {  "VCpuInfo": {    "DefaultVCpus": 2,    "DefaultCores": 2,    "DefaultThreadsPerCore": 1  },  "MemoryInfo": {    "SizeInMiB": 4096  }} |
+| :---- |
+
+#### Storage usage
+
+Navigate to the **Storage** tab for your EC2 instance.
+
+![][image4]
+
+Click the listed volume to view additional details about storage.
+
+![][image5]
+
+In the above example, the storage volume attached to the EC2 instance is type gp3, with a size of 2 GiB.
+
+You can also obtain this information by running the following command, inserting the instance ID for your specific EC2 instance:
+
+| $ aws ec2 describe-volumes \\     \--filters "Name=attachment.instance-id,Values=i-0e1dc0292b0ae7293" \\     | jq '.Volumes\[0\] | {Size, VolumeType}' {  "Size": 2,  "VolumeType": "gp3"} |
+| :---- |
+
+#### IP addresses
+
+On the instance summary page for your EC2, you can find your instance's public and private IP addresses.
+
+![][image6]
+
+You can also retrieve this information from the command line:
+
+| $ aws ec2 describe-instances \\    \--instance-ids i-0e1dc0292b0ae7293 \\    | jq \\       '.Reservations\[0\].Instances\[0\] | {PublicIpAddress,PrivateIpAddress}' {   "PublicIpAddress": "54.219.166.73",   "PrivateIpAddress": "172.31.5.242" } |
+| :---- |
+
+#### Security groups and firewall rules
+
+Navigate to the **Security** tab for information about associated security groups and firewall rules.
+
+![][image7]
+
+At the command line, you can use the security group rule IDs to obtain the detailed firewall rule information. For example:
+
+| $ aws ec2 describe-security-group-rules \\     \--security-group-rule-ids \\       sgr-0eb2e5aee98524d46 \\       sgr-0936993e811c9ea8d \\       sgr-0fa434147d85e6031 \\       sgr-029ee55aa41939b76 {    "SecurityGroupRules": \[        {            "SecurityGroupRuleId": "sgr-0eb2e5aee98524d46",            "GroupId": "sg-05bb8599e5070fc89",            "GroupOwnerId": "153917289119",            "IsEgress": false,            "IpProtocol": "tcp",            "FromPort": 443,            "ToPort": 443,            "CidrIpv4": "0.0.0.0/0",            "Tags": \[\]        },        {            "SecurityGroupRuleId": "sgr-0936993e811c9ea8d",            "GroupId": "sg-05bb8599e5070fc89",            "GroupOwnerId": "153917289119",            "IsEgress": false,            "IpProtocol": "tcp",            "FromPort": 22,            "ToPort": 22,            "CidrIpv4": "0.0.0.0/0",            "Tags": \[\]        },        {            "SecurityGroupRuleId": "sgr-0fa434147d85e6031",            "GroupId": "sg-05bb8599e5070fc89",            "GroupOwnerId": "153917289119",            "IsEgress": false,            "IpProtocol": "tcp",            "FromPort": 80,            "ToPort": 80,            "CidrIpv4": "0.0.0.0/0",            "Tags": \[\]        },        {            "SecurityGroupRuleId": "sgr-029ee55aa41939b76",            "GroupId": "sg-05bb8599e5070fc89",            "GroupOwnerId": "153917289119",            "IsEgress": true,            "IpProtocol": "-1",            "FromPort": \-1,            "ToPort": \-1,            "CidrIpv4": "0.0.0.0/0",            "Tags": \[\]        }    \]} |
+| :---- |
+
+#### Other networking-related configurations
+
+Determine if your EC2 instance has any associated load balancer resources or custom DNS configurations. Capture this information, as it may affect how you provision your Linode instance and configure its networking resources.
+
+### Back up your data on AWS EC2
+
+Creating a comprehensive backup of your EC2 instance ensures you can restore your environment in case of unexpected issues during the migration. By assessing your instance requirements and creating backups, migrating existing VMs to Akamai Linode can proceed with minimal risk.
+
+AWS provides two approaches to creating a backup:
+
+1. **Create a snapshot**: A snapshot captures a point-in-time copy of your data. Within the AWS Console, navigate to the details page for your EBS volume. Click **Actions**, then select **Create Snapshot**.
+
+![][image8]
+
+2. **Create an Amazon Machine Image (AMI):** An AMI provides a full backup of your EC2 instance, including its OS, applications, and configuration. You can also import this image to Akamai Linode when migrating a VM, which is the approach this guide demonstrates.
+
+| Note: Backups on AWS may incur costs. See Amazon for pricing information on backing up your data. |
+| :---- |
+
+## Migrating to Akamai Linode
+
+Migrating from AWS EC2 to Akamai Linode primarily involves capturing and exporting the instance image from AWS, then importing it when deploying a new Linode instance. 
+
+### Export your AWS EC2 environment
+
+#### Create AMI
+
+Create an AMI to export your EC2 instance as a transferable, virtual machine image. From the EC2 instance summary page, click **Instance state \> Image and templates \> Create image**.
+
+**![][image9]**
+
+Provide a name and description for your image. Then, click **Create image**.
+
+To create an AMI from the command line, run the following command:
+
+| $ aws ec2 create-image \\     \--instance-id i-0e1dc0292b0ae7293 \\     \--name "ec2-pre-migration-image" \\     \--description "EC2 instance prior to Linode migration" \\     \--no-reboot {     "ImageId": "ami-0b5823d737dcd831a" } |
+| :---- |
+
+The \--no-reboot flag is optional and ensures the instance does not reboot during the image creation process. If you prefer a clean shutdown, then remove this flag. The output of the command is the ID of the newly created image.
+
+To list existing images and monitor image creation status, use the describe-images command:
+
+| $ aws ec2 describe-images \--owner self {     "Images": \[         {             …             "ImageId": "ami-0b5823d737dcd831a",             "ImageType": "machine",             "Public": false,             "PlatformDetails": "Linux/UNIX",             "UsageOperation": "RunInstances",             "State": "available",             "BlockDeviceMappings": \[                 {                     "DeviceName": "/dev/xvda",                     "Ebs": {                         "DeleteOnTermination": true,                         "Iops": 3000,                         "SnapshotId": "snap-0cfa25763b370690d",                         "VolumeSize": 2,                         "VolumeType": "gp3",                         "Throughput": 125,                         "Encrypted": false                     }                 }             \],             "Description": "EC2 instance prior to Linode migration",             "EnaSupport": true,             "Hypervisor": "xen",             "Name": "ec2-pre-migration-image",             "RootDeviceName": "/dev/xvda",             "RootDeviceType": "ebs",             …             "SourceInstanceId": "i-0e1dc0292b0ae7293"         }     \] } |
+| :---- |
+
+The State of the image will transition from pending to available.
+
+#### Create S3 bucket
+
+Once the AMI is available, export it as a virtual machine image. The [export-image](https://docs.aws.amazon.com/cli/latest/reference/ec2/export-image.html) command from AWS supports the following disk formats:
+
+* RAW (.img): The required format for Linode  
+* VMDK: The required format for VMWare  
+* VHD: The required format for Hyper-V
+
+The image will be exported to AWS S3. Before you can export it, create an S3 bucket to store it.
+
+| $ aws s3 mb s3://ec2-backup-images-for-migrationmake\_bucket: ec2-backup-images-for-migration |
+| :---- |
+
+| Note: If you don’t already have an S3 bucket for storing your backup, new or additional S3 buckets may incur costs from AWS. See Amazon for S3 pricing information. |
+| :---- |
+
+#### Set up permissions for exporting AMI to S3
+
+Grant permissions for the AWS EC2 service to export to the S3 bucket. Add the following policy to the newly created bucket:
+
+| {  "Version": "2012-10-17",  "Statement": \[    {      "Effect": "Allow",      "Principal": { "Service": "vmie.amazonaws.com" },      "Action": "s3:PutObject",      "Resource": "arn:aws:s3:::\<bucket-name\>/\*",      "Condition": {        "StringEquals": { "aws:SourceAccount": "\<aws-account-id\>" }      }    }  \]} |
+| :---- |
+
+Replace \<bucket-name\> and \<aws-account-id\> with the appropriate values.
+
+![][image10]
+
+AWS [requires the vmimport role](https://docs.aws.amazon.com/vm-import/latest/userguide/required-permissions.html) to export AMIs. If this role is missing, then create it manually. To create this role, first create a trust policy JSON file (named trust-policy.json) with the following content:
+
+| {   "Version": "2012-10-17",   "Statement": \[      {         "Effect": "Allow",         "Principal": { "Service": "vmie.amazonaws.com" },         "Action": "sts:AssumeRole",         "Condition": {            "StringEquals":{               "sts:Externalid": "vmimport"            }         }      }   \]} |
+| :---- |
+
+Assuming the file is saved in /home/user folder, run the following command to create the role:
+
+| $ aws iam create-role \\     \--role-name vmimport \\     \--assume-role-policy-document file:///home/user/trust-policy.json |
+| :---- |
+
+Next, create a permissions policy (in a file named permissions-policy.json) with the following contents:
+
+| {  "Version": "2012-10-17",  "Statement": \[    {      "Effect": "Allow",      "Action": \[        "s3:GetBucketLocation",        "s3:GetObject",        "s3:PutObject"      \],      "Resource": "arn:aws:s3:::\<bucket-name\>/\*"    },    {      "Effect": "Allow",      "Action": \[        "ec2:CancelConversionTask",        "ec2:CancelExportTask",        "ec2:CreateImage",        "ec2:CreateInstanceExportTask",        "ec2:CreateTags",        "ec2:Describe\*",        "ec2:ExportImage",        "ec2:ImportInstance",        "ec2:ImportVolume",        "ec2:StartInstances",        "ec2:StopInstances",        "ec2:TerminateInstances",        "ec2:ImportImage",        "ec2:ImportSnapshot",        "ec2:ModifySnapshotAttribute",        "ec2:CopySnapshot",        "ec2:RegisterImage",        "ec2:CancelImportTask"      \],      "Resource": "\*"    }  \]} |
+| :---- |
+
+Replace \<bucket-name\> with the appropriate value.
+
+Attach this policy to the newly created vmimport role by running the following command:
+
+| $ aws iam put-role-policy \\    \--role-name vmimport \\    \--policy-name vmimport-permissions \\    \--policy-document file:///home/user/permissions-policy.json |
+| :---- |
+
+#### Export AMI to S3
+
+Run the following command to export the AMI as a RAW disk image to your S3 bucket, making sure to insert your specific AMI ID and S3 bucket name:
+
+| $ aws ec2 export-image \\                                                                                                                   \--image-id \<AMI-ID\> \\    \--disk-image-format RAW \\    \--s3-export-location \\       S3Bucket=\<bucket-name\>,S3Prefix=exports/ {     "DiskImageFormat": "RAW",     "ExportImageTaskId": "export-ami-9dadaf55b2b57810t",     "ImageId": "ami-0b5823d737dcd831a",     "Progress": "0",     "S3ExportLocation": {         "S3Bucket": "ec2-backup-images-for-migration",         "S3Prefix": "exports"     },     "Status": "active",     "StatusMessage": "validating" } |
+| :---- |
+
+Exporting the image may take several minutes or more. To check on the status, run the following command, inserting the ExportImageTaskId from the result of the previous command:
+
+| $ aws ec2 describe-export-tasks \\     \--export-task-ids export-ami-9dadaf55b2b57810t  {     "ExportTasks": \[         {             "ExportTaskId": "export-ami-9dadaf55b2b57810t",             "ExportToS3Task": {                 "DiskImageFormat": "RAW",                 "S3Bucket": "ec2-backup-images-for-migration"             },             "InstanceExportDetails": {},             "State": "active"         }     \] } |
+| :---- |
+
+When the State value changes to completed, the image is ready for download from the S3 bucket.
+
+![][image11]
+
+#### Download image file from S3
+
+Download the generated .raw file from S3 to your local machine. This can be done through the AWS Console or by running the following command:
+
+| $ aws s3 cp s3://\<bucket-name\>/exports/\<image-file\> ./ $ ls \-h \*.raw \-rw-rw-r-- 2.0G export-ami-9dadaf55b2b57810t.raw |
+| :---- |
+
+### Import and deploy VM image on Akamai Linode
+
+To provision a Linode Compute Instance by importing an existing VM image, ensure the image is in the proper format and compressed with gzip.
+
+#### Prepare image file for import
+
+The export task from AWS above produces an image with the .raw file extension. Linode expects an image file with an .img extension. To convert the file type, rename the file to use the .img extension, and it will be ready for import.
+
+| $ mv export-ami-9dadaf55b2b57810t.raw export-ami-9dadaf55b2b57810t.img |
+| :---- |
+
+Compress the image using gzip to reduce its size:
+
+| $ gzip export-ami-9dadaf55b2b57810t.img$ ls \-h \*.gz\-rw-rw-r-- 422M export-ami-9dadaf55b2b57810t.img.gz |
+| :---- |
+
+#### Upload compressed file to Akamai Linode
+
+You can use the Linode CLI to upload the compressed image file. Replace the .gz file with your specific file name. Specify the label, description, and region based on your specific use case.
+
+| $ linode-cli image-upload \\    \--label "aws-ec2-migration-ami" \\    \--description "AWS EC2 Import" \\    \--region "us-lax" \\    ./export-ami-9dadaf55b2b57810t.img.gz `┌-----------------------┬-----------┬----------------┐ │ label                 │ is_public │ status         │ ├-----------------------┼-----------┼----------------┤ │ aws-ec2-migration-ami │ False     │ pending_upload │ └-----------------------┴-----------┴----------------┘` |
+| :---- |
+
+The upload may take several minutes, depending on the size of your image and your internet speed.
+
+#### Verify the successful image upload
+
+After the upload, ensure the image is successfully processed and available for use. Run the following command to list your private images:
+
+| $ linode-cli images list \--is\_public false  ┌------------------┬-----------------------┬-----------┬--------┐ │ id               │ label                 │ status    │ size   │ ├------------------┼-----------------------┼-----------┼--------┤ │ private/29293519 │ aws-ec2-migration-ami │ available │ 2048   │ └------------------┴-----------------------┴-----------┴--------┘ |
+| :---- |
+
+Verify that the status of the image is available. If the status is pending, wait a few minutes and then check again.
+
+#### Launch a Linode Compute Instance from the uploaded image
+
+Once the image is available, you can deploy it to a new Linode Compute instance. For this command, provide the ID of your uploaded image, which was displayed when running the previous command. In addition, provide the following:
+
+* \--label: A unique label for your instance.  
+* \--region: The region for your instance.  
+* \--type: The size of the instance to deploy.  
+* \--root\_pass: A unique, secure root password for your new instance.
+
+The following example deploys a g6-standard-2 Linode, which has two cores, 80 GB disk, and 4 GB RAM with a 4000 Mbps transfer rate. Recall that the original AWS EC2 instance for this migration is a t2.medium, which has two vCPUs and 4 GiB RAM. Therefore, the g6-standard-2 Linode instance is comparable.
+
+See the [pricing page for Akamai Connected Cloud](https://www.linode.com/pricing/#compute-shared) for details on different Linode types.
+
+| $ linode-cli linodes create \\    \--image \<image-id\> \\    \--label "migrated-from-aws-ec2" \\    \--region "us-lax" \\    \--type "g6-standard-2" \\    \--root\_pass "thisismysecurerootpassword"  ┌-----------------------┬--------┬---------------┬--------------┐ │ label                 │ region │ type          │ status       │ ├-----------------------┼--------┼---------------┼--------------┤ │ migrated-from-aws-ec2 │ us-lax │ g6-standard-2 │ provisioning │ └-----------------------┴--------┴---------------┴--------------┘ |
+| :---- |
+
+After several minutes, your Linode Compute Instance will be up and running, based on the exported VM image from your original cloud provider.
+
+![][image12]
+
+### Configure and validate the Linode instance
+
+By performing a migration with an AMI that captures your EC2 instance and volume in full, you ensure that the operating system and all installed software and services exist on the newly provisioned Linode. This reduces the amount of time needed to configure the Linode instance to closely match the environment of the original VM.
+
+However, you must perform steps to configure networking to align with your needs. Recall the configurations from your original EC2 instance. As applicable, port these configurations to your Linode environment:
+
+* [IP addresses](https://techdocs.akamai.com/cloud-computing/docs/managing-ip-addresses-on-a-compute-instance)  
+* [Firewall rules](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-cloud-firewalls)  
+* [Load balancing](https://techdocs.akamai.com/cloud-computing/docs/nodebalancer)  
+* [DNS](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-dns-manager)
+
+Linode does not have a direct equivalent to AWS security groups. However, you can still implement a firewall with rules to control traffic. Options include:
+
+* [Linode Cloud Firewall](https://techdocs.akamai.com/cloud-computing/docs/cloud-firewall), for setting up inbound and outbound rules on Linode Compute Instances, either through the Linode API or the Linode CLI.  
+* [iptables](https://www.linode.com/docs/guides/control-network-traffic-with-iptables/) or [ufw](https://www.linode.com/docs/guides/configure-firewall-with-ufw/), which run from within the Linode instance to manage the Linux kernel firewall (Netfilter).
+
+Akamai Linode provides [NodeBalancers](https://www.linode.com/products/nodebalancers/), which are equivalent to AWS Application Load Balancers (ALB). If you are migrating an EC2 instance with an ALB attached, you can implement a similar configuration for your Linode.
+
+If you used AWS Route53 to implement DNS rules to route traffic to your EC2 instance, then you will need to modify your DNS settings to ensure traffic routes to your new Linode instance. This may involve pointing nameservers to Akamai Linode and creating DNS rules within the Akamai Cloud Manager.
+
+After completing your configurations, test your Linode instance to verify that the migration was successful. Validation steps may include:
+
+* **Check running services**. Ensure that all critical services, such as web servers, databases, and application processes are running as expected and configured to start on boot.  
+* **Test application functionality**. Access any applications on the new Linode through their web interface or API endpoints to confirm that they behave as expected, including core functionality and error handling.  
+* **Inspect resource utilization**. Monitor CPU, memory, and disk usage on the Linode to ensure the system performs within acceptable thresholds post-migration.  
+* **Validate DNS configuration**. Ensure DNS changes (if made) are propagating correctly, pointing to your Linode instance, and resolving to the expected IP addresses.  
+* **Check external connectivity**. Verify that the instance can access any required external resources, such as third-party APIs, databases, or storage, and that outbound requests succeed.  
+* **Review logs**. Examine system and application logs for errors or warnings that might indicate migration-related issues.  
+* **Backup and snapshot functionality**. Confirm that backups and snapshots can be created successfully on Linode to safeguard your data post migration.  
+* **Verify externally attached storage**: Ensure that any additional storage volumes, block devices, or network-attached storage are properly mounted and accessible. Check /etc/fstab entries and update disk mappings as needed.
+
+## Additional Considerations
+
+### Cost management
+
+Review the pricing for your current AWS EC2 instance ([compute](https://aws.amazon.com/ec2/pricing/on-demand/#On-Demand_Pricing), [storage](https://aws.amazon.com/ebs/pricing/), and [bandwidth](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer)). Compare this with the [pricing plans for Akamai Connected Cloud](https://www.linode.com/pricing/). Use [Akamai’s Cloud Computing Calculator](https://www.linode.com/cloud-computing-calculator/) to estimate potential costs.
+
+### Data consistency and accuracy
+
+Verify that the Linode migrated from the image export contains all necessary files, configurations, and application data. Double check for corrupted or missing files during the image export and upload process. Verification steps may include:
+
+* **Generate and compare file checksums**: Use tools like md5sum to generate checksums of critical files or directories on both the source VM and the migrated Linode. Ensure the checksums match to confirm data integrity.  
+* **Count files and directories**: Use find or ls commands to count the number of files and directories in key locations (for example: find /path \-type f | wc \-l). Compare these counts between the source and destination to identify any discrepancies.  
+* **Check application logs and settings**: Compare configuration files, environment variables, and application logs between the source and the destination to confirm they are identical or appropriately modified for the new environment. Common locations to review may include:
+
+| Application | Configuration | Location |
+| :---- | :---- | :---- |
+| **Apache Web Server** | Main | /etc/apache2/apache2.conf |
+|  | Virtual hosts | /etc/apache2/sites-available /etc/apache2/sites-enabled |
+| **NGINX Web Server** | Main | /etc/nginx/nginx.conf |
+|  | Virtual hosts | /etc/nginx/sites-available/etc/nginx/sites-enabled |
+| **Cron** | Application | /etc/cron.d |
+|  | System-wide cron jobs | /etc/crontab |
+|  | User-specific cron jobs | /var/spool/cron/crontabs |
+| **MySQL/MariaDB** | Main | /etc/mysql |
+| **PostgreSQL** | Main | /etc/postgresql |
+| **SSH** | Main | /etc/ssh/sshd\_config |
+| **Networking** | Hostname | /etc/hostname |
+|  | Hosts file | /etc/hosts |
+| **Rsyslog** | Main | /etc/rsyslog.conf |
+
+
+* **Review symbolic links and permissions**: Use CLI tools and commands to confirm that symbolic links and file permissions on the migrated Linode match those on the source VM. Examples include:
+
+| Description | Command |
+| :---- | :---- |
+| List all symbolic links in folder (recursive) | **ls \-Rla /path/to/folder | grep "\\-\>"** |
+| Calculate md5 hash for all files in a folder, then sort by filename and write to file. Then, compare files from both VMs using diff. | **find /path/to/folder/ \-type f \\  \-exec md5sum {} \+ \\  | sort \-k 2 \> hashes.txt** |
+| Write to file the folder contents (recursive) with permissions, owner name, and group name. Then, compare permissions files from both VMs using diff. | **tree /path/to/folder \-fpuig \> permissions.txt** |
+
+
+  
+After deploying your Linode, confirm that configurations (network settings, environment variables, and application dependencies) match the original VM to avoid runtime issues.
+
+### Security and access controls
+
+AWS IAM roles govern instance access. Migrate these roles and permissions to Linode by setting up Linode API tokens and fine-tuning user permissions.
+
+Use the Linode Cloud Firewall or existing system firewall on your instance to restrict access. Ensure SSH keys are properly configured, and disable root login if not required. Map AWS security group policy rules to your firewall for consistent protection.
+
+### Alternative migration options
+
+This guide covered migrating a VM by creating a disk image of the original AWS EC2 instance and importing that image to Akamai Linode as the basis of a new Linode Compute Instance. When cloud provider restrictions or image size limits make this approach unavailable, consider other migration options, including:
+
+* **Rclone**: For example, provision a Linode Compute Instance with resource levels comparable to your original VM. Then, use [rclone](https://rclone.org/)—a command line utility for managing files in cloud storage—to move all data from your original VM to your new Linode. This can effectively move your workloads from your AWS VM to your Linode.
+
+* **IaC**: You can also leverage infrastructure-as-code (IaC) and configuration management tools to streamline your migration process. Tools like [Ansible](https://docs.ansible.com/ansible/latest/index.html), [Terraform](https://www.terraform.io/), [Chef](https://www.chef.io/products/chef-infra), and [Puppet](https://www.puppet.com/why-puppet/use-cases/continuous-configuration-automation) can help you automatically replicate server configurations, deploy applications, and ensure consistent settings across your source and destination VMs. By using these tools, you can create repeatable migration workflows that reduce manual intervention and minimize the risk of configuration errors during the transition.
+
+* **Containerization**: Another option is to containerize any workloads on your original VM. These containerized images can be run in the Akamai Connected Cloud. For example, you can provision a [Linode Kubernetes Engine (LKE)](https://techdocs.akamai.com/cloud-computing/docs/linode-kubernetes-engine) cluster to host and run these containers, thereby removing the need for a VM.
+
+## Resources
+
+AWS
+
+* [EC2 export-image documentation](https://docs.aws.amazon.com/cli/latest/reference/ec2/export-image.html)
+
+Akamai Linode
+
+* [Linode CLI and Object Storage](https://techdocs.akamai.com/cloud-computing/docs/using-the-linode-cli-with-object-storage)  
+* [Uploading an image](https://techdocs.akamai.com/cloud-computing/docs/upload-an-image)  
+* [Deploying an Image](https://techdocs.akamai.com/cloud-computing/docs/deploy-an-image-to-a-new-compute-instance)
+
+Other helpful utilities
+
+* [QEMU Disk Imaging Utility](https://www.qemu.org/download/)  
+* [rclone](https://rclone.org/)

--- a/docs/guides/platform/migrate-to-linode/transfer-vm-from-gcp-compute-engine-to-akamai-using-disk-images/index.md
+++ b/docs/guides/platform/migrate-to-linode/transfer-vm-from-gcp-compute-engine-to-akamai-using-disk-images/index.md
@@ -1,0 +1,420 @@
+---
+slug: transfer-vm-from-gcp-compute-engine-to-akamai-using-disk-images
+title: "Transfer VM From GCP Compute Engine to Akamai Using Disk Images"
+description: "Two to three sentences describing your guide."
+authors: ["Linode"]
+contributors: ["Linode"]
+published: 2025-05-28
+keywords: ['list','of','keywords','and key phrases']
+license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
+external_resources:
+- '[Link Title 1](http://www.example.com)'
+- '[Link Title 2](http://www.example.net)'
+---
+
+In modern cloud computing, virtual machine (VM) migration is a process that enables organizations to transition workloads between cloud platforms to optimize costs, improve performance, or enhance flexibility. By migrating VMs, organizations can select the capabilities of various cloud providers that best satisfy their business needs.
+
+This guide focuses on migrating a VM from Google Cloud Platform (GCP) to Akamai Linode and suggests how to plan, execute, and validate the migration.
+
+## Prerequisites
+
+To follow along in this walkthrough, you’ll need the following:
+
+* An [account with Akamai Linode](https://www.linode.com/cfe)  
+* A [Linode API token (personal access token)](https://www.linode.com/docs/products/platform/accounts/guides/manage-api-tokens/)  
+* The [Linode CLI](https://www.linode.com/docs/products/tools/cli/guides/install/) installed and configured  
+* A GCP account with sufficient permissions to work with Disks, Storage, and Build Jobs.  
+* The [GCP CLI](https://cloud.google.com/sdk/docs/install-sdk) (gcloud) installed and configured  
+* [QEMU](https://www.qemu.org/) installed and configured
+
+## Preparing Your Compute Engine Image for Migration
+
+Prepare your current GCP environment to ensure a smooth and efficient transition. As you assess your Compute Engine requirements, familiarize yourself with any limitations that Akamai Linode imposes on resources imported into its systems.
+
+| Important note: [Images imported into Akamai Linode](https://techdocs.akamai.com/cloud-computing/docs/upload-an-image) must be smaller than 6 GB unzipped and 5 GB zipped. Larger images will be rejected and not imported. |
+| :---- |
+
+### Assess current Compute Engine requirements
+
+Capture the current configuration of your Compute Engine VM so that you can select the appropriate [Akamai Connected Cloud plan](https://www.linode.com/pricing/#compute-shared) to ensure post-migration performance. In the GCP Console, navigate to **Compute Engine \> VM Instances**.
+
+![][image2]
+
+Note the name and zone of your running Compute Engine instance. Click on the name.
+
+![][image3]
+
+#### Machine type
+
+Navigate to the **Machine Configuration** section of the details page to see the machine type for this VM instance. In the following example, the machine type is e2-medium.
+
+![][image4]
+
+Alternatively, the machine type can be found through the gcloud. First, configure the CLI by setting the project ID. The project ID can be found by clicking on the project name in the upper left of the page, which opens a modal.
+
+![][image5]
+
+Run the following command:
+
+| $ gcloud config set project \<PROJECT ID\> Updated property \[core/project\]. |
+| :---- |
+
+To find the machine type for your instance, run this command, replacing the instance name and zone with your own:
+
+| $ gcloud compute instances \\     describe instance-20250208-003502 \\     \--zone=us-west1-a \\     \--format="value(machineType)" https://www.googleapis.com/compute/v1/projects/gcp-vm-migration-450215/zones/us-west1-a/machineTypes/e2-medium |
+| :---- |
+
+#### CPU and memory usage
+
+Use the CLI to determine the CPU and memory configurations for this Compute Engine machine type:
+
+| $ gcloud compute machine-types \\    describe e2-medium \\    \--zone=us-west1-a \\    \--format="table(name, guestCpus, memoryMb)"NAME       GUEST\_CPUS  MEMORY\_MBe2-medium  2           4096 |
+| :---- |
+
+For this guide, the example Compute Instance VM has 2 CPUs and 4GB of memory.
+
+#### Storage usage
+
+The type and size of the storage disk associated with your VM are displayed in the **Storage (Boot disk)** section of the instance details page.
+
+![][image6]
+
+#### IP addresses
+
+In the **Network Interfaces** section of the instance details, you will see the IP addresses listed in this instance:
+
+![][image7]
+
+To find the internal and external IP address of the running instance with gcloud, run the following command:
+
+| $ gcloud compute instances list \\    \--filter="name=instance-20250208-003502" \\    \--format=\\ "table(name, networkInterfaces\[0\].accessConfigs\[0\].natIP, networkInterfaces\[0\].networkIP)"NAME                      NAT\_IP           NETWORK\_IP instance-20250208-003502  104.198.111.144  10.138.0.3 |
+| :---- |
+
+####  Security groups and firewall rules
+
+Select the network name in the Network Interfaces section to see the current network resources and configurations, such as the firewall settings:
+
+![][image8]
+
+On the command line, to find all the firewall rules for a VM, run the following:
+
+| $ gcloud compute firewall-rules list \--filter="network:default"NAME                    DIRECTION  PRIORITY   ALLOW                        default-allow-icmp      INGRESS    65534      icmpdefault-allow-internal  INGRESS    65534      tcp:0-65535,udp:0-65535,icmpdefault-allow-rdp       INGRESS    65534      tcp:3389default-allow-ssh       INGRESS    65534      tcp:22 |
+| :---- |
+
+Back up your Compute Engine Disk (optional)  
+Before starting your migration, consider backing up the Compute Engine disk just in case a restoration is needed in the future. In the **Storage** section of your Compute Instance details, find the disk associated with the VM you wish to export and select it.
+
+![][image9]
+
+Click the **Create Snapshot**.
+
+![][image10]
+
+To achieve the same on the command line, run the following:
+
+| $ gcloud compute snapshots \\     create my-vm-snapshot \\     \--source-disk=instance-20250208-003502 \\     \--source-disk-zone=us-west1-a \\     \--storage-location=us-west1  Creating gce snapshot my-vm-snapshot...done. |
+| :---- |
+
+## Migrating to Akamai Linode
+
+Migrating a Google Compute Engine Image to Akamai Linode primarily involves capturing and exporting the instance image from GCP, then resizing and importing it when launching a new Linode Compute Instance. 
+
+### Export your Compute Engine VM Disk image
+
+First, export your VM to a Machine Image using the UI or the CLI. Navigate to **Compute Engine \> Images**.
+
+![][image11]
+
+Click **Create Image** at the top of the page. On the next page, specify a name for your image. Then, find the disk for your VM instance, specifying it as the source disk for the image.
+
+![][image12]
+
+Specify the remaining location and encryption options for your image. Then, click **Create**.
+
+To create an image with the CLI, run the following equivalent command:
+
+| $ gcloud compute images \\     create my-vm-image \\     \--source-disk=instance-20250208-003502 \\     \--source-disk-zone=us-west1-a \\     \--storage-location=us-west1 \\     \--project=gcp-vm-migration-450215Created \[https://www.googleapis.com/compute/v1/projects/gcp-vm-migration-450215/global/images/my-vm-image\].NAME         PROJECT                  FAMILY  DEPRECATED  STATUSmy-vm-image  gcp-vm-migration-450215                      READY |
+| :---- |
+
+You can verify the image was created with the following command, inserting the name you specified for the new image:
+
+| $ gcloud compute images list \--filter="name=my-vm-image" NAME         PROJECT                  FAMILY  DEPRECATED  STATUSmy-vm-image  gcp-vm-migration-450215                      READY |
+| :---- |
+
+Next, create a Cloud Storage bucket to store your image for downloading. Google has [restrictions on which Cloud Storage bucket locations can export images](https://cloud.google.com/build/docs/locations#restricted_regions_for_some_projects). For bucket location, make sure to choose from the list of allowable regions.
+
+| $ gcloud storage buckets create gs://\<BUCKET-NAME\> \--location=\<REGION\> |
+| :---- |
+
+Using the name of the image from above, fill in the following:
+
+| $ gcloud compute images export \\    \--destination-uri=gs://\<BUCKET\_NAME\>/\<IMAGE\_NAME\> \\    \--image=\<IMAGE\_NAME\> \\    \--export-format=\<FORMAT\> \\    \--project=\<PROJECT\_NAME\> |
+| :---- |
+
+For \--export-format, use RAW, which is compatible with importing to Linode.
+
+An example run of the export command looks like this:
+
+| $ gcloud compute images export \\    \--destination-uri=gs://migration-vm-images/my-vm-image \\    \--image=my-vm-image \\    \--export-format=RAW \\    \--project=gcp-vm-migration-450215Created \[https://cloudbuild.googleapis.com/v1/projects/gcp-vm-migration-450215/builds/b6d6fbf5-bc51-4228-9ca5-c1b988477fe4\].Logs are available at \[https://console.cloud.google.com/cloud-build/builds/b6d6fbf5-bc51-4228-9ca5-c1b988477fe4?project=133697932277\].\[image-export\]: 2025-02-08T15:39:47Z Fetching image "my-vm-image" from project "gcp-vm-migration-450215".\[image-export-ext\]: 2025-02-08T15:39:48Z Validating workflow\[image-export-ext\]: 2025-02-08T15:39:48Z Validating step "setup-disks"\[image-export-ext\]: 2025-02-08T15:39:48Z Validating step "export-disk"\[image-export-ext.export-disk\]: 2025-02-08T15:39:48Z Validating step "setup-disks"\[image-export-ext.export-disk\]: 2025-02-08T15:39:48Z Validating step "run-export-disk"...\[image-export-ext\]: 2025-02-08T15:39:50Z Uploading sources\[image-export-ext\]: 2025-02-08T15:39:50Z Running workflow\[image-export-ext\]: 2025-02-08T15:39:50Z Running step "setup-disks" (CreateDisks)...\[image-export-ext\]: 2025-02-08T15:42:30Z Step "export-disk" (IncludeWorkflow) successfully finished.\[image-export-ext\]: 2025-02-08T15:42:30Z Running step "delete-disks" (DeleteResources)\[image-export-ext.delete-disks\]: 2025-02-08T15:42:30Z DeleteResources: Deleting disk "disk-image-export-ext".\[image-export-ext\]: 2025-02-08T15:42:30Z Step "delete-disks" (DeleteResources) successfully finished.\[image-export-ext\]: 2025-02-08T15:42:30Z Serial-output value \-\> source-size-gb:10\[image-export-ext\]: 2025-02-08T15:42:30Z Serial-output value \-\> target-size-gb:10\[image-export-ext\]: 2025-02-08T15:42:30Z Workflow "image-export-ext" cleaning up (this may take up to 2 minutes).\[image-export-ext\]: 2025-02-08T15:42:30Z Workflow "image-export-ext" finished cleanup. |
+| :---- |
+
+After the job completes, verify the image exists in the bucket:
+
+| $ gcloud storage ls gs://migration-vm-images gs://migration-vm-images/my-vm-image |
+| :---- |
+
+Download the image from the command line:
+
+| $ gsutil cp gs://migration-vm-images/my-vm-image . Copying gs://migration-vm-images/my-vm-image...| \[1 files\]\[ 10.0 GiB/ 10.0 GiB\]   22.8 MiB/s                                   Operation completed over 1 objects/10.0 GiB. |
+| :---- |
+
+### Resize disk image
+
+The size of persistent disks from GCP have a minimum size of 10 GB. Therefore, your downloaded image file might be around this size.
+
+| $ du \-BM my-vm-image 10241M	my-vm-image |
+| :---- |
+
+As noted earlier, images imported into Akamai Linode must be smaller than 6 GB unzipped and 5 GB zipped. If you know that your actual disk usage within the image is within those limits, then you can shrink the size of the disk image file by deallocating unused disk space and truncating the disk size.
+
+Shrinking the disk image size involves using [GParted](https://gparted.org/), [fdisk](https://tldp.org/HOWTO/Partition/fdisk_partitioning.html), and [qemu-img](https://qemu-project.gitlab.io/qemu/tools/qemu-img.html) on your local machine.
+
+1. Because GParted works on devices (not images), create a [loopback device](https://wiki.osdev.org/Loopback_Device) for the image. Run the following commands, using the path to the newly created loopback device and the name of your image file.
+
+| \# Enable loopback $ sudo modprobe loop\# Create a loopback device, return its path$ sudo losetup \-f/dev/loop48 \# Create a device with the disk image$ sudo losetup /dev/loop48 my-vm-image \# Load the image partitions $ sudo partprobe /dev/loop48\# Backup the GUID Partition Table (GPT) $ sudo sgdisk \-b gpt-backup.bin my-vm-image |
+| :---- |
+
+2. Run GParted on the device.
+
+| $ sudo gparted /dev/loop48 |
+| :---- |
+
+![][image13]
+
+In GParted, notice how there is unused space in the file system partition. Select that partition, then select **Partition \> Resize/Move**.
+
+![][image14]
+
+Shrink down the data partition to remove most of the unused space. 
+
+![][image15]
+
+Click **Resize/Move**, and then click the green checkmark to apply this change.
+
+![][image16]
+
+Close GParted.
+
+3. Shrink the partition table to match the last used partition:
+
+| $ sudo sgdisk \--set-alternative-lba my-vm-image |
+| :---- |
+
+   
+
+4. Use [qemu-img](https://qemu-project.gitlab.io/qemu/tools/qemu-img.html) to shrink the disk image file, eliminating the unallocated space while still fitting the partitions. A quick sum of the partition sizes from looking at GParted above shows the disk image will need approximately 5.5 GB of space. Shrink the image accordingly, adding some buffer space if desired.
+
+| $ qemu-img resize \-f raw \--shrink my-vm-image 5.8G |
+| :---- |
+
+5. Recreate the partition table headers using [gdisk](https://linux.die.net/man/8/gdisk). Use the following commands:
+
+* x: Navigate to extra functionality  
+* e: Relocate the backup GPT structure to the back of the disk.  
+* w: Write the partition table to disk and exit. (Then Y to confirm.)
+
+| $ sudo gdisk my-vm-image…Command (? for help): x  Expert command (? for help): e Relocating backup data structures to the end of the disk Expert command (? for help): w  Final checks complete. About to write GPT data. THIS WILL OVERWRITE EXISTING PARTITIONS\!\! Do you want to proceed? (Y/N): Y OK; writing new GUID partition table (GPT) to gmy-vm-image. Warning: The kernel is still using the old partition table. The new table will be used at the next reboot or after you run partprobe(8) or kpartx(8) The operation has completed successfully. |
+| :---- |
+
+The resulting size of the disk image file is smaller, within the size constraints for importing into Akamai Linode.
+
+| $ du \-BM my-vm-image 5940M	my-vm-image |
+| :---- |
+
+6. Unload the loopback device to clean up.
+
+| $ sudo losetup \-d /dev/loop48 |
+| :---- |
+
+For a deeper dive into this image-shrinking technique, see “[Shrinking images on Linux](https://softwarebakery.com//shrinking-images-on-linux).”
+
+### Import and deploy VM image on Akamai Linode
+
+To provision a Linode Compute Instance by importing an existing VM image, ensure the image is in the proper format and compressed with gzip.
+
+#### Prepare image file for import
+
+You may have already named the image file above with the .raw file extension or nothing. Linode requires an image file to have a .img extension. The naming convention does not have a functional difference; simply rename the file to use the .img extension, and it will be ready for import.
+
+| $ mv my-vm-image my-vm-image.img |
+| :---- |
+
+Compress the image using gzip to reduce its size:
+
+| $ gzip my-vm-image.img$ du \-BM my-vm-image.img.gz  1060M	my-vm-image.img.gz |
+| :---- |
+
+#### Upload the compressed IMG file to Akamai Linode
+
+Use the Linode CLI to upload the compressed image file. Replace the .gz file with your specific file name. Specify the label, description, and region based on your use case.
+
+| $ linode-cli image-upload \\    \--label "gcp-vm-migration" \\    \--description "GCP VM Import" \\    \--region "us-lax" \\    ./my-vm-image.img.gz `┌-----------------------┬-----------┬----------------┐ │ label                 │ is_public │ status         │ ├-----------------------┼-----------┼----------------┤ │ gcp-vm-migration      │ False     │ pending_upload │ └-----------------------┴-----------┴----------------┘` |
+| :---- |
+
+The upload may take several minutes, depending on your image's size and internet speed.
+
+#### Verify the successful image upload
+
+After the upload, ensure the image is successfully processed and available for use. Run the following command to list your private images:
+
+| $ linode-cli images list \--is\_public false  ┌------------------┬-----------------------┬-----------┬--------┐ │ id               │ label                 │ status    │ size   │ ├------------------┼-----------------------┼-----------┼--------┤ │ private/30127625 │ gcp-vm-migration      │ available │ 5940   │ └------------------┴-----------------------┴-----------┴--------┘ |
+| :---- |
+
+Verify that the status of the image is available. If the status is pending, wait a few minutes and then check again.
+
+You can also watch the progress of the image ingestion via the Linode Images dashboard:
+
+![][image17]
+
+#### Launch a Linode Compute Instance from the uploaded image
+
+Once the image is available, you can deploy it to a new Linode Compute instance. For this command, provide the ID of your uploaded image, which was displayed when running the previous command. In addition, provide the following:
+
+* \--label: A unique label for your instance.  
+* \--region: The region for your instance.  
+* \--type: The size of the instance to deploy.  
+* \--root\_pass: A unique, secure root password for your new instance.
+
+The following example deploys a g6-standard-2 Linode with two cores, 80 GB disk, and 4 GB RAM with a 4000 Mbps transfer rate. Recall that the original GCP VM instance for this migration is a e2-medium, which has 2 CPUs and 4 GiB RAM. Therefore, the g6-standard-2 Linode instance is comparable.
+
+See the [pricing page for Akamai Connected Cloud](https://www.linode.com/pricing/#compute-shared) for details on different Linode types.
+
+| $ linode-cli linodes create \\    \--image \<image-id\> \\    \--label "migrated-from-gcp" \\    \--region "us-lax" \\    \--type "g6-standard-2" \\    \--root\_pass "thisismysecurerootpassword"  ┌-----------------------┬--------┬---------------┬--------------┐ │ label                 │ region │ type          │ status       │ ├-----------------------┼--------┼---------------┼--------------┤ │ migrated-from-gcp     │ us-lax │ g6-standard-2 │ provisioning │ └-----------------------┴--------┴---------------┴--------------┘ |
+| :---- |
+
+After several minutes, your Linode Compute Instance will be up and running based on the exported VM image from your original cloud provider.
+
+By default, Linode boots instances with its own kernel. However, you should use the kernel inside your image when booting it up. This can be done in the Linode dashboard. Navigate to your Linode Compute Instance. Click the **Configurations** tab at the bottom. Then, click **Edit**.
+
+![][image18]
+
+Under **Boot Settings**, select **Direct Disk** as the kernel.
+
+![][image19]
+
+Click **Save Changes**. Then, **reboot** your Linode.
+
+![][image20]
+
+After several minutes, your Linode Compute Instance will be up and running, based on the exported VM image from your original cloud provider.
+
+### Configure and validate the Linode instance
+
+By migrating via a disk image that fully captures your GCP VM and disk, you ensure that the operating system and all installed software and services are on the newly provisioned Linode. This reduces the time needed to configure the Linode instance to closely match the environment of the original VM.
+
+However, you must perform steps to configure networking to align with your needs. Recall the configurations from your original GCP Compute Engine VM:
+
+* [IP addresses](https://techdocs.akamai.com/cloud-computing/docs/managing-ip-addresses-on-a-compute-instance)  
+* [Firewall rules](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-cloud-firewalls)  
+* [Load balancing](https://techdocs.akamai.com/cloud-computing/docs/nodebalancer)  
+* [DNS](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-dns-manager)
+
+Linode does not have a direct equivalent to GCP security groups. However, you can still implement a firewall with rules to control traffic. Options include:
+
+* [Linode Cloud Firewall](https://techdocs.akamai.com/cloud-computing/docs/cloud-firewall), for setting up inbound and outbound rules on Linode Compute Instances, either through the Linode API or the Linode CLI.  
+* [iptables](https://www.linode.com/docs/guides/control-network-traffic-with-iptables/) or [ufw](https://www.linode.com/docs/guides/configure-firewall-with-ufw/), which run from within the Linode instance to manage the Linux kernel firewall (Netfilter).
+
+Akamai Linode provides [NodeBalancers](https://www.linode.com/products/nodebalancers/), which are equivalent to GCP’s HTTPS LoadBalancers. If you are migrating a Compute Engine VM with an HTTPS LoadBalancer, you can implement a similar configuration for your Linode.
+
+If you used Cloud DNS to implement DNS rules to route traffic to your VM, then you will need to modify your DNS settings to ensure traffic routes to your new Linode instance. This may involve pointing nameservers to Akamai Linode and creating DNS rules within the Akamai Cloud Manager.
+
+After completing your configurations, test your Linode instance to verify that the migration was successful. Validation steps may include:
+
+* **Check running services**. Ensure that all critical services, such as web servers, databases, and application processes are running as expected and configured to start on boot.  
+* **Test application functionality**. Access any applications on the new Linode through their web interface or API endpoints to confirm that they behave as expected, including core functionality and error handling.  
+* **Inspect resource utilization**. Monitor CPU, memory, and disk usage on the Linode to ensure the system performs within acceptable thresholds post-migration.  
+* **Validate DNS configuration**. Ensure DNS changes (if made) are propagating correctly, pointing to your Linode instance, and resolving to the expected IP addresses.  
+* **Check external connectivity**. Verify that the instance can access any required external resources, such as third-party APIs, databases, or storage, and that outbound requests succeed.  
+* **Review logs**. Examine system and application logs for errors or warnings that might indicate migration-related issues.  
+* **Backup and snapshot functionality**. Confirm that backups and snapshots can be created successfully on Linode to safeguard your data post migration.  
+* **Verify externally attached storage**: Ensure that any additional storage volumes, block devices, or network-attached storage are properly mounted and accessible. Check /etc/fstab entries and update disk mappings as needed.
+
+## Additional Considerations
+
+### Cost management
+
+Review the pricing for your current GCP Compute Engine VM instance ([compute](https://cloud.google.com/compute/vm-instance-pricing?hl=en), [storage](https://cloud.google.com/compute/disks-image-pricing?hl=en#tg1-t0), and [bandwidth](https://cloud.google.com/vpc/network-pricing?hl=en)). Compare this with the [pricing plans for Akamai Connected Cloud](https://www.linode.com/pricing/). Use [Akamai’s Cloud Computing Calculator](https://www.linode.com/cloud-computing-calculator/) to estimate potential costs.
+
+### Data consistency and accuracy
+
+Verify that the Linode migrated from the image export contains all necessary files, configurations, and application data. Double-check for corrupted or missing files during the image export and upload process. Verification steps may include:
+
+* **Generate and compare file checksums**: Use tools like md5sum to generate checksums of critical files or directories on both the source VM and the migrated Linode. Ensure the checksums match to confirm data integrity.  
+* **Count files and directories**: Use find or ls commands to count the number of files and directories in key locations (for example: find /path \-type f | wc \-l). Compare these counts between the source and destination to identify any discrepancies.  
+* **Check application logs and settings**: Compare configuration files, environment variables, and application logs between the source and the destination to confirm they are identical or appropriately modified for the new environment. Common locations to review may include:
+
+| Application | Configuration | Location |
+| :---- | :---- | :---- |
+| **Apache Web Server** | Main | /etc/apache2/apache2.conf |
+|  | Virtual hosts | /etc/apache2/sites-available /etc/apache2/sites-enabled |
+| **NGINX Web Server** | Main | /etc/nginx/nginx.conf |
+|  | Virtual hosts | /etc/nginx/sites-available/etc/nginx/sites-enabled |
+| **Cron** | Application | /etc/cron.d |
+|  | System-wide cron jobs | /etc/crontab |
+|  | User-specific cron jobs | /var/spool/cron/crontabs |
+| **MySQL/MariaDB** | Main | /etc/mysql |
+| **PostgreSQL** | Main | /etc/postgresql |
+| **SSH** | Main | /etc/ssh/sshd\_config |
+| **Networking** | Hostname | /etc/hostname |
+|  | Hosts file | /etc/hosts |
+| **Rsyslog** | Main | /etc/rsyslog.conf |
+
+
+* **Review symbolic links and permissions**: Use CLI tools and commands to confirm that symbolic links and file permissions on the migrated Linode match those on the source VM. Examples include:
+
+| Description | Command |
+| :---- | :---- |
+| List all symbolic links in folder (recursive) | **ls \-Rla /path/to/folder | grep "\\-\>"** |
+| Calculate md5 hash for all files in a folder, then sort by filename and write to file. Then, compare files from both VMs using diff. | **find /path/to/folder/ \-type f \\  \-exec md5sum {} \+ \\  | sort \-k 2 \> hashes.txt** |
+| Write to file the folder contents (recursive) with permissions, owner name, and group name. Then, compare permissions files from both VMs using diff. | **tree /path/to/folder \-fpuig \> permissions.txt** |
+
+
+After deploying your Linode, confirm that configurations (network settings, environment variables, and application dependencies) match the original VM to avoid runtime issues.
+
+### Security and access controls
+
+GCP IAM roles govern instance access. Migrate these roles and permissions to Linode by setting up Linode API tokens and fine-tuning user permissions.
+
+Use the Linode Cloud Firewall or existing system firewall on your instance to restrict access. Ensure SSH keys are properly configured, and disable root login if not required. Map GCP security group policy rules to your firewall for consistent protection.
+
+### Alternative migration options
+
+This guide covered migrating a VM by creating a disk image of the original GCP Compute Engine VM instance and importing that image to Akamai Linode as the basis of a new Linode Compute Instance. When cloud provider restrictions or image size limits make this approach unavailable, consider other migration options, including:
+
+* **Rclone**: For example, provision a Linode Compute Instance with resource levels comparable to your original VM. Then, use [rclone](https://rclone.org/)—a command line utility for managing files in cloud storage—to move all data from your original VM to your new Linode. This can effectively move your workloads from your GCP VM to your Linode.
+
+* **IaC**: You can also leverage infrastructure-as-code (IaC) and configuration management tools to streamline your migration process. Tools like [Ansible](https://docs.ansible.com/ansible/latest/index.html), [Terraform](https://www.terraform.io/), [Chef](https://www.chef.io/products/chef-infra), and [Puppet](https://www.puppet.com/why-puppet/use-cases/continuous-configuration-automation) can help you automatically replicate server configurations, deploy applications, and ensure consistent settings across your source and destination VMs. By using these tools, you can create repeatable migration workflows that reduce manual intervention and minimize the risk of configuration errors during the transition.
+
+* **Containerization**: Another option is to containerize any workloads on your original VM. These containerized images can be run in the Akamai Connected Cloud. For example, you can provision a [Linode Kubernetes Engine (LKE)](https://techdocs.akamai.com/cloud-computing/docs/linode-kubernetes-engine) cluster to host and run these containers, thereby removing the need for a VM.
+
+## Resources
+
+GCP
+
+* [GCP CLI Documentation](https://cloud.google.com/sdk/docs)  
+* [GCP Export Custom Image](https://cloud.google.com/compute/docs/images/export-image)  
+* [VM Migration Guide](https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1)  
+* [Regions with Build Capabilities](https://cloud.google.com/build/docs/locations#restricted_regions_for_some_projects)  
+* [Troubleshooting VM Export and Import](https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-import-export-images)
+
+Akamai Linode
+
+* [Linode CLI and Object Storage](https://techdocs.akamai.com/cloud-computing/docs/using-the-linode-cli-with-object-storage)  
+* [Uploading an image](https://techdocs.akamai.com/cloud-computing/docs/upload-an-image)  
+* [Deploying an Image](https://techdocs.akamai.com/cloud-computing/docs/deploy-an-image-to-a-new-compute-instance)
+
+Other helpful utilities
+
+* [QEMU Disk Imaging Utility](https://www.qemu.org/download/)  
+* [rclone](https://rclone.org/)  
+* [Shrinking images on Linux](https://softwarebakery.com//shrinking-images-on-linux)


### PR DESCRIPTION
This PR contains the following three VM/Disk Image migration guides:

-   Transfer VM from AWS EC2 to Akamai Using Disk Images
-   Transfer Azure Virtual Machine to Akamai Using Disk Images
-   Transfer VM from GCP Compute Engine to Akamai Using Disk Images