### PR TITLE
[Update] Kali Linux Marketplace OCA Documentation

### DIFF
--- a/docs/marketplace-docs/guides/kali-linux/index.md
+++ b/docs/marketplace-docs/guides/kali-linux/index.md
@@ -5,6 +5,10 @@ published: 2022-07-05
 modified: 2025-08-22
 keywords: ['kali','security','pentest']
 tags: ["marketplace", "linode platform", "cloud manager"]
+external_resources:
+- '[What is Kali Linux?](https://www.kali.org/docs/introduction/what-is-kali-linux/)'
+- '[Should I Use Kali Linux?](https://www.kali.org/docs/introduction/should-i-use-kali-linux/)'
+- '[Kali Linux official documentation](https://www.kali.org/docs/)'
 aliases: ['/products/tools/marketplace/guides/kali-linux/','/products/tools/marketplace/guides/kalilinux/']
 authors: ["Akamai"]
 contributors: ["Akamai"]
@@ -13,10 +17,7 @@ marketplace_app_id: 1017300
 marketplace_app_name: "Kali Linux"
 ---
 
-[Kali Linux](https://www.kali.org/) is a specialized Debian-based Linux distribution that has become an industry-standard tool for penetration testing. Kali Linux includes hundreds of free tools for reverse engineering, penetration testing, computer forensics, security audits, and more. It is open source and prioritizes simplicity. To learn more about Kali Linux and determine if its a viable solution for your workloads, see the following resources from its official documentation site:
-
-- [What is Kali Linux?](https://www.kali.org/docs/introduction/what-is-kali-linux/)
-- [Should I Use Kali Linux?](https://www.kali.org/docs/introduction/should-i-use-kali-linux/)
+[Kali Linux](https://www.kali.org/) is a specialized Debian-based Linux distribution that has become an industry-standard tool for penetration testing. Kali Linux includes hundreds of free tools for reverse engineering, penetration testing, computer forensics, security audits, and more. It is open source and prioritizes simplicity.
 
 {{< note >}}
 This Marketplace App extends Linode's Kali Linux distribution image by allowing the user to preinstall one of the available metapackages.
@@ -29,7 +30,7 @@ This Marketplace App extends Linode's Kali Linux distribution image by allowing 
 {{% content "marketplace-verify-standard-shortguide" %}}
 
 {{< note >}}
-**Estimated deployment time:** Kali Linux should be fully installed within 5-10 minutes (Core), 15-20 minutes (Default), and 45-60 minutes (Everything) after the Compute Instance has finished provisioning. VNC installation adds approximately 5-10 additional minutes.
+**Estimated deployment time:** Kali Linux should be fully installed within 5-10 minutes (Core), 15-20 minutes (Default), and 45-60 minutes (Everything) after the Compute Instance has finished provisioning. VNC installation takes approximately 5-10 additional minutes.
 {{< /note >}}
 
 ## Configuration Options
@@ -40,15 +41,15 @@ This Marketplace App extends Linode's Kali Linux distribution image by allowing 
 ### Kali Options
 
 - **Kali Linux Package** *(required)*: Select the Kali Linux metapackage to install:
-  - **Core**: Installs the [kali-linux-core](https://www.kali.org/tools/kali-meta/#kali-linux-core) metapackage, which includes essential penetration testing tools
-  - **Default**: Installs the [kali-linux-default](https://www.kali.org/tools/kali-meta/#kali-linux-default) metapackage, which includes commonly used tools and utilities
-  - **Everything**: Installs the [kali-linux-everything](https://www.kali.org/tools/kali-meta/#kali-linux-everything) metapackage, which includes all available Kali packages
+  - **Core**. Installs the [kali-linux-core](https://www.kali.org/tools/kali-meta/#kali-linux-core) metapackage, which includes essential penetration testing tools.
+  - **Default**. Installs the [kali-linux-default](https://www.kali.org/tools/kali-meta/#kali-linux-default) metapackage, which includes commonly used tools and utilities.
+  - **Everything**. Installs the [kali-linux-everything](https://www.kali.org/tools/kali-meta/#kali-linux-everything) metapackage, which includes all available Kali packages.
 
-- **Setup VNC Remote Desktop?** *(required)*: Choose whether to install and configure [TigerVNC](https://tigervnc.org/) with [XFCE Desktop](https://www.xfce.org/) for remote desktop access. This is recommended for the Everything package and adds desktop functionality to Default/Core packages.
+- **Setup VNC Remote Desktop?** *(required)*. Choose whether to install and configure [TigerVNC](https://tigervnc.org/) with [XFCE Desktop](https://www.xfce.org/) for remote desktop access. This is recommended for the *Everything* package and adds desktop functionality to the Default and Core packages.
 
 {{% content "marketplace-required-limited-user-fields-shortguide" %}}
 
-- **VNC Username** *(conditional)*: Required only if VNC is enabled. The VNC username you wish to create for this Compute Instance. This user will have elevated privileges (`sudo`) and can access the VNC session.
+- **VNC Username** *(Required only if VNC is enabled)*. It's the VNC username for this Compute Instance. This username has elevated privileges (`sudo`) and can access the VNC session.
 
 {{% content "marketplace-custom-domain-fields-shortguide" %}}
 
@@ -56,30 +57,36 @@ This Marketplace App extends Linode's Kali Linux distribution image by allowing 
 
 ## Getting Started after Deployment
 
-After Kali Linux has been fully deployed, you can log in through an SSH session as the `root` user and perform your workloads as needed. Your deployment credentials are stored in `/home/[username]/.credentials` for reference. See the [Kali Linux documentation](https://www.kali.org/docs/) to learn how to further use your instance.
+After Kali Linux is deployed, you can log in through an SSH session as the `root` user and perform your workloads as needed. Your deployment credentials are stored in `/home/[username]/.credentials` for reference. To learn more, See the [Kali Linux documentation](https://www.kali.org/docs/) to learn how to further use your instance.
 
 ### Remote Desktop Connection with VNC
 
-If you enabled VNC during deployment, [TigerVNC](https://tigervnc.org/) and the XFCE desktop environment are installed. This allows you to connect remotely to the desktop environment and access Kali's GUI tools. Perform the steps below to access your Kali Linux desktop through a VNC client. While there are many options for OS X and Windows, this guide will use [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/).
+If you enabled VNC during deployment, [TigerVNC](https://tigervnc.org/) and the XFCE desktop environment are installed. This allows you to connect remotely to the desktop environment and access Kali's GUI tools.
 
-1. From your desktop, create an SSH tunnel to your Compute Instance with the following command. Be sure to replace *[username]* with the VNC username you created and *[ip]* with the IPv4 address of your Compute Instance. See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) guide for information on viewing IP addresses.
+To access your Kali Linux desktop through a VNC client:
+
+{{< note >}}
+There are many options for OS X and Windows, but this guide uses [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/).
+{{< /note >}}
+
+1. From your desktop, create an SSH tunnel to your Compute Instance with the command below replacing `[username]` with the VNC username you created and `[ip]` with the IPv4 address of your Compute Instance. To learn more on viewing IP addresses, see [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/).
 
     ```output
     ssh -L 61000:localhost:5901 -N -l [username] [ip]
     ```
 
-2. Open your preferred VNC viewer application and connect to your Compute Instance through the SSH tunnel you created. The format is `localhost:61000`
+2. Open your preferred VNC viewer application and connect to your Compute Instance through the SSH tunnel you created. The format is `localhost:61000`.
 
     ![Screenshot of RealVNC connection detail](realvnc-connection.jpg)
 
-3. A warning may appear notifying you that the connection is unencrypted. Since you are using an SSH tunnel, your connection is encrypted over the internet. You can safely ignore this warning and continue.
+    A warning may appear notifying you that the connection is unencrypted. Since you're using an SSH tunnel, your connection is encrypted over the internet. You can safely ignore this warning and continue.
 
     ![Screenshot of RealVNC unencrypted connection warning](realvnc-warning.jpg)
 
-4. You are then prompted to enter the password you created for the VNC user.
+4. Enter the password you created for the VNC user.
 
     ![Screenshot of RealVNC password prompt](realvnc-password.jpg)
 
-After connecting, the Kali Linux desktop should appear.
+After connecting, the Kali Linux desktop appears.
 
 {{% content "marketplace-update-note-shortguide" %}}

--- a/docs/marketplace-docs/guides/kali-linux/index.md
+++ b/docs/marketplace-docs/guides/kali-linux/index.md
@@ -2,6 +2,7 @@
 title: "Deploy Kali Linux through the Linode Marketplace"
 description: "Deploy Kali Linux, a popular Linux distribution for penetration testing and security research, on a Linode Compute Instance."
 published: 2022-07-05
+modified: 2025-08-22
 keywords: ['kali','security','pentest']
 tags: ["marketplace", "linode platform", "cloud manager"]
 aliases: ['/products/tools/marketplace/guides/kali-linux/','/products/tools/marketplace/guides/kalilinux/']
@@ -28,7 +29,7 @@ This Marketplace App extends Linode's Kali Linux distribution image by allowing 
 {{% content "marketplace-verify-standard-shortguide" %}}
 
 {{< note >}}
-**Estimated deployment time:** Kali Linux should be fully installed within 45-60 minutes after the Compute Instance has finished provisioning.
+**Estimated deployment time:** Kali Linux should be fully installed within 5-10 minutes (Core), 15-20 minutes (Default), and 45-60 minutes (Everything) after the Compute Instance has finished provisioning. VNC installation adds approximately 5-10 additional minutes.
 {{< /note >}}
 
 ## Configuration Options
@@ -38,16 +39,16 @@ This Marketplace App extends Linode's Kali Linux distribution image by allowing 
 
 ### Kali Options
 
-- **Kali Headless Package** *(required)*: This installs the [kali-linux-headless](https://www.kali.org/tools/kali-meta/#kali-linux-headless) metapackage, which includes all non-GUI packages.
-- **Kali Everything Package** *(required)*: This installs the [kali-linux-everything](https://www.kali.org/tools/kali-meta/#kali-linux-everything) metapackage, which includes all available Kali packages.
+- **Kali Linux Package** *(required)*: Select the Kali Linux metapackage to install:
+  - **Core**: Installs the [kali-linux-core](https://www.kali.org/tools/kali-meta/#kali-linux-core) metapackage, which includes essential penetration testing tools
+  - **Default**: Installs the [kali-linux-default](https://www.kali.org/tools/kali-meta/#kali-linux-default) metapackage, which includes commonly used tools and utilities
+  - **Everything**: Installs the [kali-linux-everything](https://www.kali.org/tools/kali-meta/#kali-linux-everything) metapackage, which includes all available Kali packages
 
-    {{< note >}}
-    If both packages are selected, only the [kali-linux-everything](https://www.kali.org/tools/kali-meta/#kali-linux-everything) package is installed (which includes everything in [kali-linux-headless](https://www.kali.org/tools/kali-meta/#kali-linux-headless)).
-    {{< /note >}}
+- **Setup VNC Remote Desktop?** *(required)*: Choose whether to install and configure [TigerVNC](https://tigervnc.org/) with [XFCE Desktop](https://www.xfce.org/) for remote desktop access. This is recommended for the Everything package and adds desktop functionality to Default/Core packages.
 
-- **VNC Installation** *(required)*: This option installs and starts [TigerVNC](https://tigervnc.org/) and [XFCE Desktop package](https://www.xfce.org/).
-- **Sudo/VNC Username** *(required)*: The VNC username you wish to create for this Compute Instance. This is used for your VNC session and will have elevated privileges (`sudo`).
-- **Sudo/VNC User Password** *(required)*: The password you wish to use for your VNC user.
+{{% content "marketplace-required-limited-user-fields-shortguide" %}}
+
+- **VNC Username** *(conditional)*: Required only if VNC is enabled. The VNC username you wish to create for this Compute Instance. This user will have elevated privileges (`sudo`) and can access the VNC session.
 
 {{% content "marketplace-custom-domain-fields-shortguide" %}}
 
@@ -55,11 +56,11 @@ This Marketplace App extends Linode's Kali Linux distribution image by allowing 
 
 ## Getting Started after Deployment
 
-After Kali Linux has been fully deployed, you can log in through an SSH session as the `root` user and perform your workloads as needed. See the [Kali Linux documentation](https://www.kali.org/docs/) to learn how to further use your instance.
+After Kali Linux has been fully deployed, you can log in through an SSH session as the `root` user and perform your workloads as needed. Your deployment credentials are stored in `/home/[username]/.credentials` for reference. See the [Kali Linux documentation](https://www.kali.org/docs/) to learn how to further use your instance.
 
 ### Remote Desktop Connection with VNC
 
-If you selected the VNC installation option, [TigerVNC](https://tigervnc.org/) is installed. This lets you connect remotely to the desktop environment and access Kali's GUI tools. Perform the steps below to access your Kali Linux desktop through a VNC client. While there are many options for OS X and Windows, this guide will use [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/).
+If you enabled VNC during deployment, [TigerVNC](https://tigervnc.org/) and the XFCE desktop environment are installed. This allows you to connect remotely to the desktop environment and access Kali's GUI tools. Perform the steps below to access your Kali Linux desktop through a VNC client. While there are many options for OS X and Windows, this guide will use [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/).
 
 1. From your desktop, create an SSH tunnel to your Compute Instance with the following command. Be sure to replace *[username]* with the VNC username you created and *[ip]* with the IPv4 address of your Compute Instance. See the [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/) guide for information on viewing IP addresses.
 

--- a/docs/marketplace-docs/guides/kali-linux/index.md
+++ b/docs/marketplace-docs/guides/kali-linux/index.md
@@ -49,7 +49,7 @@ This Marketplace App extends Linode's Kali Linux distribution image by allowing 
 
 {{% content "marketplace-required-limited-user-fields-shortguide" %}}
 
-- **VNC Username** *(Required only if VNC is enabled)*. It's the VNC username for this Compute Instance. This username has elevated privileges (`sudo`) and can access the VNC session.
+- **VNC Username:** *(Required only if VNC is enabled)*. It's the VNC username for this Compute Instance. This username has elevated privileges (`sudo`) and can access the VNC session.
 
 {{% content "marketplace-custom-domain-fields-shortguide" %}}
 
@@ -57,7 +57,7 @@ This Marketplace App extends Linode's Kali Linux distribution image by allowing 
 
 ## Getting Started after Deployment
 
-After Kali Linux is deployed, you can log in through an SSH session as the `root` user and perform your workloads as needed. Your deployment credentials are stored in `/home/[username]/.credentials` for reference. To learn more, See the [Kali Linux documentation](https://www.kali.org/docs/) to learn how to further use your instance.
+After Kali Linux is deployed, you can log in through an SSH session as the `root` user and perform your workloads as needed. Your deployment credentials are stored in `/home/{{< placeholder "USERNAME" >}}/.credentials` for reference. To learn more, See the [Kali Linux documentation](https://www.kali.org/docs/) to learn how to further use your instance.
 
 ### Remote Desktop Connection with VNC
 
@@ -66,13 +66,13 @@ If you enabled VNC during deployment, [TigerVNC](https://tigervnc.org/) and the 
 To access your Kali Linux desktop through a VNC client:
 
 {{< note >}}
-There are many options for OS X and Windows, but this guide uses [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/).
+There are many options for macOS and Windows, but this guide uses [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/).
 {{< /note >}}
 
-1. From your desktop, create an SSH tunnel to your Compute Instance with the command below replacing `[username]` with the VNC username you created and `[ip]` with the IPv4 address of your Compute Instance. To learn more on viewing IP addresses, see [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/).
+1. From your desktop, create an SSH tunnel to your Compute Instance with the command below replacing `{{< placeholder "USERNAME" >}}` with the VNC username you created and `[ip]` with the IPv4 address of your Compute Instance. To learn more on viewing IP addresses, see [Managing IP Addresses](/docs/products/compute/compute-instances/guides/manage-ip-addresses/).
 
     ```output
-    ssh -L 61000:localhost:5901 -N -l [username] [ip]
+    ssh -L 61000:localhost:5901 -N -l {{< placeholder "USERNAME" >}} [ip]
     ```
 
 2. Open your preferred VNC viewer application and connect to your Compute Instance through the SSH tunnel you created. The format is `localhost:61000`.


### PR DESCRIPTION
* Updates instructions to include the three different Kali packages that can be installed with this updated Marketplace app: Core, Default, and Everything.
* Updates VNC section to reflect app update - VNC is now optional

The new app has already been merged to to the main branch of the akamai-compute-marketplace repo, so this PR can be merged whenever is convenient for your team. 

I also tested it with `hugo server`