### PR TITLE
[update] Installing a Mastodon Server on Ubuntu 16.04

### DIFF
--- a/docs/guides/applications/messaging/install-mastodon-on-ubuntu-1604/docker-compose.yml
+++ b/docs/guides/applications/messaging/install-mastodon-on-ubuntu-1604/docker-compose.yml
@@ -81,24 +81,6 @@ services:
       - ./public/system:/mastodon/public/system
       - ./public/packs:/mastodon/public/packs
 
-## Uncomment to enable federation with tor instances along with adding the following ENV variables
-## http_proxy=http://privoxy:8118
-## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
-#  tor:
-#    build: https://github.com/usbsnowcrash/docker-tor.git
-#    networks:
-#      - external_network
-#      - internal_network
-#
-#  privoxy:
-#    build: https://github.com/usbsnowcrash/docker-privoxy.git
-#    command: /opt/sbin/privoxy --no-daemon --user privoxy.privoxy /opt/config
-#    volumes:
-#      - ./priv-config:/opt/config
-#    networks:
-#      - external_network
-#      - internal_network
-
   nginx:
     build:
       context: ./nginx


### PR DESCRIPTION
* removed references to third-party GitHub repository: 
•	https://github.com/usbsnowcrash/docker-tor.git
•	https://github.com/usbsnowcrash/docker-privoxy.git

PS: these were lines were anyways uncommented and not required to complete the steps in the guide. Hence, I have removed them from the .yaml file