### PR TITLE
[update] Installing and Configuring ownCloud on CentOS Stream 8

### DIFF
--- a/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-centos-stream-8/index.md
+++ b/docs/guides/applications/cloud-storage/install-and-configure-owncloud-on-centos-stream-8/index.md
@@ -17,6 +17,7 @@ relations:
         key: how-to-install-owncloud
         keywords:
             - distribution: CentOS Stream 8
+deprecated: true
 ---
 
 ## What is ownCloud?


### PR DESCRIPTION
This version of OS is not listed as supported in : https://doc.owncloud.com/server/10.16/admin_manual/installation/system_requirements.html#officially-supported-environments

Hence marking it as deprecated


fixes: https://github.com/linode/docs/issues/7380