### PR TITLE
Fix duplicate YAML keys in front matter

### DIFF
--- a/docs/guides/applications/big-data/deep-learning-frameworks-overview/index.md
+++ b/docs/guides/applications/big-data/deep-learning-frameworks-overview/index.md
@@ -9,7 +9,6 @@ published: 2021-08-27
 keywords: ['deep learning frameworks']
 tags: ['python']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-tags: ["saas"]
 ---
 
 ## What is Deep Learning?

--- a/docs/guides/applications/configuration-management/ansible/deploy-linodes-using-ansible/index.md
+++ b/docs/guides/applications/configuration-management/ansible/deploy-linodes-using-ansible/index.md
@@ -14,7 +14,6 @@ external_resources:
 aliases: ['/applications/configuration-management/ansible/deploy-linodes-using-ansible/','/applications/configuration-management/deploy-linodes-using-ansible/']
 tags: ["automation"]
 image: how-to-use-the-linode-ansible-module-to-deploy-linodes.png
-tags: ["saas"]
 deprecated: true
 deprecated_link: 'guides/deploy-linodes-using-linode-ansible-collection/'
 ---

--- a/docs/guides/applications/configuration-management/ansible/secrets-management-with-ansible/index.md
+++ b/docs/guides/applications/configuration-management/ansible/secrets-management-with-ansible/index.md
@@ -10,7 +10,6 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[Red Hat - Enable Sysadmin: Handling Secrets in Your Ansible Playbooks](https://www.redhat.com/sysadmin/ansible-playbooks-secrets)'
 - '[Ansible Documentation: Protecting Sensitive Data with Ansible Vault](https://docs.ansible.com/ansible/latest/vault_guide/index.html)'
-tags: ["saas"]
 ---
 
 Ansible stands out for its capabilities in automating server provisioning and management. Ansible's playbooks, its ability to group and organize resources, and numerous other features make it a great asset for administering servers.

--- a/docs/guides/applications/configuration-management/basics/gitops-principles-and-workflow/index.md
+++ b/docs/guides/applications/configuration-management/basics/gitops-principles-and-workflow/index.md
@@ -9,7 +9,6 @@ published: 2021-12-17
 keywords: ['gitops vs devops', 'gitops and kubernetes', 'gitops workflow']
 tags: ['kubernetes', 'container', 'monitoring']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-tags: ["saas"]
 ---
 
 If you're a developer, chances are you know what [Git](/docs/guides/a-beginners-guide-to-github/) is. However, you may not be as familiar with *GitOps*. This guide gives you an understanding of GitOps, compares GitOps to DevOps, describes the GitOps workflow, and the tools often used with this methodology.

--- a/docs/guides/applications/configuration-management/basics/what-is-infrastructure-as-a-service/index.md
+++ b/docs/guides/applications/configuration-management/basics/what-is-infrastructure-as-a-service/index.md
@@ -14,7 +14,6 @@ external_resources:
 - '[Open Stack](https://www.openstack.org/)'
 - '[Apache CloudStack](https://cloudstack.apache.org/)'
 - '[Docker](https://www.docker.com/)'
-tags: ["saas"]
 ---
 
 *Infrastructure as a Service* (IaaS) is a cloud computing service that provides virtual infrastructure to customers on demand. However, customers still manage and operate their own resources. This model frees users from having to operate and maintain their own costly equipment. Some of the infrastructure components offered by IaaS providers include servers, data storage, and networking capabilities. This guide describes IaaS and explains its advantages and rationale, and outlines how to use it.

--- a/docs/guides/applications/configuration-management/chef/how-to-install-chef-on-ubuntu-20-04/index.md
+++ b/docs/guides/applications/configuration-management/chef/how-to-install-chef-on-ubuntu-20-04/index.md
@@ -21,7 +21,6 @@ external_resources:
 - '[Chef Supermarket](https://supermarket.chef.io/)'
 - '[Chef Supermarket documentation](https://docs.chef.io/workstation/knife_supermarket/)'
 - '[Chef bootstrap documentation](https://docs.chef.io/install_bootstrap/)'
-tags: ["saas"]
 ---
 
 [Chef](https://www.chef.io/) is a free and open source *Infrastructure as Code* (IaC) application. It's a configuration management system that allows administrators to provision and manage infrastructure using automation. A complete Chef workflow includes one or more Chef Workstations, a Chef Server, and a set of nodes. This guide provides some background on how Chef works, and explains how to install and configure Chef on Ubuntu 20.04.

--- a/docs/guides/applications/configuration-management/packer/deploy-packer-image-with-terraform/index.md
+++ b/docs/guides/applications/configuration-management/packer/deploy-packer-image-with-terraform/index.md
@@ -12,7 +12,6 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[Terraform - HashiCorp Learn: Provision Infrastructure with Packer](https://learn.hashicorp.com/tutorials/terraform/packer)'
 - '[Packer - Use Cases: Integrate with Terraform](https://www.packer.io/use-cases/integrate-with-terraform)'
-tags: ["saas"]
 ---
 
 Both the Packer and Terraform tools by HashiCorp stand out for remarkable infrastructure-automating. Despite some overlap, the tools have distinct and complimentary features. This makes them an effective pair, with Packer used to create images that Terraform then deploys as a complete infrastructure.

--- a/docs/guides/applications/configuration-management/terraform/beginners-guide-to-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/beginners-guide-to-terraform/index.md
@@ -12,7 +12,6 @@ image: ABeginnersGuidetoTerraform.png
 external_resources:
 - '[Terraform Documentation](https://www.terraform.io/docs/index.html)'
 aliases: ['/applications/configuration-management/terraform/beginners-guide-to-terraform/','/applications/configuration-management/beginners-guide-to-terraform/']
-tags: ["saas"]
 ---
 
 [Terraform](https://www.terraform.io) by HashiCorp is an orchestration tool that allows you to represent your Linode instances and other resources with declarative code inside configuration files, instead of manually creating those resources via the Linode Manager or API. This practice is referred to as *Infrastructure as Code*, and Terraform is a popular example of this methodology. The basic workflow when using Terraform is:

--- a/docs/guides/applications/configuration-management/terraform/create-a-multicloud-infrastructure-using-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/create-a-multicloud-infrastructure-using-terraform/index.md
@@ -23,7 +23,6 @@ external_resources:
 - '[DynamoDB service](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/SettingUp.DynamoWebService.html)'
 - '[AWS Provider in the Terraform Registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)'
 - '[Build, update, or destroy AWS infrastructure with Terraform](https://learn.hashicorp.com/collections/terraform/aws-get-started)'
-tags: ["saas"]
 ---
 
 [*Terraform*](https://www.terraform.io/) is an open-source tool that is built by [*HashiCorp*](https://www.hashicorp.com). Using the *HashiCorp Configuration Language* (HCL), you can automate deploying your infrastructure, and provisioning its resources.

--- a/docs/guides/applications/configuration-management/terraform/how-to-deploy-secure-linodes-using-cloud-firewalls-and-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-deploy-secure-linodes-using-cloud-firewalls-and-terraform/index.md
@@ -12,7 +12,6 @@ image: feature.png
 external_resources:
 - '[Terraform Linode Provider Official Documentation](https://registry.terraform.io/providers/linode/linode/latest/docs)'
 aliases: ['/applications/configuration-management/terraform/how-to-deploy-secure-linodes-using-cloud-firewalls-and-terraform/']
-tags: ["saas"]
 ---
 
 Terraform modules allow you to better organize your configuration code and to distribute and reuse it. You can host your Terraform modules on remote version control services, like GitHub, for others to use. The Terraform Module Registry hosts community modules that you can reuse for your own Terraform configurations, or you can publish your own modules for consumption by the Terraform community.

--- a/docs/guides/applications/configuration-management/terraform/how-to-use-terraform-with-linode-object-storage/index.md
+++ b/docs/guides/applications/configuration-management/terraform/how-to-use-terraform-with-linode-object-storage/index.md
@@ -22,7 +22,6 @@ external_resources:
 - '[Linode Object Storage Cluster data source](https://registry.terraform.io/providers/linode/linode/latest/docs/data-sources/object_storage_cluster)'
 - '[Linode Object Storage Bucket documentation](https://registry.terraform.io/providers/linode/linode/latest/docs/resources/object_storage_bucket)'
 - '[Linode Object Storage Objects documentation](https://registry.terraform.io/providers/linode/linode/latest/docs/resources/object_storage_object)'
-tags: ["saas"]
 ---
 
 [Terraform](https://www.terraform.io/) is a powerful *Infrastructure as Code* (IaC) application for deploying and managing infrastructure. It can be used to add, modify, and delete resources including servers, networking elements, and storage objects. Linode has partnered with Terraform to provide an API to configure common Linode infrastructure items. This guide provides a brief introduction to Terraform and explains how to use it to create [Linode Object Storage](/docs/products/storage/object-storage/) solutions.

--- a/docs/guides/applications/configuration-management/terraform/import-existing-infrastructure-to-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/import-existing-infrastructure-to-terraform/index.md
@@ -13,7 +13,6 @@ external_resources:
 - '[Terraform Import Usage](https://www.terraform.io/docs/import/usage.html)'
 - '[Terraform Linode Instance Documentation](https://www.terraform.io/docs/providers/linode/r/instance.html)'
 aliases: ['/applications/configuration-management/import-existing-infrastructure-to-terraform/','/applications/configuration-management/terraform/import-existing-infrastructure-to-terraform/']
-tags: ["saas"]
 ---
 
 Terraform is an orchestration tool that uses declarative code to build, change, and version infrastructure that is made up of server instances and services. You can use [Linode's official Terraform provider](https://www.terraform.io/docs/providers/linode/index.html) to interact with Linode services. Existing Linode infrastructure can be imported and brought under Terraform management. This guide describes how to import existing Linode infrastructure into Terraform using the official Linode provider plugin.

--- a/docs/guides/applications/configuration-management/terraform/secrets-management-with-terraform/index.md
+++ b/docs/guides/applications/configuration-management/terraform/secrets-management-with-terraform/index.md
@@ -18,7 +18,6 @@ external_resources:
 - '[Terraform State Storage and Locking](https://www.terraform.io/docs/backends/state.html)'
 - '[GitHub Discussion - Storing Sensitive Values in State Files](https://github.com/hashicorp/terraform/issues/516)'
 aliases: ['/applications/configuration-management/terraform/secrets-management-with-terraform/','/applications/configuration-management/secrets-management-with-terraform/']
-tags: ["saas"]
 ---
 
 Terraform is an Infrastructure as Code (IaC) tool that allows you to write declarative code to manage your infrastructure. In order to implement IaC with Terraform it is necessary to supply secrets, such as server passwords and API tokens, in the code. This guide discusses methods for securing those secrets within Terraform.

--- a/docs/guides/applications/configuration-management/vault/use-hashicorp-vault-for-secret-management/index.md
+++ b/docs/guides/applications/configuration-management/vault/use-hashicorp-vault-for-secret-management/index.md
@@ -14,7 +14,6 @@ external_resources:
 - '[Vault Auth Methods](https://www.vaultproject.io/docs/auth/index.html)'
 aliases: ['/applications/configuration-management/use-hashicorp-vault-for-secret-management/','/applications/configuration-management/vault/use-hashicorp-vault-for-secret-management/']
 tags: ["security","automation"]
-tags: ["saas"]
 ---
 
 [HashiCorp Vault](https://www.vaultproject.io/) is a secrets management tool that helps to provide secure, automated access to sensitive data. Vault meets these use cases by coupling authentication methods (such as application tokens) to secret engines (such as simple key/value pairs) using policies to control how access is granted. In this guide, you will install, configure, and access Vault in an example deployment to illustrate Vault's features and API.

--- a/docs/guides/applications/containers/deploying-microservices-with-docker/index.md
+++ b/docs/guides/applications/containers/deploying-microservices-with-docker/index.md
@@ -13,7 +13,6 @@ external_resources:
 - '[Github Repository for Example Microservice](https://github.com/bobstrecansky/flask-microservice)'
 - '[Using Containers to Build a Microservices Architecture](https://medium.com/aws-activate-startup-blog/using-containers-to-build-a-microservices-architecture-6e1b8bacb7d1)'
 aliases: ['/applications/containers/deploying-microservices-with-docker/']
-tags: ["saas"]
 ---
 
 ![Deploying Microservices with Docker](how-to-deploy-microservices-with-docker-smg.jpg)

--- a/docs/guides/applications/containers/podman-vs-docker/index.md
+++ b/docs/guides/applications/containers/podman-vs-docker/index.md
@@ -11,7 +11,6 @@ external_resources:
 - '[Red Hat Developer: Podman and Buildah for Docker Users](https://developers.redhat.com/blog/2019/02/21/podman-and-buildah-for-docker-users#)'
 - '[phoenixNAP: Podman vs Docker - Everything You Need to Know](https://phoenixnap.com/kb/podman-vs-docker)'
 - '[How-to Geek: What Is Podman and How Does It Differ from Docker?](https://www.howtogeek.com/devops/what-is-podman-and-how-does-it-differ-from-docker/)'
-tags: ["saas"]
 ---
 
 Containers offer you powerful tools for developing and deploying applications. They give you distinct and portable virtual environments with a fraction of the overhead of traditional virtual machines.

--- a/docs/guides/applications/containers/using-buildah-oci-images/index.md
+++ b/docs/guides/applications/containers/using-buildah-oci-images/index.md
@@ -13,7 +13,6 @@ external_resources:
 - '[Red Hat: Building with Buildah - Dockerfiles, Command Line, or Scripts](https://www.redhat.com/sysadmin/building-buildah)'
 - '[Red Hat Developer: Best Practices for Running Buildah in a Container](https://developers.redhat.com/blog/2019/08/14/best-practices-for-running-buildah-in-a-container#)'
 - '[Computing for Geeks: How To Build OCI & Docker Container Images With Buildah](https://computingforgeeks.com/how-to-build-oci-docker-container-images-with-buildah/)'
-tags: ["saas"]
 ---
 
 Buildah is an open source containerization tool capable of creating images from scratch, Dockerfiles, or Containerfiles. It also follows the Open Container Initiative (OCI) specifications, making Buildah images both versatile and open.

--- a/docs/guides/applications/containers/using-podman/index.md
+++ b/docs/guides/applications/containers/using-podman/index.md
@@ -13,7 +13,6 @@ external_resources:
 - '[Red Hat Developer: Podman Basics: Resources for Beginners and Experts](https://developers.redhat.com/articles/2022/05/02/podman-basics-resources-beginners-and-experts#)'
 - '[Red Hat Developer: Podman and Buildah for Docker Users](https://developers.redhat.com/blog/2019/02/21/podman-and-buildah-for-docker-users#)'
 - '[phoenixNAP: Install Podman on Ubuntu](https://phoenixnap.com/kb/install-podman-on-ubuntu)'
-tags: ["saas"]
 ---
 
 Podman is an open source containerization tool. Like Docker, Podman is a solution for creating, running, and managing containers. But Podman goes beyond Docker, using a secure daemonless process to run containers in rootless mode.

--- a/docs/guides/databases/hadoop/how-to-install-and-set-up-hadoop-cluster/index.md
+++ b/docs/guides/databases/hadoop/how-to-install-and-set-up-hadoop-cluster/index.md
@@ -17,7 +17,6 @@ external_resources:
 - '[core-site.xml properties](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)'
 tags: ["database"]
 aliases: ['/databases/hadoop/how-to-install-and-set-up-hadoop-cluster/']
-tags: ["saas"]
 ---
 
 ## What is Hadoop?

--- a/docs/guides/databases/mariadb/backup-mariadb-mysql-to-object-storage-with-restic/index.md
+++ b/docs/guides/databases/mariadb/backup-mariadb-mysql-to-object-storage-with-restic/index.md
@@ -14,7 +14,6 @@ external_resources:
 - '[Preparing a new Restic repository](https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html)'
 - '[Backing up](https://restic.readthedocs.io/en/stable/040_backup.html)'
 - '[Removing snapshots according to a policy](https://restic.readthedocs.io/en/stable/060_forget.html#removing-snapshots-according-to-a-policy)'
-tags: ["saas"]
 ---
 
 ## Introduction

--- a/docs/guides/databases/mariadb/set-up-mariadb-clusters-with-galera-debian-and-ubuntu/index.md
+++ b/docs/guides/databases/mariadb/set-up-mariadb-clusters-with-galera-debian-and-ubuntu/index.md
@@ -12,7 +12,6 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
  - '[MariaDB Foundation: Installing MariaDB Galera Cluster on Debian/Ubuntu](https://blog.mariadb.org/installing-mariadb-galera-cluster-on-debian-ubuntu/)'
 tags: ["ubuntu","debian","mariadb","database"]
-tags: ["ecommerce"]
 relations:
     platform:
         key: mariadb-galera-clusters

--- a/docs/guides/databases/mongodb/a-shell-script-to-automatically-backup-mongodb-databases/index.md
+++ b/docs/guides/databases/mongodb/a-shell-script-to-automatically-backup-mongodb-databases/index.md
@@ -12,7 +12,6 @@ external_resources:
 - '[MongoDB](https://www.mongodb.com/)'
 - '[Crontab](https://man7.org/linux/man-pages/man5/crontab.5.html)'
 - '[Nano](https://www.nano-editor.org/docs.php)'
-tags: ["saas"]
 ---
 
 MongoDB is a popular non-relationship database management system that stores keys and their values in a collection of documents rather than tables with fixed schemas. MongoDB supports a wide variety of options for horizontal scaling, making it an ideal tool for large enterprise production environments.

--- a/docs/guides/databases/mongodb/getting-started-with-mongodb/index.md
+++ b/docs/guides/databases/mongodb/getting-started-with-mongodb/index.md
@@ -12,7 +12,6 @@ external_resources:
 - '[MongoDB: Getting Started](https://www.mongodb.com/docs/manual/tutorial/getting-started/)'
 - '[freeCodeCamp: How to Get Started with MongoDB in 10 Minutes](https://www.freecodecamp.org/news/learn-mongodb-a4ce205e7739/)'
 - '[GeeksforGeeks: MongoDB — Getting Started](https://www.geeksforgeeks.org/mongodb-getting-started/)'
-tags: ["saas"]
 ---
 
 [MongoDB](https://www.mongodb.com/) is a NoSQL database, that provides more flexible and less rigidly structured data storage than traditional relational databases. This MongoDB guide introduces you to all the basic MongoDB operations you need to get started, including commands for operations like queries, inserts, updates, and deletions. It sets you up to begin effectively populating and using your MongoDB instance.

--- a/docs/guides/databases/mongodb/indexing-mongodb/index.md
+++ b/docs/guides/databases/mongodb/indexing-mongodb/index.md
@@ -13,7 +13,6 @@ external_resources:
 - '[MongoDB: Indexes](https://www.mongodb.com/docs/manual/indexes/)'
 - '[MongoDB: Create Indexes to Support Your Queries](https://www.mongodb.com/docs/manual/tutorial/create-indexes-to-support-queries/)'
 - '[MongoDB: Performance Best Practices — Indexing](https://www.mongodb.com/blog/post/performance-best-practices-indexing)'
-tags: ["saas"]
 ---
 
 [MongoDB](https://www.mongodb.com/) is a NoSQL database, an alternative to relational SQL databases that uses JSON-like documents to store data. To learn about what MongoDB is and how it works, review our [Introduction to MongoDB and its Use Cases](/docs/guides/mongodb-introduction/) guide. Know more about the basics of using MongoDB in our [Getting Started with MongoDB](/docs/guides/getting-started-with-mongodb/) guide.

--- a/docs/guides/databases/mongodb/mongodb-community-shell-installation/index.md
+++ b/docs/guides/databases/mongodb/mongodb-community-shell-installation/index.md
@@ -8,7 +8,6 @@ published: 2021-12-10
 keywords: ['mongodb community shell', 'mongosh', 'mongodb']
 tags: ['debian', 'database']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-tags: ["saas"]
 ---
 
 MongoDB is a non-relational, document-oriented database that can operate over many hosts, database shards, and collections. A key feature of MongoDB is its ability to associate disparate data types and sources into quickly returned results that link data together. The MongoDB shell can be used to perform queries, update records, and find useful correlations among collections. The MongoDB Shell provides a command-line interface to your database and can run all MongoDB queries. It prints error messages, modifies data, and provide access to JavaScript using JSON queries. This tutorial explains how to install the MongoDB Community Shell on macOS, Windows 10, and Debian. It also shows you how to connect to a MongoDB deployment and provides tips on using the MongoDB Shell with examples.

--- a/docs/guides/databases/mongodb/navigate-mongodb-databases/index.md
+++ b/docs/guides/databases/mongodb/navigate-mongodb-databases/index.md
@@ -11,7 +11,6 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[MongoDB Manual: Query Documents](https://www.mongodb.com/docs/manual/tutorial/query-documents/)'
 - '[MongoDB Guides: Read Data from MongoDB With Queries](https://www.mongodb.com/docs/guides/server/read_queries/)'
-tags: ["saas"]
 ---
 
 [MongoDB](https://www.mongodb.com/) is a flexible, NoSQL database solution which stores data as JSON-like documents. Compared to other database systems, MongoDB has much more to offer for effectively working with data. For those familiar with SQL, it may take some time and experience before feeling confident using MongoDB. This MongoDB tutorial shows you how to make more advanced queries. From querying arrays and nested objects to using comparative and logical operations, learn it all in this guide with practical examples.

--- a/docs/guides/databases/mysql/configure-source-replica-replication-in-mysql/index.md
+++ b/docs/guides/databases/mysql/configure-source-replica-replication-in-mysql/index.md
@@ -10,7 +10,6 @@ tags: ['mysql', 'database', 'security']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[MySQL Documentation](https://dev.mysql.com/doc/refman/8.0/en/replication.html)'
-tags: ["saas"]
 ---
 
 The [*MySQL*](https://dev.mysql.com/) is a relational database management system that is one of the most popular open-source projects. Although known for its stability, MySQL is even more reliable if source-replica replication is configured. In replication, one MySQL server is typically designated the *source*. A source sends any database changes and data updates to one or more *replica* database servers. MySQL's data replication procedure is flexible, and the replica servers do not need to be permanently connected to the source. This guide explains how to configure source-replica data replication in MySQL.

--- a/docs/guides/databases/mysql/install-mysql/index.md
+++ b/docs/guides/databases/mysql/install-mysql/index.md
@@ -11,7 +11,6 @@ tags: ['mysql']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[Installing and Upgrading MySQL](https://dev.mysql.com/doc/refman/8.0/en/installing.html)'
-tags: ["saas"]
 ---
 
 [MySQL](/docs/guides/an-overview-of-mysql/) is one of the most popular SQL-based relational databases. The Community Edition is available at no charge and is widely used across the industry. This guide walks you through installing and updating MySQL Community on Windows, macOS, and Linux (either through the native repositories or MySQL's own repositories).

--- a/docs/guides/databases/mysql/securing-mysql/index.md
+++ b/docs/guides/databases/mysql/securing-mysql/index.md
@@ -12,7 +12,6 @@ bundles: ['debian-security', 'centos-security']
 tags: ["mysql","security","database"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 image: SecureMySQLserver.png
-tags: ["saas"]
 ---
 
 ## MySQL

--- a/docs/guides/databases/neo4j/an-introduction-to-neo4j/index.md
+++ b/docs/guides/databases/neo4j/an-introduction-to-neo4j/index.md
@@ -4,7 +4,6 @@ title: "An Introduction to Neo4j"
 description: "Neoj4 is a graph database that excels at complex datasets. Learn how it differs from relational databases like SQL and discover some practical use cases."
 authors: ["Cameron Laird"]
 contributors: ["Cameron Laird"]
-published: 2022-03-30
 published: 2024-05-09
 keywords: ['what is neo4j','what is neo4j used for','what is neo4j graph database']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/guides/databases/postgresql/an-introduction-to-postgresql/index.md
+++ b/docs/guides/databases/postgresql/an-introduction-to-postgresql/index.md
@@ -11,7 +11,6 @@ tags: ['postgresql', 'mysql']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[PostgreSQL website](https://www.postgresql.org/)'
-tags: ["saas"]
 ---
 
 [*PostgreSQL*](https://www.postgresql.org/) is an *object-relational database management system* (ORDBMS) that provides a powerful alternative to a traditional *relational database management system* (RDBMS). It combines relational and non-relational models to allow for more user flexibility and can handle more complex scenarios and unstructured data. This guide answers the question "What is PostgreSQL?" and outlines the differences between [MySQL](https://www.mysql.com/) and PostgreSQL. It also explains the different PostgreSQL use cases.

--- a/docs/guides/databases/postgresql/configure-postgresql/index.md
+++ b/docs/guides/databases/postgresql/configure-postgresql/index.md
@@ -12,7 +12,6 @@ external_resources:
  - '[PostgreSQL Documentation](https://www.postgresql.org/docs/)'
 tags: ["database","postgresql"]
 aliases: ['/databases/postgresql/configure-postgresql/']
-tags: ["saas"]
 ---
 
 ![Configure PostgreSQL](Configure_PostgreSQL.jpg)

--- a/docs/guides/databases/redis/hashes-in-redis-databases/index.md
+++ b/docs/guides/databases/redis/hashes-in-redis-databases/index.md
@@ -13,7 +13,6 @@ external_resources:
 - '[Redis: An Introduction to Redis Data Types and Abstractions](https://redis.io/topics/data-types-intro)'
 - '[Redis: Command Reference - Hashes](https://redis.io/commands#hash)'
 - '[Redis in Action: Hashes in Redis](https://redis.com/ebook/part-1-getting-started/chapter-1-getting-to-know-redis/1-2-what-redis-data-structures-look-like/1-2-4-hashes-in-redis/)'
-tags: ["saas"]
 ---
 
 Redis, the open-source NoSQL database, is frequently used for caching, messaging, and other storage needs where speed and low latency are required. Redis supports the hash data type which enables you to store field-value pairs of simple to highly complex data. This tutorial breakdown what Redis hashes are and walks you through examples of how to create, access, and modify hashes. This tutorial provides you with the tools to start using hashes in your Redis databases.

--- a/docs/guides/databases/redis/redis-client-side-caching/index.md
+++ b/docs/guides/databases/redis/redis-client-side-caching/index.md
@@ -12,7 +12,6 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[Redis: Redis server-assisted client side caching](https://redis.io/topics/client-side-caching)'
 - '[MDN Web Docs: Client-side Storage](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage)'
-tags: ["saas"]
 ---
 
 Redis is an open-source in-memory database with a reputation for working exceptionally well for caching web application data. Redis's fast transactions and low latency help to increase application performance while its server-assisted caching feature makes client-side caching more efficient.

--- a/docs/guides/databases/redis/redis-getting-started/index.md
+++ b/docs/guides/databases/redis/redis-getting-started/index.md
@@ -12,7 +12,6 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[Redis: Commands](https://redis.io/commands)'
 aliases: ['/guides/how-to-connect-to-redis/']
-tags: ["saas"]
 ---
 
 Redis is an open-source NoSQL database used for in-memory storage of data structures. It works exceptionally well for caching, messaging, and other data storage contexts where quick, and low-latency storage is needed.

--- a/docs/guides/databases/sql-syntax/sharded-database/index.md
+++ b/docs/guides/databases/sql-syntax/sharded-database/index.md
@@ -11,7 +11,6 @@ license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 external_resources:
 - '[Wikipedia page on database sharding](https://en.wikipedia.org/wiki/Shard_(database_architecture))'
 - '[MongoDB explanation of database sharding](https://www.mongodb.com/features/database-sharding-explained)'
-tags: ["saas"]
 ---
 
 Many software applications use a *relational database management system* (RDBMS) to store data. As the database grows, it becomes more time-and-storage intensive to store the data. One popular solution to this problem is [*database sharding*](https://en.wikipedia.org/wiki/Shard_(database_architecture)). A sharded database distributes the records in a database's tables across different databases on different computer systems. This guide explains how database sharding works and discusses some of the advantages and disadvantages of sharding. It also describes some of the main sharding strategies and provides some database sharding examples.

--- a/docs/guides/development/frameworks/apache-tomcat/apache-tomcat-on-centos-8/index.md
+++ b/docs/guides/development/frameworks/apache-tomcat/apache-tomcat-on-centos-8/index.md
@@ -10,7 +10,6 @@ keywords: ["apache tomcat centos 8", "tomcat java", "java centos 8", "tomcat ubu
 tags: ["web applications","java","centos"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/development/frameworks/apache-tomcat-on-centos-8/','/development/frameworks/apache-tomcat/apache-tomcat-on-centos-8/','/websites/frameworks/apache-tomcat-on-centos-8/']
-image: ApacheTomcat_CentOS8.png
 external_resources:
  - '[Tomcat Home Page](http://tomcat.apache.org/)'
  - '[Tomcat FAQ](http://wiki.apache.org/tomcat/FAQ)'

--- a/docs/guides/development/frameworks/apache-tomcat/apache-tomcat-on-debian-10/index.md
+++ b/docs/guides/development/frameworks/apache-tomcat/apache-tomcat-on-debian-10/index.md
@@ -10,7 +10,6 @@ keywords: ["apache tomcat debian 10", "tomcat java", "java debian 10", "tomcat d
 tags: ["web applications","java","debian"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 aliases: ['/websites/frameworks/apache-tomcat-on-debian-10/','/development/frameworks/apache-tomcat/apache-tomcat-on-debian-10/','/development/frameworks/apache-tomcat-on-debian-10/']
-image: ApacheTomcat_Deb10.png
 external_resources:
  - '[Tomcat Home Page](http://tomcat.apache.org/)'
  - '[Tomcat FAQ](http://wiki.apache.org/tomcat/FAQ)'

--- a/docs/guides/kubernetes/how-to-deploy-jenkins-x-in-linode-kubernetes-engine/index.md
+++ b/docs/guides/kubernetes/how-to-deploy-jenkins-x-in-linode-kubernetes-engine/index.md
@@ -9,7 +9,6 @@ published: 2020-07-29
 keywords: ['kubernetes','pipelines','ci/cd','kubernetes','jenkins x','jenkins']
 tags: ["docker","kubernetes","container","automation","linode platform"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
-image: DeployJenkinsX_LinodeKubEng.png
 image: 'learnk8s_jenkinsX.png'
 external_resources:
 - '[How to run Jenkins X Boot](https://jenkins-x.io/docs/install-setup/boot/how-it-works/)'

--- a/docs/guides/networking/dns/how-to-understand-ip-addresses/index.md
+++ b/docs/guides/networking/dns/how-to-understand-ip-addresses/index.md
@@ -15,7 +15,6 @@ external_resources:
 - '[Wikipedia IPv4 Packet Description Page](https://en.wikipedia.org/wiki/IPv4#Packet_structure)'
 - '[RFC 2460 for IPv6](https://datatracker.ietf.org/doc/html/rfc2460)'
 - '[Subnet Calculator](http://www.csgnetwork.com/ipaddconv.html)'
-tags: ["saas"]
 ---
 
 The *Internet Protocol* (IP), as described in [RFC 791](https://datatracker.ietf.org/doc/html/rfc791), is the framework that underlies the behavior of the entire internet. The Internet Protocol Version 4 (IPv4) and Version 6 (IPv6) address systems are used to identify interfaces and locate hosts on the network. This allows hosts and routers to determine the path to another networking device and send packets to it. This guide outlines how to understand IP addresses, and how to describe and use them.

--- a/docs/guides/networking/vpn/set-up-wireguard-vpn-on-debian/index.md
+++ b/docs/guides/networking/vpn/set-up-wireguard-vpn-on-debian/index.md
@@ -17,7 +17,6 @@ relations:
         keywords:
             - distribution: Debian 9
 aliases: ['/networking/vpn/set-up-wireguard-vpn-on-debian/']
-tags: ["saas"]
 ---
 
 ## What is WireGuard?

--- a/docs/marketplace-docs/guides/clustercontrol/index.md
+++ b/docs/marketplace-docs/guides/clustercontrol/index.md
@@ -5,10 +5,9 @@ published: 2021-08-13
 modified: 2022-05-17
 keywords: ['database','cluster','backups','configuration management']
 tags: ["marketplace", "linode platform", "cloud manager"]
-aliases: ['/guides/deploying-clustercontrol-marketplace-app/','/guides/clustercontrol-marketplace-app/']
 external_resources:
 - '[ClusterControl](https://severalnines.com/product/clustercontrol/clustercontrol-community-edition)'
-aliases: ['/products/tools/marketplace/guides/clustercontrol/']
+aliases: ['/products/tools/marketplace/guides/clustercontrol/','/guides/deploying-clustercontrol-marketplace-app/','/guides/clustercontrol-marketplace-app/']
 authors: ["Akamai"]
 contributors: ["Akamai"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/marketplace-docs/guides/jetbackup/index.md
+++ b/docs/marketplace-docs/guides/jetbackup/index.md
@@ -5,10 +5,9 @@ published: 2021-08-13
 modified: 2022-05-17
 keywords: ['backups','cpanel', 'backup']
 tags: ["marketplace", "linode platform", "cloud manager"]
-aliases: ['/guides/deploying-jetbackup-marketplace-app/','/guides/jetbackup-marketplace-app/']
 external_resources:
 - '[JetBackup](https://www.jetbackup.com/)'
-aliases: ['/products/tools/marketplace/guides/jetbackup/']
+aliases: ['/products/tools/marketplace/guides/jetbackup/','/guides/deploying-jetbackup-marketplace-app/','/guides/jetbackup-marketplace-app/']
 authors: ["Akamai"]
 contributors: ["Akamai"]
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'

--- a/docs/marketplace-docs/guides/shadowsocks/index.md
+++ b/docs/marketplace-docs/guides/shadowsocks/index.md
@@ -5,7 +5,6 @@ published: 2020-03-18
 modified: 2022-03-08
 keywords: ['shadowsocks','marketplace', 'server']
 tags: ["proxy","cloud-manager","linode platform","security","marketplace"]
-image: DeployShadowsocksServer_oneclickapps.png
 external_resources:
 - '[Shadowsocks Official](https://shadowsocks.org)'
 - '[Shadowsocks-libev Github](https://github.com/shadowsocks/shadowsocks-libev)'


### PR DESCRIPTION
Hugo upgraded its YAML library to a YAML 1.1 compliant version in v0.152.0 (https://github.com/gohugoio/hugo/releases/tag/v0.152.0), which now throws an error on duplicate keys.

This commit fixes that. Note that:

* The old behaviour was to keep the last occurrence of a duplicate key, so that's is the most commin strategy used here.
* But I have also manually inspected and merged some of them.