### PR TITLE
[Updated] Terraform Provider Version

### DIFF
--- a/docs/guides/applications/configuration-management/terraform/create-a-multicloud-infrastructure-using-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/create-a-multicloud-infrastructure-using-terraform/index.md
@@ -6,6 +6,7 @@ description: 'This guide shows you how to use Multicloud Terraform to provide a 
 authors: ["Jeff Novotny"]
 contributors: ["Jeff Novotny"]
 published: 2021-04-23
+modified: 2025-06-18
 keywords: ['Terraform','Linode','IaC','multicloud', 'automation', 'cloud manager']
 tags: ['terraform','ubuntu', 'ssh', 'security']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
@@ -69,7 +70,7 @@ This guide is written for a non-root user. Commands that require elevated privil
 
 ## Downloading Terraform on your Linode Server
 
-In this section, you install Terraform on an Ubuntu 20.04 Linode. These steps are generally applicable to most Debian-based distributions. You can use the Linode server as the hub for your Terraform-managed infrastructure, however, you can also install Terraform on your computer.
+In this section, you install Terraform on an Ubuntu 24.04 LTS Linode. These steps are generally applicable to most Debian-based distributions. You can use the Linode server as the hub for your Terraform-managed infrastructure, however, you can also install Terraform on your computer.
 
 To download Terraform on a Linode server, follow the steps below:
 
@@ -87,72 +88,68 @@ To download Terraform on a Linode server, follow the steps below:
         mkdir terraform
         cd terraform
 
-1. Download Terraform using the `wget` command or from [Terraform's download page](https://www.terraform.io/downloads.html). This guide is written for the latest Terraform version 0.15.0 (at the time of writing this guide).
+1. Download Terraform using the `wget` command or from [Terraform's download page](https://www.terraform.io/downloads.html). This guide is written for Terraform version 1.12.2 (at the time of this writing).
 
-        wget https://releases.hashicorp.com/terraform/0.15.0/terraform_0.15.0_linux_amd64.zip
+        wget https://releases.hashicorp.com/terraform/1.12.2/terraform_1.12.2_linux_amd64.zip
 
-    {{< note respectIndent=false >}}
-  Previous versions of Terraform can be found on the [Terraform releases page](https://releases.hashicorp.com/terraform/).
-  {{< /note >}}
+    {{< note >}}
+    See the [Terraform releases page](https://releases.hashicorp.com/terraform/) for release date and version information.
+    {{< /note >}}
 
-1. Download the `SHA256SUMS` file, and checksum `sig` file for the most recent version of Terraform (0.15.0 in this case).
+1. Download the `SHA256SUMS` file, and checksum `sig` file for the most recent version of Terraform (1.12.2 in this case).
 
     - The SHA256 checksum file:
 
-            wget https://releases.hashicorp.com/terraform/0.15.0/terraform_0.15.0_SHA256SUMS
+            wget https://releases.hashicorp.com/terraform/1.12.2/terraform_1.12.2_SHA256SUMS
 
     - The checksum signature file:
 
-            wget https://releases.hashicorp.com/terraform/0.15.0/terraform_0.15.0_SHA256SUMS.sig
+            wget https://releases.hashicorp.com/terraform/1.12.2/terraform_1.12.2_SHA256SUMS.sig
 
 ### Verify the Terraform Download
 
-1. Locate HashiCorp's public GPG key on their [Security page](https://www.hashicorp.com/security) under the “Secure Communications” section. The key ID is `51852D87348FFC4C`.
+1. Locate HashiCorp's public GPG key on their [Security page](https://www.hashicorp.com/security) under the “Secure Communications” section. Replace `51852D87348FFC4C` with the current public key value.
 
         gpg --recv-keys 51852D87348FFC4C
 
     The following output confirms that the `gpg` key has been successfully imported.
 
     {{< output >}}
-gpg: directory '/root/.gnupg' created
-gpg: keybox '/root/.gnupg/pubring.kbx' created
 gpg: /root/.gnupg/trustdb.gpg: trustdb created
-gpg: key 51852D87348FFC4C: public key "HashiCorp Security <security@hashicorp.com>" imported
+gpg: key 34365D9472D7468F: public key "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" imported
 gpg: Total number processed: 1
-gpg: imported: 1
+gpg:               imported: 1
 {{< /output >}}
 
 1. Use `gpg` to validate the signature file. Use the exact names of the `sig` and `SHA256` files.
 
-          gpg --verify terraform_0.15.0_SHA256SUMS.sig terraform_0.15.0_SHA256SUMS
+          gpg --verify terraform_1.12.2_SHA256SUMS.sig terraform_1.12.2_SHA256SUMS
 
     The following output confirms that the `sig` file is a good signature from HashiCorp Security.
 
     {{< output >}}
-gpg: Signature made Wed Apr 14 15:41:39 2021 UTC
-gpg: using RSA key 91A6E7F85D05C65630BEF18951852D87348FFC4C
-gpg: Good signature from "HashiCorp Security <security@hashicorp.com>" [unknown]
+gpg: Signature made Wed 11 Jun 2025 10:34:29 AM UTC
+gpg: using RSA key 374EC75B485913604A831CC7C820C6D5CD27AB87
+gpg: Good signature from "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" [unknown]
 {{< /output >}}
 
 1. Ensure the RSA key displayed in the output of the last step matches the fingerprint shown on the [Terraform Security page](https://www.hashicorp.com/security). The fingerprint is located in the same place as the GPG key in the "Secure Communications" section.
 
 1. Verify the checksum of the `zip` archive. For the following command, use the exact name of the `SHA256SUMS` file.
 
-        sha256sum -c terraform_0.15.0_SHA256SUMS 2>&1 | grep OK
+        sha256sum -c terraform_1.12.2_SHA256SUMS 2>&1 | grep OK
 
     The `sha256sum` program displays the name of the `zip` file along with the status. If the status is **NOT** `OK`, then the `zip` file is corrupt and must be downloaded again.
 
     {{< output >}}
-
-terraform_0.15.0_linux_amd64.zip: OK
-
-  {{< /output >}}
+terraform_1.12.2_linux_amd64.zip: OK
+{{< /output >}}
 
 ### Installing and Configuring Terraform on the Linode Server
 
 1. Unzip the `terraform_*_linux_amd64.zip` to your `terraform` directory.
 
-        unzip terraform_0.15.0_linux_amd64.zip
+        unzip terraform_1.12.2_linux_amd64.zip
 
     {{< note respectIndent=false >}}
   If you receive an error that indicates `unzip` is missing from your system, install the `unzip` package using the following command `sudo apt install unzip` and try again.
@@ -204,13 +201,19 @@ The following steps explain how you can construct a multicloud configuration con
 
 1. At the top of the file, add a `terraform` block to define the [Linode Provider](https://registry.terraform.io/providers/linode/linode/latest/docs), followed by the declaration of the Linode provider itself. Within the provider block, add the `token` declaration. See Linode’s guide on [Getting Started with the Linode API](/docs/products/tools/api/get-started/#get-an-access-token) to learn how to create an API token, if you have not done so already.
 
+    {{< note title ="Linode Provider Version 3.0.0" >}}
+    As of June, 2025, the Linode Terraform Provider version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
+
+    The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
+    {{< /note >}}
+
     {{< file "~/terraform/linode-terraform.tf" >}}
 
 terraform {
   required_providers {
       linode = {
         source = "linode/linode"
-        version = "1.16.0"
+        version = "3.0.0"
       }
   }
 }
@@ -227,7 +230,7 @@ provider  "linode" {
     {{< file "~/terraform/linode-terraform.tf" >}}
 
 resource  "linode_instance"  "terraform" {
-  image = "linode/ubuntu20.04"
+  image = "linode/ubuntu24.04"
   label = "Terraform-Example"
   group = "Terraform"
   region = "us-east"
@@ -247,7 +250,7 @@ terraform {
   required_providers {
   linode = {
     source = "linode/linode"
-    version = "1.16.0"
+    version = "3.0.0"
     }
   }
 }
@@ -259,7 +262,7 @@ provider  "linode" {
 }
 
 resource  "linode_instance"  "terraform" {
-  image = "linode/ubuntu20.04"
+  image = "linode/ubuntu24.04"
   label = "terraform-example"
   group = "terraform"
   region = "us-east"
@@ -390,12 +393,12 @@ This guide describes all three steps in detail.
 
     {{< output >}}
 
-* Finding linode/linode versions matching "1.16.0"...
+* Finding linode/linode versions matching "3.0.0"...
 * Finding latest version of hashicorp/aws...
-* Installing linode/linode v1.16.0...
-* Installed linode/linode v1.16.0 (signed by a HashiCorp partner, key ID F4E6BBD0EA4FE463)
-* Installing hashicorp/aws v3.34.0...
-* Installed hashicorp/aws v3.34.0 (signed by HashiCorp)
+* Installing linode/linode v3.0.0...
+* Installed linode/linode v3.0.0 (signed by a HashiCorp partner, key ID F4E6BBD0EA4FE463)
+* Installing hashicorp/aws v6.0.0...
+* Installed hashicorp/aws v6.0.0 (signed by HashiCorp)
 ...
 Terraform has been successfully initialized!
 
@@ -463,7 +466,7 @@ Terraform will perform the following actions:
   * boot_config_label  = (known after apply)
   * group              = "Terraform"
   * id                 = (known after apply)
-  * image              = "linode/ubuntu20.04"
+  * image              = "linode/ubuntu24.04"
   * ip_address         = (known after apply)
   * ipv4               = (known after apply)
   * ipv6               = (known after apply)
@@ -522,7 +525,7 @@ linode_instance.terraform-web: Creating...
   backups_enabled:    "" => "<computed>"
   boot_config_label:  "" => "<computed>"
   group:              "" => "Terraform"
-  image:              "" => "linode/ubuntu18.04"
+  image:              "" => "linode/ubuntu24.04"
   ip_address:         "" => "<computed>"
   ipv4.#:             "" => "<computed>"
   ipv6:               "" => "<computed>"
@@ -557,12 +560,12 @@ Terraform can modify a resource without affecting the other elements of your inf
 
 The following example illustrates how to simultaneously add a new Linode and change the AWS database table.
 
-1. Edit the `linode-terraform.tf` file, and add the following snippet to the end of the file. This defines a 1GB Linode running Ubuntu 20.04 as a new resource.
+1. Edit the `linode-terraform.tf` file, and add the following snippet to the end of the file. This defines a 1GB Linode running Ubuntu 24.04 as a new resource.
 
     {{< file "~/terraform/linode-terraform.tf" aconf >}}
 ...
 resource "linode_instance" "terraform2-example" {
-  image = "linode/ubuntu20.04"
+  image = "linode/ubuntu24.04"
   label = "terraform-web-example-2"
   group = "terraform"
   region = "eu-west"
@@ -649,7 +652,7 @@ Terraform will perform the following actions:
   * boot_config_label  = (known after apply)
   * group              = "Terraform"
   * id                 = (known after apply)
-  * image              = "linode/ubuntu18.04"
+  * image              = "linode/ubuntu24.04"
   * ip_address         = (known after apply)
   * ipv4               = (known after apply)
   * ipv6               = (known after apply)

--- a/docs/guides/applications/configuration-management/terraform/create-a-nodebalancer-with-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/create-a-nodebalancer-with-terraform/index.md
@@ -5,7 +5,7 @@ description: 'This guide provides you with step-by-step instructions for install
 authors: ["Linode"]
 contributors: ["Linode"]
 published: 2018-12-12
-modified: 2021-12-29
+modified: 2025-06-18
 keywords: ['terraform','nodebalancer','node','balancer','provider','linode']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 image: CreateaNodeBalancerwitTerraform.png
@@ -32,10 +32,12 @@ If you would like to stop billing for the resources created in this guide, [remo
 
 1.  You should have Terraform installed in your development environment, and have a working knowledge of Terraform resource configuration and the [Linode provider](https://www.terraform.io/docs/providers/linode/index.html). For more information on how to install and use Terraform, check out our [Use Terraform to Provision Linode Environments](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/) guide.
 
-    {{< note respectIndent=false >}}
-[Terraform’s Linode Provider](https://github.com/terraform-providers/terraform-provider-linode) has been updated and now requires Terraform version 0.12+.  To learn how to safely upgrade to Terraform version 0.12+, see [Terraform’s official documentation](https://www.terraform.io/upgrade-guides/0-12.html). View [Terraform v0.12’s changelog](https://github.com/hashicorp/terraform/blob/v0.12.0/CHANGELOG.md) for a full list of new features and version incompatibility notes.
+    {{< note title ="Linode Provider Version 3.0.0" >}}
+    As of June, 2025, the [Linode Terraform Provider](https://github.com/linode/terraform-provider-linode/) version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
 
-The examples in this guide were written to be compatible with [Terraform version 0.11](https://www.terraform.io/docs/configuration-0-11/terraform.html) and will be updated in the near future.
+    The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
+
+    The examples in this guide were originally written to be compatible with [Terraform version 0.11](https://www.terraform.io/docs/configuration-0-11/terraform.html).
     {{< /note >}}
 
 1.  Terraform requires an API access token. Follow the [Getting Started with the Linode API](/docs/products/tools/api/get-started/#get-an-access-token) guide to obtain a token.
@@ -56,7 +58,7 @@ terraform {
   required_providers {
     linode = {
       source = "linode/linode"
-      version = "1.16.0"
+      version = "3.0.0"
     }
   }
 }
@@ -156,7 +158,7 @@ resource "linode_instance" "example-instance" {
     tags = ["nodebalancer-example"]
     region = var.region
     type = "g6-nanode-1"
-    image = "linode/ubuntu18.10"
+    image = "linode/ubuntu24.04"
     authorized_keys = [chomp(file(var.ssh_key))]
     root_pass = random_string.password.result
     private_ip = true

--- a/docs/guides/applications/configuration-management/terraform/create-terraform-module/index.md
+++ b/docs/guides/applications/configuration-management/terraform/create-terraform-module/index.md
@@ -6,7 +6,7 @@ description: 'This guide shows you how to create a Terraform module with nested 
 authors: ["Linode"]
 contributors: ["Linode"]
 published: 2018-12-12
-modified: 2021-06-01
+modified: 2025-06-18
 keywords: ['terraform','resource','modules','provider']
 tags: ["terraform"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
@@ -36,8 +36,10 @@ This guide covers the creation of a Terraform module used to deploy a Linode ins
 
 1. Install Terraform on your local computer using the steps found in the **Install Terraform** section of the [Use Terraform to Provision Linode Environments](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/#install-terraform) guide. Your Terraform project directory should be named `linode_stackscripts`.
 
-    {{< note respectIndent=false >}}
-[Terraform’s Linode Provider](https://github.com/terraform-providers/terraform-provider-linode) has been updated and now requires Terraform version 0.12+.  To learn how to safely upgrade to Terraform version 0.12+, see [Terraform’s official documentation](https://www.terraform.io/upgrade-guides/0-12.html). View [Terraform v0.12’s changelog](https://github.com/hashicorp/terraform/blob/v0.12.0/CHANGELOG.md) for a full list of new features and version incompatibility notes.
+    {{< note title ="Linode Provider Version 3.0.0" >}}
+    As of June, 2025, the [Linode Terraform Provider](https://github.com/linode/terraform-provider-linode/) version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
+
+    The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
     {{< /note >}}
 
 2. Terraform requires an API access token. Follow the [Getting Started with the Linode API](/docs/products/tools/api/get-started/#get-an-access-token) guide to obtain a token.
@@ -242,7 +244,7 @@ variable "stackscript_data" {
 
     - Modules must include a description for each input variable to help document your configuration’s usage. This will make it easier for anyone else to use this module.
 
-    - Every variable can contain a default value. The default value is only used if no other value is provided. For example, if you have a favorite Linux distribution, you may want to provide it as your image variable’s default value. In this case, `linode/ubuntu18.04` is set as the default value.
+    - Every variable can contain a default value. The default value is only used if no other value is provided. For example, if you have a preferred Linux distribution, you may want to provide it as your image variable’s default value. In this case, `linode/ubuntu18.04` is set as the default value.
 
     - You can declare a `type` for each variable. If no `type` is provided, the variable will default to `type = "string"`.
 
@@ -327,7 +329,7 @@ terraform {
   required_providers {
     linode = {
       source = "linode/linode"
-      version = "1.16.0"
+      version = "3.0.0"
     }
   }
 }

--- a/docs/guides/applications/configuration-management/terraform/deploy-a-wordpress-site-using-terraform-and-linode-stackscripts/index.md
+++ b/docs/guides/applications/configuration-management/terraform/deploy-a-wordpress-site-using-terraform-and-linode-stackscripts/index.md
@@ -5,7 +5,7 @@ description: 'In this guide you will learn how to use a Community StackScript to
 authors: ["Linode"]
 contributors: ["Linode"]
 published: 2018-12-12
-modified: 2023-01-31
+modified: 2025-06-18
 keywords: ['terraform','stackscripts','wordpress','orchestration']
 tags: ["wordpress"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
@@ -28,8 +28,10 @@ Following this guide results in the creation of billable resources on your accou
 
 1. Install Terraform on your computer by following the *Install Terraform* section of our [Use Terraform to Provision Linode Environments](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/#install-terraform) guide.
 
-    {{< note >}}
-    [Terraform’s Linode Provider](https://github.com/terraform-providers/terraform-provider-linode) has been updated and now requires Terraform version 0.12+.  To learn how to safely upgrade to Terraform version 0.12+, see [Terraform’s official documentation](https://www.terraform.io/upgrade-guides/0-12.html). View [Terraform v0.12’s changelog](https://github.com/hashicorp/terraform/blob/v0.12.0/CHANGELOG.md) for a full list of new features and version incompatibility notes.
+    {{< note title ="Linode Provider Version 3.0.0" >}}
+    As of June, 2025, the [Linode Terraform Provider](https://github.com/linode/terraform-provider-linode/) version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
+
+    The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
     {{< /note >}}
 
 1. Terraform requires an API access token. Follow the [Getting Started with the Linode API](/docs/products/tools/api/get-started/#get-an-access-token) guide to obtain one.
@@ -57,7 +59,7 @@ Terraform defines the elements of your Linode infrastructure inside of configura
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "1.26.0"
+          version = "3.0.0"
         }
       }
     }
@@ -316,12 +318,12 @@ Terraform will automatically load any file named `terraform.tfvars` and use its 
     }
     ```
 
-    {{< note >}}
-    In Terraform 0.12, variables with map and object values will use the last value found and override previous values. This is different from previous versions of Terraform, which would merge map values instead of overriding them. For this reason the `stackscript_data` map and its values are defined in a single variable definitions file.
+    {{< note title="Terraform v0.12 or greater" >}}
+    Starting with Terraform 0.12, variables with map and object values will use the last value found and override previous values. This is different from previous versions of Terraform, which would merge map values instead of overriding them. For this reason the `stackscript_data` map and its values are defined in a single variable definitions file.
     {{< /note >}}
 
     {{< note >}}
-    It is helpful to reference Terraform's [Linode provider](https://www.terraform.io/docs/providers/linode/) documentation and the [Linode APIv4 documentation](/docs/api/) for assistance in determining appropriate values for Linode resources.
+    It can be helpful to reference Terraform's [Linode provider](https://www.terraform.io/docs/providers/linode/) documentation and the [Linode APIv4 documentation](/docs/api/) for assistance in determining appropriate values for Linode resources.
     {{< /note >}}
 
 1. Replace the following values in your new `.tfvars` files:

--- a/docs/guides/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/index.md
@@ -5,7 +5,7 @@ description: 'This article gives you step-by-step instructions on how to use Ter
 authors: ["Damaso Sanoja"]
 contributors: ["Damaso Sanoja"]
 published: 2017-11-06
-modified: 2024-08-26
+modified: 2025-06-18
 keywords: ["terraform", "infrastructure", "IaC"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/applications/configuration-management/terraform/how-to-build-your-infrastructure-using-terraform-and-linode/','/applications/configuration-management/how-to-build-your-infrastructure-using-terraform-and-linode/','/platform/how-to-build-your-infrastructure-using-terraform-and-linode/']
@@ -25,17 +25,19 @@ The configurations and commands used in this guide results in multiple Linodes b
 
 ## Before You Begin
 
+{{< note title ="Linode Provider Version 3.0.0" >}}
+As of June, 2025, the [Linode Terraform Provider](https://github.com/linode/terraform-provider-linode/) version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
+
+The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
+
+The examples in this guide were originally written to be compatible with [Terraform version 0.11](https://www.terraform.io/docs/configuration-0-11/terraform.html).
+{{< /note >}}
+
 -   This guide shows you how to install and use the Terraform client software from a Linux system. Terraform can be installed on other operating systems, and the instructions for those platforms are analogous to the commands presented in this guide.
 
-    {{< note >}}
-    When following this guide, your Linux user may need sudo privileges in order to install supplementary software packages.
-    {{< /note >}}
+-   When following this guide, your Linux user may need sudo privileges in order to install supplementary software packages.
 
 -   You need a personal access token for Linode's [v4 API](/docs/api/) to use with Terraform. Follow the [Getting Started with the Linode API](/docs/products/tools/api/get-started/#get-an-access-token) to get a token.
-
-    {{< note >}}
-    Any Personal Access Tokens generated from the previous Linode Manager are API v3 tokens and do not work with Terraform's Linode provider.
-    {{< /note >}}
 
 ## Install Terraform
 
@@ -122,7 +124,7 @@ Terraform uses a declarative approach in which configuration files specify the d
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "2.5.2"
+          version = "3.0.0"
         }
       }
     }
@@ -132,7 +134,7 @@ Terraform uses a declarative approach in which configuration files specify the d
     }
 
     resource "linode_instance" "terraform-web" {
-            image = "linode/ubuntu18.04"
+            image = "linode/ubuntu24.04"
             label = "Terraform-Web-Example"
             group = "Terraform"
             region = "us-east"
@@ -157,19 +159,19 @@ Terraform uses a declarative approach in which configuration files specify the d
     Terraform confirms successful initialization:
 
     ```output
+    Initializing the backend...
     Initializing provider plugins...
-    - Checking for available provider plugins on https://releases.hashicorp.com...
-    - Downloading plugin for provider "linode" (1.0.0)...
+    - Finding linode/linode versions matching "3.0.0"...
+    - Installing linode/linode v3.0.0...
+    - Installed linode/linode v3.0.0 (signed by a HashiCorp partner, key ID F4E6BBD0EA4FE463)
+    Partner and community providers are signed by their developers.
+    If you'd like to know more about provider signing, you can read about it here:
+    https://developer.hashicorp.com/terraform/cli/plugins/signing
+    Terraform has created a lock file .terraform.lock.hcl to record the provider
+    selections it made above. Include this file in your version control repository
+    so that Terraform can guarantee to make the same selections by default when
+    you run "terraform init" in the future.
 
-    The following providers do not have any version constraints in configuration,
-    so the latest version was installed.
-
-    To prevent automatic upgrades to new major versions that may contain breaking
-    changes, it is recommended to add version = "..." constraints to the
-    corresponding provider blocks in configuration, with the constraint strings
-    suggested below.
-
-    * provider.linode: version = "~> 1.0"
     Terraform has been successfully initialized!
     ```
 
@@ -210,7 +212,7 @@ Terraform uses a declarative approach in which configuration files specify the d
           backups_enabled:    <computed>
           boot_config_label:  <computed>
           group:              "Terraform"
-          image:              "linode/ubuntu18.04"
+          image:              "linode/ubuntu24.04"
           ip_address:         <computed>
           ipv4.#:             <computed>
           ipv6:               <computed>
@@ -267,7 +269,7 @@ Terraform uses a declarative approach in which configuration files specify the d
       backups_enabled:    "" => "<computed>"
       boot_config_label:  "" => "<computed>"
       group:              "" => "Terraform"
-      image:              "" => "linode/ubuntu18.04"
+      image:              "" => "linode/ubuntu24.04"
       ip_address:         "" => "<computed>"
       ipv4.#:             "" => "<computed>"
       ipv6:               "" => "<computed>"
@@ -432,7 +434,7 @@ To solve these issues, Terraform allows you to declare variables and insert thos
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "2.5.2"
+          version = "3.0.0"
         }
       }
     }
@@ -455,7 +457,7 @@ To solve these issues, Terraform allows you to declare variables and insert thos
 
     # Example Database Server
     resource "linode_instance" "terraform-db" {
-            image = "linode/ubuntu18.04"
+            image = "linode/ubuntu24.04"
             label = "Terraform-Db-Example"
             group = "Terraform"
             region = var.region
@@ -557,7 +559,7 @@ The module structure is flexible, so you can use as many Terraform files as need
     ```file {title="~/terraform/modules/app-deployment/main.tf"}
     # Web Server
     resource "linode_instance" "terraform-web" {
-            image = "linode/ubuntu18.04"
+            image = "linode/ubuntu24.04"
             label = var.webserver_label
             group = "Terraform"
             region = var.region
@@ -635,7 +637,7 @@ Create a deployment for an imaginary client:
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "2.5.2"
+          version = "3.0.0"
         }
       }
     }

--- a/docs/guides/applications/configuration-management/terraform/how-to-deploy-secure-linodes-using-cloud-firewalls-and-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-deploy-secure-linodes-using-cloud-firewalls-and-terraform/index.md
@@ -5,7 +5,7 @@ description: 'This guide will show you how to use the Terraform application to d
 authors: ["Leslie Salazar"]
 contributors: ["Leslie Salazar"]
 published: 2020-07-29
-modified: 2022-11-29
+modified: 2025-06-18
 keywords: ['terraform','infrastructure','firewalls','orchestration']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 image: feature.png
@@ -28,27 +28,21 @@ In this guide, you will create a Linode Firewalls module which declares commonly
 1. You need a Linode API personal access token to use with Terraform. This token will allow you to create, update, and destroy Linode resources. See the [Manage Personal Access Tokens](/docs/products/platform/accounts/guides/manage-api-tokens/) guide for steps to create a token.
 
     {{< note respectIndent=false >}}
-    When you create a personal access token ensure that you set **Read/Write** access permissions for Linode instances and Cloud Firewalls.
+When you create a personal access token ensure that you set **Read/Write** access permissions for Linode instances and Cloud Firewalls.
     {{< /note >}}
 
-1. [Install Terraform](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/#install-terraform) on your local computer.
-
-    {{< note respectIndent=false >}}
-This guide was written using [Terraform version 0.13.0](https://github.com/hashicorp/terraform/releases).
-    {{< /note >}}
+1. [Install Terraform](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/#install-terraform) on your local computer. This guide uses [Terraform version 1.12.2](https://github.com/hashicorp/terraform/releases).
 
 1. Install Git on your computer and complete the steps in the **Configure Git** section of the [Getting Started with Git guide](/docs/guides/how-to-configure-git/#configure-git).
 
 ## Create Your Cloud Firewalls Module
 
-The following steps will create the Cloud Firewalls module, which includes several child modules that split up the required resources between the *root module*, an `inbound_ssh` module, a `mysql` module, and a `web-server` module. The root module is the directory that holds the Terraform configuration files that are applied to build your desired infrastructure. These files provide an entry point into any child modules. Each child module uses the `linode_firewall` resource to create reusable Cloud Firewall rules for specific use cases.
+The following steps will create the Cloud Firewalls module, which includes several child modules that split up the required resources between the *root module*, an `inbound_ssh` module, a `mysql` module, and a `web-server` module.
+
+The root module is the directory that holds the Terraform configuration files that are applied to build your desired infrastructure. These files provide an entry point into any child modules. Each child module uses the `linode_firewall` resource to create reusable Cloud Firewall rules for specific use cases. You can apply up to three Cloud Firewalls per Linode instance.
 
 {{< note >}}
-You can apply up to three Cloud Firewalls per Linode instance.
-{{< /note >}}
-
-{{< note >}}
-You can view the files created throughout this tutorial in the [author's GitHub repository](https://github.com/leslitagordita/main-firewalls). You can clone the repository and use it as a foundation to create your own custom Cloud Firewalls module.
+You can view the files created throughout this tutorial in the [author's GitHub repository](https://github.com/leslitagordita/main-firewalls). You can also clone the repository and use it as a foundation to create your own custom Cloud Firewalls module.
 {{< /note >}}
 
 ### Create Your Module's Directory Structure
@@ -91,7 +85,7 @@ main_firewalls/
     ```
 
     {{< note respectIndent=false >}}
-    If you followed our [install Terraform](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/#install-terraform) steps, then your Terraform executable will be located in the `terraform` directory. If this is not the case, ensure that you can execute Terraform commands from the `main_firewalls` directory.
+If you followed the steps in our guide for [installing Terraform](/docs/guides/how-to-build-your-infrastructure-using-terraform-and-linode/#install-terraform), then your Terraform executable will be located in the `terraform` directory. If this is not the case, ensure that you can execute Terraform commands from the `main_firewalls` directory.
     {{< /note >}}
 
 ### Create the Inbound SSH Child Module
@@ -100,12 +94,18 @@ When applied to a Terraform configuration, the `inbound_ssh` module will create 
 
 1. Using your preferred text editor, create the `inbound_ssh` module's `main.tf` file. Copy and save the contents of the example below.
 
+    {{< note title ="Linode Provider Version 3.0.0" >}}
+    As of June, 2025, the Linode Terraform Provider version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
+
+    The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
+    {{< /note >}}
+
     ```file {title="~/main_firewalls/inbound_ssh/main.tf"}
     terraform {
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "1.16.0"
+          version = "3.0.0"
         }
       }
     }
@@ -162,7 +162,7 @@ The `mysql` child module creates a Cloud Firewall with an inbound rule commonly 
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "1.16.0"
+          version = "3.0.0"
         }
       }
     }
@@ -225,7 +225,7 @@ The `web_server` child module, when applied, creates a Cloud Firewall with inbou
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "1.16.0"
+          version = "3.0.0"
         }
       }
     }
@@ -303,7 +303,7 @@ Now that all the Cloud Firewalls child modules have been created, you can create
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "1.16.0"
+          version = "3.0.0"
         }
       }
     }
@@ -388,7 +388,7 @@ Now that all the Cloud Firewalls child modules have been created, you can create
 
     variable "image" {
       description = "Image to use for Linode instance."
-      default = "linode/ubuntu18.04"
+      default = "linode/ubuntu24.04"
     }
 
     variable "label" {

--- a/docs/guides/applications/configuration-management/terraform/how-to-use-terraform-with-linode-object-storage/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-use-terraform-with-linode-object-storage/index.md
@@ -6,7 +6,7 @@ description: 'This guide provides a brief introduction to Terraform, and explain
 authors: ["Jeff Novotny"]
 contributors: ["Jeff Novotny"]
 published: 2022-10-25
-modified: 2024-08-26
+modified: 2025-06-18
 keywords: ['Linode Terraform','Terraform Linode Object Storage','Install Terraform']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
@@ -89,20 +89,20 @@ These instructions are geared towards Ubuntu 22.04 users, but are generally appl
     sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
     ```
 
-1. Download the updates for Terraform and install the application. This installs Terraform release 1.3.4, the most recent release.
+1. Download the updates for Terraform and install the most recent version of the application. The version downloaded may vary based on release date. See Terraform's [Releases](https://github.com/hashicorp/terraform/releases) page for version information.
 
     ```command
     sudo apt update && sudo apt install terraform
     ```
 
     ```output
-    Get:1 https://apt.releases.hashicorp.com jammy/main amd64 terraform amd64 1.3.4 [19.5 MB]
-    Fetched 19.5 MB in 0s (210 MB/s)
+    Get:1 https://apt.releases.hashicorp.com noble/main amd64 terraform amd64 1.12.2-1 [28.4 MB]
+    Fetched 28.4 MB in 0s (187 MB/s)
     Selecting previously unselected package terraform.
-    (Reading database ... 109186 files and directories currently installed.)
-    Preparing to unpack .../terraform_1.3.4_amd64.deb ...
-    Unpacking terraform (1.3.4) ...
-    Setting up terraform (1.3.4) ...
+    (Reading database ... 124941 files and directories currently installed.)
+    Preparing to unpack .../terraform_1.12.2-1_amd64.deb ...
+    Unpacking terraform (1.12.2-1) ...
+    Setting up terraform (1.12.2-1) ...
     ```
 
 1. Confirm the application has been installed correctly. Use the `terraform` command without any parameters and ensure the Terraform help information is displayed.
@@ -124,14 +124,14 @@ These instructions are geared towards Ubuntu 22.04 users, but are generally appl
     -version      An alias for the "version" subcommand.
     ```
 
-1. To determine the current release of Terraform, use the `terraform -v` command.
+1. To see the version of Terraform installed, use the `terraform -v` command.
 
     ```command
     terraform -v
     ```
 
     ```output
-    Terraform v1.3.4
+    Terraform v1.12.2
     on linux_amd64
     ```
 
@@ -155,13 +155,19 @@ To deploy the necessary infrastructure for a Linode Object Storage solution, cre
 
 To construct the Terraform file, execute the following instructions. For more information on how to create a Terraform file, see the [Terraform documentation](https://developer.hashicorp.com/terraform/docs).
 
-1. Create the file `linode-terraform-storage.tf` inside the `terraform` directory.
+1. Using a text editor such as `nano`, create a Terraform configuration file named `linode-terraform-storage.tf` inside the `terraform` directory.
 
     ```command
     nano linode-terraform-storage.tf
     ```
 
-1. At the top of the file, add a `terraform` section, including all `required_providers` for the infrastructure. In this case, the only required provider is `linode`. Set the source to `linode/linode`. Use the current `version` of the `linode` provider. At publication time, the version is `1.29.4`. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
+1. At the top of the file, add a `terraform` section, including all `required_providers` for the infrastructure. In this case, the only required provider is `linode`. Set the source to `linode/linode`. Use the current `version` of the `linode` provider.
+
+    As of June, 2025, the Linode Terraform Provider version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
+
+    {{< note title ="Linode Provider Version 3.0.0" >}}
+    The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
+    {{< /note >}}
 
     ```file {title="/terraform/linode-terraform-storage.tf" lang="aconf"}
 
@@ -169,7 +175,7 @@ To construct the Terraform file, execute the following instructions. For more in
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "1.29.4"
+          version = "3.0.0"
         }
       }
     }
@@ -265,7 +271,7 @@ The Linode Object Storage Bucket resource contains many other configurable attri
       required_providers {
         linode = {
           source = "linode/linode"
-          version = "1.29.4"
+          version = "3.0.0"
         }
       }
     }
@@ -330,9 +336,9 @@ Terraform commands act upon the `linode-terraform-storage.tf` file to analyze th
     Initializing the backend...
 
     Initializing provider plugins...
-    - Finding linode/linode versions matching "1.29.4"...
-    - Installing linode/linode v1.29.4...
-    - Installed linode/linode v1.29.4 (signed by a HashiCorp partner, key ID F4E6BBD0EA4FE463)
+    - Finding linode/linode versions matching "3.0.0"...
+    - Installing linode/linode v3.0.0...
+    - Installed linode/linode v3.0.0 (signed by a HashiCorp partner, key ID F4E6BBD0EA4FE463)
     ...
     Terraform has been successfully initialized!
     ...

--- a/docs/guides/applications/configuration-management/terraform/import-existing-infrastructure-to-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/import-existing-infrastructure-to-terraform/index.md
@@ -5,7 +5,7 @@ description: 'This guide will describe how to import existing Linode infrastruct
 authors: ["Linode"]
 contributors: ["Linode"]
 published: 2018-12-17
-modified: 2020-12-03
+modified: 2025-06-18
 keywords: ['terraform','configuration management','import']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 image: ImportExistingInfrastructuretoTerraform.png
@@ -18,8 +18,10 @@ tags: ["saas"]
 
 Terraform is an orchestration tool that uses declarative code to build, change, and version infrastructure that is made up of server instances and services. You can use [Linode's official Terraform provider](https://www.terraform.io/docs/providers/linode/index.html) to interact with Linode services. Existing Linode infrastructure can be imported and brought under Terraform management. This guide describes how to import existing Linode infrastructure into Terraform using the official Linode provider plugin.
 
-{{< note >}}
-[Terraform’s Linode Provider](https://github.com/terraform-providers/terraform-provider-linode) has been updated and now requires Terraform version 0.12+. To learn how to safely upgrade to Terraform version 0.12+, see [Terraform’s official documentation](https://www.terraform.io/upgrade-guides/0-12.html). View [Terraform v0.12’s changelog](https://github.com/hashicorp/terraform/blob/v0.12.0/CHANGELOG.md) for a full list of new features and version incompatibility notes.
+{{< note title ="Linode Provider Version 3.0.0" >}}
+As of June, 2025, the [Linode Terraform Provider](https://github.com/linode/terraform-provider-linode/) version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
+
+The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
 {{< /note >}}
 
 ## Before You Begin

--- a/docs/guides/applications/configuration-management/terraform/secrets-management-with-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/secrets-management-with-terraform/index.md
@@ -6,7 +6,7 @@ description: 'Learn everything you need to know about secrets management with Te
 authors: ["Linode"]
 contributors: ["Linode"]
 published: 2018-12-12
-modified: 2021-08-13
+modified: 2025-06-18
 keywords: ['terraform','secrets','secrets management','backend','hcl']
 tags: ["security"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
@@ -23,10 +23,12 @@ tags: ["saas"]
 
 Terraform is an Infrastructure as Code (IaC) tool that allows you to write declarative code to manage your infrastructure. In order to implement IaC with Terraform it is necessary to supply secrets, such as server passwords and API tokens, in the code. This guide discusses methods for securing those secrets within Terraform.
 
-{{< note >}}
-[Terraform’s Linode Provider](https://github.com/terraform-providers/terraform-provider-linode) has been updated and now requires Terraform version 0.12 or later. To learn how to safely upgrade to Terraform version 0.12 or later, see [Terraform’s official documentation](https://www.terraform.io/upgrade-guides/0-12.html). View [Terraform v0.12’s changelog](https://github.com/hashicorp/terraform/blob/v0.12.0/CHANGELOG.md) for a full list of new features and version incompatibility notes.
+{{< note title ="Linode Provider Version 3.0.0" >}}
+As of June, 2025, the [Linode Terraform Provider](https://github.com/linode/terraform-provider-linode/) version is 3.0.0. To determine the current version, see the [Linode Namespace](https://registry.terraform.io/namespaces/linode) in the Terraform Registry.
 
-The examples in this guide were written to be compatible with [Terraform version 0.11](https://www.terraform.io/docs/configuration-0-11/terraform.html).
+The Linode Terraform Provider version 3.0.0 requires `terraform` version 1.0 or greater. See [Terraform's developer documentation](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) for guidance on upgrading to version 1.0.
+
+The examples in this guide were originally written to be compatible with [Terraform version 0.11](https://www.terraform.io/docs/configuration-0-11/terraform.html).
 {{< /note >}}
 
 ## Keeping Secrets Out of .tf Files


### PR DESCRIPTION
Updated multiple guides for newest Linode Terraform Provider and Terraform versions:
- Use Terraform With Linode Object Storage
- Creating a Multicloud Infrastructure Using Terraform
- Deploy Secure Linodes using Cloud Firewalls and Terraform
- Import Existing Infrastructure to Terraform
- Create a Terraform Module
- Managing Secrets with Terraform
- Deploy a WordPress Site Using Terraform and Linode StackScripts
- Create a NodeBalancer with Terraform
- Use Terraform to Provision Infrastructure on Linode
